### PR TITLE
Disable Psionics

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2105,6 +2105,6 @@ namespace Content.Shared.CCVar
         ///     Guaranteed psionics will still go through.
         /// </summary>
         public static readonly CVarDef<bool> PsionicRollsEnabled =
-            CVarDef.Create("psionics.rolls_enabled", true, CVar.SERVERONLY);
+            CVarDef.Create("psionics.rolls_enabled", false, CVar.SERVERONLY);
     }
 }

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/familiars.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/familiars.yml
@@ -81,8 +81,8 @@
   - type: ZombieImmune # No zombie servant
   - type: RandomMetadata
     nameSegments: [names_golem]
-  - type: PotentialPsionic
-  - type: Psionic
+  #- type: PotentialPsionic
+  #- type: Psionic
     removable: false
   # - type: PyrokinesisPower # Pending psionic rework
   - type: Grammar

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/glimmer_creatures.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/glimmer_creatures.yml
@@ -22,8 +22,8 @@
         reagents:
         - ReagentId: Ectoplasm
           Quantity: 15
-  - type: PotentialPsionic
-  - type: Psionic
+  #- type: PotentialPsionic
+  #- type: Psionic
   - type: GlimmerSource
   - type: AmbientSound
     range: 6

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Player/harpy.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Player/harpy.yml
@@ -26,4 +26,4 @@
   - type: NpcFactionMember
     factions:
     - NanoTrasen
-  - type: PotentialPsionic
+  #- type: PotentialPsionic

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Player/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Player/vulpkanin.yml
@@ -24,7 +24,7 @@
     - type: NpcFactionMember
       factions:
         - NanoTrasen
-    - type: PotentialPsionic
+    #- type: PotentialPsionic
     - type: Respirator
       damage:
        types:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -118,7 +118,7 @@
   - type: Grammar
     attributes:
       gender: male
-  - type: PotentialPsionic # Nyano
+  #- type: PotentialPsionic # Nyano
 
 - type: entity
   id: MobRatKingBuff

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -121,9 +121,9 @@
     molsPerSecondPerUnitMass: 0.0005
   - type: Speech
     speechVerb: LargeMob
-  - type: PotentialPsionic #Nyano - Summary: makes potentially psionic.
+  #- type: PotentialPsionic #Nyano - Summary: makes potentially psionic.
     chance: -2
-  - type: Psionic #Nyano - Summary: makes psionic by default.
+  #- type: Psionic #Nyano - Summary: makes psionic by default.
     removable: false
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -121,10 +121,6 @@
     molsPerSecondPerUnitMass: 0.0005
   - type: Speech
     speechVerb: LargeMob
-  #- type: PotentialPsionic #Nyano - Summary: makes potentially psionic.
-    chance: -2
-  #- type: Psionic #Nyano - Summary: makes psionic by default.
-    removable: false
 
 - type: entity
   name: Praetorian

--- a/Resources/Prototypes/Entities/Mobs/Player/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/arachnid.yml
@@ -11,4 +11,4 @@
     damageRecovery:
       types:
         Asphyxiation: -0.5
-  - type: PotentialPsionic #Nyano - Summary: makes potentially psionic. 
+  #- type: PotentialPsionic #Nyano - Summary: makes potentially psionic.

--- a/Resources/Prototypes/Entities/Mobs/Player/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/diona.yml
@@ -11,7 +11,7 @@
       damageRecovery:
         types:
           Asphyxiation: -1.0
-    - type: PotentialPsionic #Nyano - Summary: makes potentially psionic.
+    #- type: PotentialPsionic #Nyano - Summary: makes potentially psionic.
 
 # Reformed Diona
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Player/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dwarf.yml
@@ -4,4 +4,4 @@
   parent: BaseMobDwarf
   id: MobDwarf
   components:
-    - type: PotentialPsionic #Nyano - Summary: makes potentially psionic. 
+    #- type: PotentialPsionic #Nyano - Summary: makes potentially psionic.

--- a/Resources/Prototypes/Entities/Mobs/Player/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dwarf.yml
@@ -3,5 +3,3 @@
   name: Urist McHands The Dwarf
   parent: BaseMobDwarf
   id: MobDwarf
-  components:
-    #- type: PotentialPsionic #Nyano - Summary: makes potentially psionic.

--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -34,7 +34,7 @@
     - PsionicInterloper #Nyano - Summary: makes a part of the psionic faction.
   - type: Alerts
   - type: Familiar
-  - type: Psionic #Nyano - Summary: Makes psionic on creation.
+  #- type: Psionic #Nyano - Summary: Makes psionic on creation.
     removable: false
 
 - type: entity
@@ -91,7 +91,7 @@
     showExamineInfo: true
   - type: Familiar
   - type: Dispellable
-  - type: Psionic #Nyano - Summary: makes psionic on creation.
+  #- type: Psionic #Nyano - Summary: makes psionic on creation.
     removable: false
   - type: Vocal
     sounds:

--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -90,9 +90,6 @@
   - type: MindContainer
     showExamineInfo: true
   - type: Familiar
-  - type: Dispellable
-  #- type: Psionic #Nyano - Summary: makes psionic on creation.
-    removable: false
   - type: Vocal
     sounds:
       Male: Cerberus

--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -4,7 +4,7 @@
   parent: BaseMobHuman
   id: MobHuman
   components:
-  - type: PotentialPsionic #Nyano - Summary: makes potentially psionic. 
+  #- type: PotentialPsionic #Nyano - Summary: makes potentially psionic.
 
 #Syndie
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -48,9 +48,9 @@
   components:
     - type: NukeOperative
     - type: RandomHumanoidAppearance
-    - type: PsionicBonusChance #Nyano - Summary: makes more likely to be psionic.
-      multiplier: 7
-      warn: false
+    #- type: PsionicBonusChance #Nyano - Summary: makes more likely to be psionic.
+    #  multiplier: 7
+    #  warn: false
 
 - type: entity
   noSpawn: true
@@ -70,9 +70,9 @@
     - type: NpcFactionMember
       factions:
       - Syndicate
-    - type: PsionicBonusChance #Nyano - Summary: makes more likely to be psionic.
-      multiplier: 7
-      warn: false
+    #- type: PsionicBonusChance #Nyano - Summary: makes more likely to be psionic.
+    #  multiplier: 7
+    #  warn: false
 
 # Space Ninja
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -3,7 +3,7 @@
   name: Urist McHands
   parent: BaseMobHuman
   id: MobHuman
-  components:
+  #components:
   #- type: PotentialPsionic #Nyano - Summary: makes potentially psionic.
 
 #Syndie

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -468,9 +468,9 @@
   id: NukeOp
   components:
     - type: NukeOperative
-    - type: PsionicBonusChance #Nyano - Summary: makes more likely to be psionic. 
-      multiplier: 7
-      warn: false
+    #- type: PsionicBonusChance #Nyano - Summary: makes more likely to be psionic.
+    #  multiplier: 7
+    #  warn: false
 
 - type: entity
   id: RandomHumanoidSpawnerCluwne

--- a/Resources/Prototypes/Entities/Mobs/Player/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/moth.yml
@@ -3,5 +3,3 @@
   name: Urist McFluff
   parent: BaseMobMoth
   id: MobMoth
-  components:
-  #- type: PotentialPsionic #Nyano - Summary: makes potentially psionic.

--- a/Resources/Prototypes/Entities/Mobs/Player/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/moth.yml
@@ -1,7 +1,7 @@
 - type: entity
   save: false
   name: Urist McFluff
-  parent: BaseMobMoth  
+  parent: BaseMobMoth
   id: MobMoth
   components:
-  - type: PotentialPsionic #Nyano - Summary: makes potentially psionic. 
+  #- type: PotentialPsionic #Nyano - Summary: makes potentially psionic.

--- a/Resources/Prototypes/Entities/Mobs/Player/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/reptilian.yml
@@ -4,6 +4,6 @@
   parent: BaseMobReptilian
   id: MobReptilian
   components:
-    - type: PotentialPsionic #Nyano - Summary: makes potentially psionic. 
+    #- type: PotentialPsionic #Nyano - Summary: makes potentially psionic.
 
 #Weh

--- a/Resources/Prototypes/Entities/Mobs/Player/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/reptilian.yml
@@ -3,7 +3,5 @@
   name: Urisst' Mzhand
   parent: BaseMobReptilian
   id: MobReptilian
-  components:
-    #- type: PotentialPsionic #Nyano - Summary: makes potentially psionic.
 
 #Weh

--- a/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
@@ -8,7 +8,7 @@
     interactSuccessString: hugging-success-generic
     interactSuccessSound: /Audio/Effects/thudswoosh.ogg
     messagePerceivedByOthers: hugging-success-generic-others
-  - type: PotentialPsionic #Nyano - Summary: makes potentially psionic. 
+  #- type: PotentialPsionic #Nyano - Summary: makes potentially psionic.
 
 - type: entity
   name: skeleton pirate

--- a/Resources/Prototypes/Entities/Mobs/Player/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/slime.yml
@@ -3,4 +3,4 @@
   parent: BaseMobSlimePerson
   id: MobSlimePerson
   components:
-    - type: PotentialPsionic #Nyano - Summary: makes potentially psionic. 
+    #- type: PotentialPsionic #Nyano - Summary: makes potentially psionic.

--- a/Resources/Prototypes/Entities/Mobs/Player/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/slime.yml
@@ -2,5 +2,3 @@
   save: false
   parent: BaseMobSlimePerson
   id: MobSlimePerson
-  components:
-    #- type: PotentialPsionic #Nyano - Summary: makes potentially psionic.

--- a/Resources/Prototypes/Entities/Mobs/Player/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/vox.yml
@@ -3,5 +3,3 @@
   name: Vox
   parent: BaseMobVox
   id: MobVox
-  components:
-  #- type: PotentialPsionic #Nyano - Summary: makes potentially psionic.

--- a/Resources/Prototypes/Entities/Mobs/Player/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/vox.yml
@@ -4,4 +4,4 @@
   parent: BaseMobVox
   id: MobVox
   components:
-  - type: PotentialPsionic #Nyano - Summary: makes potentially psionic. 
+  #- type: PotentialPsionic #Nyano - Summary: makes potentially psionic.

--- a/Resources/Prototypes/Entities/Mobs/Species/golem.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/golem.yml
@@ -245,7 +245,7 @@
 #         clownedon:
 #           True: {visible: true}
 #           False: {visible: false}
-#   - type: Psionic
+#   #- type: Psionic
 #     removable: false
 #   - type: Laws
 #   - type: IntrinsicUI

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/item_artifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/item_artifacts.yml
@@ -59,7 +59,7 @@
     sprite: Objects/Specific/Xenoarchaeology/item_artifacts.rsi
     heldPrefix: ano01
   - type: Actions
-  - type: Psionic #Nyano - Summary: makes psionic on creation.
+  #- type: Psionic #Nyano - Summary: makes psionic on creation.
   - type: Construction
     graph: Artifact
     node: done

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/structure_artifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/structure_artifacts.yml
@@ -54,7 +54,7 @@
           ano01_on: Rainbow
     - type: Appearance
     - type: Actions
-    - type: Psionic #Nyano - Summary: Makes psionic on creation.
+    #- type: Psionic #Nyano - Summary: Makes psionic on creation.
     - type: GuideHelp
       guides:
       - Xenoarchaeology

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -47,8 +47,8 @@
   - type: EmitSoundOnSpawn
     sound:
       path: /Audio/Effects/teleport_arrival.ogg
-  - type: Psionic #Nyano - Summary: makes psionic on creation.
-  - type: GlimmerSource #Nyano - Summary: makes this a potential source of Glimmer. 
+  #- type: Psionic #Nyano - Summary: makes psionic on creation.
+  - type: GlimmerSource #Nyano - Summary: makes this a potential source of Glimmer.
     active: false
 
 - type: entity

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/factions.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/factions.yml
@@ -85,15 +85,14 @@
   - TownDeputy
   - TownSheriff
   - TownMayor
-  
+
 - type: department
   id: Zetan
   description: department-Zetan-description
   color: "#7ec133"
-  editorHidden: true
   roles:
   - Zetan
-  
+
 - type: department
   id: Followers
   description: department-Followers-description

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -5,7 +5,7 @@
   name: mystagogue's hardsuit helmet
   description: Lightweight hardsuit helmet that has a galaxy-first psionic passthrough system.
   components:
-  - type: Psionic
+  #- type: Psionic
   - type: TinfoilHat
     passthrough: true
     destroyOnFry: false

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/psionic_clothing.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/psionic_clothing.yml
@@ -11,7 +11,7 @@
   - type: VisionCorrection
   - type: ClothingGrantPsionicPower
     power: TelegnosisPower
-  - type: Psionic
+  #- type: Psionic
 
 - type: entity
   id: BedsheetInvisibilityCloak
@@ -25,7 +25,7 @@
     sprite: Clothing/Neck/Bedsheets/black.rsi
   - type: ClothingGrantPsionicPower
     power: PsionicInvisibilityPower
-  - type: Psionic
+  #- type: Psionic
 
 - type: entity
   parent: ClothingHandsBase
@@ -45,7 +45,7 @@
   - type: FingerprintMask
   - type: ClothingGrantPsionicPower
     power: DispelPower
-  - type: Psionic
+  #- type: Psionic
 
 - type: entity
   parent: ClothingHandsBase
@@ -63,4 +63,4 @@
   - type: FingerprintMask
   - type: ClothingGrantPsionicPower
     power: NoosphericZapPower
-  - type: Psionic
+  #- type: Psionic

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/mutants.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/mutants.yml
@@ -143,8 +143,8 @@
 #     bloodReagent: DemonsBlood
 #   - type: Body
 #     prototype: VampiricAnimalLarge
-#   - type: PotentialPsionic
-#   - type: Psionic
+#   #- type: PotentialPsionic
+#   #- type: Psionic
 #     removable: false
 #   - type: MetapsionicPower
 #   - type: MeleeWeapon

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/Oni.yml
@@ -32,4 +32,4 @@
   - type: NpcFactionMember
     factions:
     - NanoTrasen
-  - type: PotentialPsionic
+  #- type: PotentialPsionic

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/felinid.yml
@@ -49,5 +49,5 @@
   - type: NpcFactionMember
     factions:
     - NanoTrasen
-  - type: PotentialPsionic
+  #- type: PotentialPsionic
 

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/special.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/special.yml
@@ -14,7 +14,7 @@
     layers:
       - state: eyeball
         shader: unshaded
-  - type: Psionic
+  #- type: Psionic
   - type: MindContainer
   - type: Clickable
   - type: InteractionOutline

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Research/crystals.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Research/crystals.yml
@@ -23,7 +23,7 @@
 #     state: bluespace
 #     color: purple
 #   - type: Speech
-#   - type: Psionic
+#   #- type: Psionic
 #   - type: SoulCrystal
 #   - type: SolutionContainerManager
 #     solutions:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/metempsychoticMachine.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/metempsychoticMachine.yml
@@ -22,4 +22,4 @@
             NoMind: { state: pod_1 }
             Gore: { state: pod_1 }
             Idle: { state: pod_0 }
-    - type: Psionic
+    #- type: Psionic

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/glimmer_prober.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/glimmer_prober.yml
@@ -4,7 +4,7 @@
   name: glimmer prober
   description: Probes the noösphere to generate research points. Might be worth turning off if glimmer is a problem.
   components:
-  - type: Psionic
+  #- type: Psionic
   - type: GlimmerSource
   - type: Construction
     graph: GlimmerDevices
@@ -90,7 +90,7 @@
   name: glimmer drain
   description: Uses electricity to try and sort out the noösphere, reducing its level of entropy.
   components:
-  - type: Psionic
+  #- type: Psionic
   - type: GlimmerSource
     addToGlimmer: false
   - type: Construction

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/oracle.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/oracle.yml
@@ -16,7 +16,7 @@
   - type: Oracle
   - type: Speech
     speechSounds: Tenor
-  - type: Psionic
+  #- type: Psionic
   - type: SolutionContainerManager
     solutions:
       fountain:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/sophicscribe.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/sophicscribe.yml
@@ -27,8 +27,8 @@
     channels:
     - Common
     - Science
-  - type: PotentialPsionic #this makes her easier to access for glimmer events, dw about it
-  - type: Psionic
+  #- type: PotentialPsionic #this makes her easier to access for glimmer events, dw about it
+  #- type: Psionic
   - type: Grammar
     attributes:
       gender: female

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -22,7 +22,7 @@
   special:
   - !type:AddComponentSpecial
     components:
-    - type: Psionic
+    #- type: Psionic
     - type: MetapsionicPower
   setPreference: false
 

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -18,10 +18,10 @@
   - !type:AddComponentSpecial
     components:
     - type: BibleUser #Lets them heal with bibles
-  - !type:AddComponentSpecial
-    components:
-    - type: PsionicBonusChance #Nyano - Summary: makes it more likely to become psionic.
-      multiplier: 3
+  #- !type:AddComponentSpecial
+  #  components:
+  #  - type: PsionicBonusChance #Nyano - Summary: makes it more likely to become psionic.
+  #    multiplier: 3
   setPreference: false
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -16,7 +16,7 @@
   special:
   - !type:AddComponentSpecial
     components:
-    - type: Psionic # Nyano - Summary: Makes the mime psionic.
+    #- type: Psionic # Nyano - Summary: Makes the mime psionic.
     - type: MimePowers
     - type: FrenchAccent
   setPreference: false

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -41,10 +41,10 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
-  - !type:AddComponentSpecial
-    components:
-    - type: PsionicBonusChance #Nyano - Summary: makes it more likely to become psionic.
-      flatBonus: 0.025
+  #- !type:AddComponentSpecial
+  #  components:
+  #  - type: PsionicBonusChance #Nyano - Summary: makes it more likely to become psionic.
+  #    flatBonus: 0.025
 
 - type: startingGear
   id: CaptainGear

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -67,10 +67,10 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
-  - !type:AddComponentSpecial
-    components:
-    - type: PsionicBonusChance #Nyano - Summary: makes it more likely to become psionic.
-      flatBonus: 0.025
+  #- !type:AddComponentSpecial
+  #  components:
+  #  - type: PsionicBonusChance #Nyano - Summary: makes it more likely to become psionic.
+  #    flatBonus: 0.025
 
 - type: startingGear
   id: HoPGear

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -35,10 +35,10 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
-  - !type:AddComponentSpecial
-    components:
-    - type: PsionicBonusChance #Nyano - Summary: makes it more likely to become psionic.
-      flatBonus: 0.025
+  #- !type:AddComponentSpecial
+  #  components:
+  #  - type: PsionicBonusChance #Nyano - Summary: makes it more likely to become psionic.
+  #    flatBonus: 0.025
   setPreference: false
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -40,10 +40,10 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
-  - !type:AddComponentSpecial
-    components:
-    - type: PsionicBonusChance #Nyano - Summary: makes it more likely to become psionic.
-      flatBonus: 0.025
+  #- !type:AddComponentSpecial
+  #  components:
+  #  - type: PsionicBonusChance #Nyano - Summary: makes it more likely to become psionic.
+  #    flatBonus: 0.025
   setPreference: false
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -28,7 +28,7 @@
   - !type:AddComponentSpecial
     components:
     - type: BibleUser # Nyano - Lets them heal with bibles
-    - type: Psionic # Nyano - They start with telepathic chat
+    #- type: Psionic # Nyano - They start with telepathic chat
     - type: DispelPower # Nyano - They get the Dispel psionic power on spawn
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -40,10 +40,10 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
-  - !type:AddComponentSpecial
-    components:
-    - type: PsionicBonusChance #Nyano - Summary: makes it more likely to become psionic.
-      flatBonus: 0.025
+  #- !type:AddComponentSpecial
+  #  components:
+  #  - type: PsionicBonusChance #Nyano - Summary: makes it more likely to become psionic.
+  #    flatBonus: 0.025
   setPreference: false
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -2,7 +2,6 @@
   id: Logistics # DeltaV - Logistics Department replacing Cargo
   description: department-Cargo-description
   color: "#A46106"
-  editorHidden: true
   roles:
   - CargoTechnician
   - Quartermaster
@@ -14,7 +13,6 @@
   description: department-Civilian-description
   color: "#9FED58"
   weight: -10
-  editorHidden: true
   roles:
   - Bartender
   - Borg
@@ -42,7 +40,6 @@
   id: Command
   description: department-Command-description
   color: "#334E6D"
-  editorHidden: true
   roles:
   - Captain
   - CentralCommandOfficial
@@ -59,7 +56,6 @@
   id: Engineering
   description: department-Engineering-description
   color: "#EFB341"
-  editorHidden: true
   roles:
   - AtmosphericTechnician
   - ChiefEngineer
@@ -71,7 +67,6 @@
   id: Medical
   description: department-Medical-description
   color: "#52B4E9"
-  editorHidden: true
   roles:
   - Chemist
   - ChiefMedicalOfficer
@@ -87,7 +82,6 @@
   description: department-Security-description
   color: "#DE3A3A"
   weight: 20
-  editorHidden: true
   roles:
   - HeadOfSecurity
   - SecurityCadet
@@ -102,7 +96,6 @@
   id: Epistemics # DeltaV - Epistemics Department replacing Science
   description: department-Science-description
   color: "#D381C9"
-  editorHidden: true
   roles:
   - ResearchDirector
   - SeniorResearcher
@@ -116,7 +109,6 @@
   description: department-Specific-description
   color: "#9FED58"
   weight: 10
-  editorHidden: true
   roles:
   - Boxer
   - Reporter


### PR DESCRIPTION
Nuclear-14 wasn't intended to have psionics, and this slipped through the cracks. 

Remind me tomorrow so I can properly make exit condition CVars across the entire psionic system so that disabling it can be done a lot cleaner and without merge conflicts. 