### PR TITLE
ranged_mobs

### DIFF
--- a/Resources/Prototypes/Nuclear14/Entities/Objects/Weapons/Guns/Projectiles/creature.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Objects/Weapons/Guns/Projectiles/creature.yml
@@ -1,0 +1,16 @@
+- type: entity
+  id: N14BulletAcid
+  name: acid spit
+  parent: BaseBullet
+  noSpawn: true
+  components:
+    - type: Projectile
+      damage:
+        types:
+          Caustic: 2
+    - type: Sprite
+      sprite: Objects/Weapons/Guns/Projectiles/xeno_toxic.rsi
+      layers:
+        - state: xeno_toxic
+    - type: Ammo
+      muzzleFlash: null

--- a/Resources/Prototypes/Nuclear14/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Nuclear14/Mobs/NPCs/animals.yml
@@ -6,6 +6,9 @@
   id: N14MobBloatfly
   description: A mutated floating bug with an infectious bite.
   components:
+  - type: HTN
+    rootTask:
+      task: SimpleRangedHostileCompound
   - type: Sprite
     drawdepth: Mobs
   - type: Physics
@@ -34,15 +37,13 @@
     bloodMaxVolume: 50
   - type: ReplacementAccent
     accent: mouse
-  - type: MeleeWeapon
-    hidden: true
-    soundHit:
-        path: /Audio/Effects/bite.ogg
-    angle: 0
-    animation: WeaponArcBite
-    damage:
-      types:
-        Piercing: 3
+  - type: BallisticAmmoProvider
+    proto: BulletAcid
+    capacity: 500
+  - type: Gun
+    fireRate: 1
+    selectedMode: FullAuto
+    soundGunshot: /Audio/Weapons/Xeno/alien_spitacid.ogg
   - type: NoSlip
   
   


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Makes bloatflies ranged, and adds a new weaker bloatfly spittle projectile to reflect their puny level 1 status
