### PR TITLE
Allows hiding of recipes (from prim14)

### DIFF
--- a/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
+++ b/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
@@ -161,6 +161,9 @@ namespace Content.Client.Construction.UI
 
             foreach (var recipe in _prototypeManager.EnumeratePrototypes<ConstructionPrototype>())
             {
+                if (!recipe.Show)
+					continue;
+
                 if (!string.IsNullOrEmpty(search))
                 {
                     if (!recipe.Name.ToLowerInvariant().Contains(search.Trim().ToLowerInvariant()))

--- a/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
+++ b/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
@@ -195,6 +195,9 @@ namespace Content.Client.Construction.UI
 
             foreach (var prototype in _prototypeManager.EnumeratePrototypes<ConstructionPrototype>())
             {
+                if (!prototype.Show)
+                    continue;
+
                 var category = Loc.GetString(prototype.Category);
 
                 if (!string.IsNullOrEmpty(category))

--- a/Content.Shared/Construction/Prototypes/ConstructionPrototype.cs
+++ b/Content.Shared/Construction/Prototypes/ConstructionPrototype.cs
@@ -23,6 +23,12 @@ namespace Content.Shared.Construction.Prototypes
         public string Description { get; } = string.Empty;
 
         /// <summary>
+        ///     Whether or not the recipe is hidden.
+        /// </summary>
+        [DataField("show")]
+        public bool Show { get; }
+
+        /// <summary>
         ///     The <see cref="ConstructionGraphPrototype"/> this construction will be using.
         /// </summary>
         [DataField("graph", customTypeSerializer:typeof(PrototypeIdSerializer<ConstructionGraphPrototype>))]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
See title:

Now you need to explicity have a "show:" field in your construction entry.
example:
```
- type: construction
  name: example name
  id: ExampleID
  graph: ExampleGraph
  startNode: examplestartnode
  targetNode: exampleendnode
  category: Tools
  description: Write stuff here
  show: true
```
The last field is what you need.