### PR TITLE
Speed up the wave defense timers

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/WaveDefenseRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/WaveDefenseRuleComponent.cs
@@ -9,7 +9,7 @@ public sealed class WaveDefenseRuleComponent : Component
     public float DifficultyMod = 0.65f;
 
     [DataField("waveTime")]
-    public int WaveTime = 240;
+    public int WaveTime = 210;
 
     [DataField("greetingSound", customTypeSerializer: typeof(SoundSpecifierTypeSerializer))]
     public SoundSpecifier? GreetSound = new SoundPathSpecifier("/Audio/Misc/nukeops.ogg");


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
speeds up the timer on wave defense to 3.5 minutes