### PR TITLE
timed storage filler component.

### DIFF
--- a/Content.Server/Spawners/Components/TimedStorageFillComponent.cs
+++ b/Content.Server/Spawners/Components/TimedStorageFillComponent.cs
@@ -1,0 +1,22 @@
+using Content.Shared.Storage;
+
+namespace Content.Server.Spawners.Components
+{
+    [RegisterComponent]
+    public sealed class TimedStorageFillComponent : Component
+    {
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("contents")]
+        public List<EntitySpawnEntry> Contents = new();
+
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("minimumSeconds")]
+        public int MinimumSeconds = 300;
+
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("maximumSeconds")]
+        public int MaximumSeconds = 1200;
+
+        public float NextRefillTime = 0;
+    }
+}

--- a/Content.Server/Spawners/EntitySystems/TimedStorageFillSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/TimedStorageFillSystem.cs
@@ -1,0 +1,76 @@
+using Content.Server.Storage.Components;
+using Content.Shared.Storage;
+using Robust.Shared.Random;
+using Content.Server.Spawners.Components;
+
+namespace Content.Server.Storage.EntitySystems;
+
+public sealed partial class TimedStorageFillSystem : EntitySystem
+{
+    [Dependency] private readonly IRobustRandom _robustRandom = default!;
+    [Dependency] private readonly EntityStorageSystem _entityStorage = default!;
+    [Dependency] private readonly StorageSystem _storageSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<TimedStorageFillComponent, ComponentStartup>(OnStartup);
+    }
+
+    private void OnStartup(EntityUid uid, TimedStorageFillComponent component, ComponentStartup args)
+    {        
+        FillStorage(uid, component);
+        component.NextRefillTime = _robustRandom.NextFloat(component.MinimumSeconds, component.MaximumSeconds);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+        var query = EntityQueryEnumerator<TimedStorageFillComponent>();
+        while (query.MoveNext(out var timedComp))
+        {
+            timedComp.NextRefillTime -= frameTime;
+
+            if (timedComp.NextRefillTime < 0)
+            {
+                FillStorage(timedComp.Owner, timedComp);
+                timedComp.NextRefillTime = frameTime + _robustRandom.NextFloat(timedComp.MinimumSeconds, timedComp.MaximumSeconds);
+            }
+        }
+    }
+
+    private void FillStorage(EntityUid uid, TimedStorageFillComponent component)
+    {
+        if (component.Contents.Count == 0) return;
+
+        TryComp<ServerStorageComponent>(uid, out var serverStorageComp);
+        TryComp<EntityStorageComponent>(uid, out var entityStorageComp);
+
+        if (entityStorageComp == null && serverStorageComp == null)
+        {
+            Logger.Error($"StorageFillComponent couldn't find any StorageComponent ({uid})");
+            return;
+        }
+
+        if (serverStorageComp?.Storage?.ContainedEntities.Count > 0 || entityStorageComp?.Contents.ContainedEntities.Count > 0)
+            return;
+
+        var coordinates = Transform(uid).Coordinates;
+
+        var spawnItems = EntitySpawnCollection.GetSpawns(component.Contents, _robustRandom);
+        foreach (var item in spawnItems)
+        {
+            var ent = EntityManager.SpawnEntity(item, coordinates);
+
+            // handle depending on storage component, again this should be unified after ECS
+            if (entityStorageComp != null && _entityStorage.Insert(ent, uid))
+               continue;
+
+            if (serverStorageComp != null && _storageSystem.Insert(uid, ent, serverStorageComp, false))
+                continue;
+
+            Logger.ErrorS("storage", $"Tried to StorageFill {item} inside {ToPrettyString(uid)} but can't.");
+            EntityManager.DeleteEntity(ent);
+        }
+    }
+}

--- a/Resources/Prototypes/Nuclear14/Entities/Objects/Misc/storage_fills.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Objects/Misc/storage_fills.yml
@@ -1,0 +1,191 @@
+- type: entity
+  abstract: true
+  id: N14BaseTimedStorageFill
+  components:
+  - type: TimedStorageFill
+    contents:
+      - id: Pen
+        prob: 0.03
+      - id: N14CombatKnife
+        prob: 0.01
+      - id: N14Screwdriver
+        prob: 0.055
+      - id: N14Wirecutter
+        prob: 0.055
+      - id: N14Wrench
+        prob: 0.055
+      - id: PaperOffice
+        prob: 0.04
+        amount: 1
+        maxAmount: 3
+      - id: N14DrinkNukaColaBottleFull
+        prob: 0.05
+        amount: 1
+        maxAmount: 2
+      - id: N14Stimpak
+        prob: 0.03
+        amount: 1
+        maxAmount: 2
+      - id: N14SuperStimpak
+        prob: 0.005
+      - id: N14DrinkIrradiatedNukaColaBottleFull
+        prob: 0.01
+      - id: N14FoodDogfood
+        prob: 0.02
+      - id: N14FoodBubblegum
+        prob: 0.02
+      - id: N14FoodTato
+        prob: 0.02
+      - id: N14ClothingOuterCoatLeatherDuster
+        prob: 0.6
+        orGroup: Clothing
+      - id: N14ClothingOuterCoatDuster
+        prob: 0.6
+        orGroup: Clothing
+      - id: N14ClothingOuterCoatFollowerLab
+        prob: 0.3
+        orGroup: Clothing
+      - id: N14ClothingOuterEnclaverOfficerCoat
+        prob: 0.2
+        orGroup: Clothing
+      - id: N14ClothingOuterBattlecoatTan
+        prob: 0.2
+        orGroup: Clothing
+      - id: N14ClothingOuterBattlecoatCoat
+        prob: 0.2
+        orGroup: Clothing
+      - id: ClothingHeadHatBaseball
+        prob: 0.6
+        orGroup: Clothing
+      - id: ClothingHeadHatBandit
+        prob: 0.6
+        orGroup: Clothing
+      - id: ClothingShoesJamrock
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingShoesRags
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingShoesRaider
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpskirtFalloutBlack
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpskirtFalloutBlue
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpskirtDressBlack
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpskirtDressBlue
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpskirtSundress
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpskirtWastelandDoc
+        prob: 0.2
+        orGroup: Clothing
+      - id: ClothingUniformJumpskirtMerc
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpskirtTribal
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpskirtFalloutBlue
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpskirtDressBlack
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpskirtDressBlue
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpskirtSundress
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpskirtWastelandDoc
+        prob: 0.2
+        orGroup: Clothing
+      - id: ClothingUniformJumpskirtMerc
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpskirtTribal
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitVault
+        prob: 0.05
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitVault14
+        prob: 0.1
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitDetectiveAlt
+        prob: 0.2
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitBartenderAlt
+        prob: 0.2
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitRags
+        prob: 0.6
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitSettlerRags
+        prob: 0.6
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitCheckered
+        prob: 0.2
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitWastelandDoc
+        prob: 0.2
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitEnclave
+        prob: 0.2
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitMerc
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitMerchant
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitTrader
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitCaravan
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitMechanic
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitPreWarRelaxed
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitPreWarCasual
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitManagerSuit
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitPreWarManager
+        prob: 0.2
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitBlueSuit
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitPreWarLumberjack
+        prob: 0.2
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitCombat
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitBrahminFarmer
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitFollowers
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitCowboyB
+        prob: 0.4
+        orGroup: Clothing
+      - id: ClothingUniformJumpsuitCowboyG
+        prob: 0.4
+        orGroup: Clothing

--- a/Resources/Prototypes/Nuclear14/Entities/Structures/Furniture/filing_cabinets.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Structures/Furniture/filing_cabinets.yml
@@ -1,0 +1,43 @@
+- type: entity
+  name: N14 filing cabinet
+  parent: BaseStructureDynamic
+  id: N14filingCabinet
+  suffix: Empty
+  description: A cabinet for all your filing needs.
+  components:
+  - type: Storage
+    capacity: 80
+  - type: Sprite
+    netsync: false
+    sprite: Structures/Storage/cabinets.rsi
+    state: filingcabinet
+    noRot: true
+  - type: Appearance
+    visuals:
+    - type: BagOpenCloseVisualizer
+      openIcon: filingcabinet-open
+  - type: UserInterface
+    interfaces:
+    - key: enum.StorageUiKey.Key
+      type: StorageBoundUserInterface
+  - type: Transform
+    noRot: true
+  - type: Fixtures
+    fixtures:
+    - shape:
+        !type:PhysShapeAabb
+        bounds: "-0.18,-0.48,0.18,0.48"
+      density: 200
+      mask:
+      - MachineMask
+      layer:
+      - MachineLayer
+  - type: InteractionOutline
+  - type: ContainerContainer
+    containers:
+      storagebase: !type:Container
+
+- type: entity
+  parent: [ N14filingCabinet, N14BaseTimedStorageFill ]
+  id: N14FilingCabinetRefilling
+  suffix: Refilling,Random


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
adds a system and component that will refill a storage container from a loot table at a specified interval. includes a singular example (using a pre-existing sprite).

The containers themselves are easy to make in yml and we just need sprites for all kinds of containers because I'm terrible at sprites

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/Vault-Overseers/nuclear-14/assets/71046427/db770a1e-394a-4a77-b79e-a09547a8df90
example is sped up for testing. default is random timer between 5 and 20 minutes and only refills if empty.

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

