### PR TITLE
rangers role expansion

### DIFF
--- a/Resources/Prototypes/Nuclear14/Catalog/Fills/Belts/belt.yml
+++ b/Resources/Prototypes/Nuclear14/Catalog/Fills/Belts/belt.yml
@@ -1,0 +1,11 @@
+- type: entity
+  noSpawn: true
+  parent: ClothingBeltRevolver
+  id: ClothingBeltRevolverfilled
+  components:
+    - type: StorageFill
+      contents:
+        - id: N14WeaponRevolverMagnun
+        - id: SpeedLoader44
+        - id: SpeedLoader44
+        - id: SpeedLoader44

--- a/Resources/Prototypes/Nuclear14/Catalog/uplink/uplink_catalog.yml
+++ b/Resources/Prototypes/Nuclear14/Catalog/uplink/uplink_catalog.yml
@@ -1,0 +1,263 @@
+# TODO: make more categories
+
+# Guns (hand guns)
+- type: listing
+  id: UplinkRevolverHunter
+  name: hunter revolver
+  description: A massive revolver capable of holding .45-70 ammo.
+  productEntity: N14WeaponHunterRevolver
+  cost:
+    Telecrystal: 8
+  categories:
+  - UplinkWeapons
+
+- type: listing
+  id: UplinkRevolverMagnum
+  name: magnum revolver
+  description: A revolver chambered on .44 magnum.
+  productEntity: N14WeaponRevolverMagnun
+  cost:
+    Telecrystal: 6
+  categories:
+  - UplinkWeapons
+
+- type: listing
+  id: UplinkPistol12mm
+  name: 12.7mm handgun
+  description: A advance 12.7mm handgun.
+  productEntity: N14WeaponPistol12mm
+  cost:
+    Telecrystal: 4
+  categories:
+  - UplinkWeapons
+
+# Guns (long guns)
+- type: listing
+  id: UplinkAntimaterielRifle
+  name: antimateriel rifle
+  description: A extremely powerfull .50 cal rifle.
+  productEntity: N14WeaponAntiMateriel
+  cost:
+    Telecrystal: 12
+  categories:
+  - UplinkWeapons
+
+- type: listing
+  id: UplinkMarksmanCarbine
+  name: marksman carbine
+  description: A accurate semiauto rifle chambered on 7.62mm.
+  productEntity: N14WeaponMarksman
+  cost:
+    Telecrystal: 10
+  categories:
+  - UplinkWeapons
+
+- type: listing
+  id: Uplink12mmSMG
+  name: advance 12mm SMG
+  description: Fast and with a big magazine and a good firerate, this SMG uses 12.7mm ammo.
+  icon: { sprite: /Textures/Objects/Weapons/Melee/e_dagger.rsi, state: icon }
+  productEntity: N14WeaponAdvanceSubMachineGun12mm
+  cost:
+    Telecrystal: 10
+  categories:
+  - UplinkWeapons
+
+- type: listing
+  id: UplinkLeverRifle
+  name: lever action rifle
+  description: A strong lever action rifle, chambered on .308.
+  productEntity: N14WeaponLeverRifle
+  cost:
+    Telecrystal: 10
+  categories:
+  - UplinkWeapons
+
+- type: listing
+  id: UplinkDisposableTurret
+  name: riot shotgun
+  description: A compact semiauto shotgun chambered on 20 gauge shells.
+  productEntity: N14WeaponRiotShotgun
+  cost:
+    Telecrystal: 10
+  categories:
+  - UplinkWeapons
+
+# Ammo (long guns)
+
+- type: listing
+  id: Uplink50AmmoBox
+  name: .50 cal ammo box
+  description: A ammo box for the antimateriel rifle
+  icon: { sprite: Nuclear14/Objects/Weapons/Guns/Ammunition/Boxes/50anti-material.rsi, state: icon }
+  productEntity: MagazineBox50
+  cost:
+    Telecrystal: 5
+  categories:
+  - UplinkAmmo
+
+- type: listing
+  id: UplinkMagazineMarksmanCarbine
+  name: 7.62mm magazine
+  description: A 7.62mm magazine for the marksman rifle
+  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/smg_mag.rsi, state: icon }
+  productEntity: MagazinePistolSubMachineGun
+  cost:
+    Telecrystal: 2
+  categories:
+  - UplinkAmmo
+
+- type: listing
+  id: UplinkMagazine12mmSMG
+  name: 12.7mm top magazine
+  description: A top magazine for the 12mm advance SMG
+  icon: { sprite: Nuclear14/Objects/Weapons/Guns/Ammunition/Magazines/12.7/topmag.rsi, state: icon }
+  productEntity: N14TopMagazineSMG12mm
+  cost:
+    Telecrystal: 2
+  categories:
+  - UplinkAmmo
+
+- type: listing
+  id: Uplink308AmmoBox
+  name: .308 ammo box
+  description: A .308 ammo box for the lever action rifle.
+  icon: { sprite: Nuclear14/Objects/Weapons/Guns/Ammunition/Boxes/308.rsi, state: icon }
+  productEntity: MagazineBox308
+  cost:
+    Telecrystal: 3
+  categories:
+  - UplinkAmmo
+
+- type: listing
+  id: Uplink20gaugeMagazine
+  name: 20 gauge magazine
+  description: A round 20 gauge magazine for the riot shotgun.
+  icon: { sprite: Nuclear14/Objects/Weapons/Guns/Ammunition/Magazines/20gauge/mag.rsi, state: icon }
+  productEntity: N14MagazineShotgun20
+  cost:
+    Telecrystal: 2
+  categories:
+  - UplinkAmmo
+
+# Ammo (hand guns)
+
+- type: listing
+  id: UplinkSpeedloader45-70
+  name: .45-70 speedloader
+  description: A .45-70 speedloader for the hunter revolver.
+  icon: { sprite: Nuclear14/Objects/Weapons/Guns/Ammunition/Speedloaders/45_70loader.rsi, state: icon }
+  productEntity: SpeedLoader45-70
+  cost:
+    Telecrystal: 2
+  categories:
+  - UplinkAmmo
+
+- type: listing
+  id: UplinkSpeedloader44
+  name: .44 speedloader
+  description: A .44 speedloader for the magnum revolver.
+  icon: { sprite: Nuclear14/Objects/Weapons/Guns/Ammunition/Speedloaders/44loader.rsi, state: icon }
+  productEntity: SpeedLoader44
+  cost:
+    Telecrystal: 2
+  categories:
+  - UplinkAmmo
+
+- type: listing
+  id: Uplink12mmPistolMagazine
+  name: 12.7mm pistol magazine
+  description: A 12.7mm pistol magazine for the 12.7mm handgun.
+  icon: { sprite: Nuclear14/Objects/Weapons/Guns/Ammunition/Magazines/12.7/pistolmag.rsi, state: icon }
+  productEntity: N14MagazinePistol12mm
+  cost:
+    Telecrystal: 1
+  categories:
+  - UplinkAmmo
+
+#Utility
+
+- type: listing
+  id: UplinkRevolverHolster
+  name: revolver holster
+  description: A belt capable of holding all revolver related things.
+  icon: { sprite: Nuclear14/Clothing/Belt/revolverholster.rsi, state: icon }
+  productEntity: ClothingBeltRevolver
+  cost:
+    Telecrystal: 6
+  categories:
+  - UplinkUtility
+
+- type: listing
+  id: UplinkMilitaryCarrier
+  name: military carrier
+  description: A pre war military carrier to hold magazines.
+  icon: { sprite: Nuclear14/Clothing/Belt/militarywebbing.rsi, state: icon }
+  productEntity: ClothingBeltMilitary
+  cost:
+    Telecrystal: 6
+  categories:
+  - UplinkUtility
+
+- type: listing
+  id: UplinkToolBelt
+  name: military carrier
+  description: A pre war military carrier to hold magazines.
+  icon: { sprite: Nuclear14/Clothing/Belt/militarywebbing.rsi, state: icon }
+  productEntity: ClothingBeltMilitary
+  cost:
+    Telecrystal: 6
+  categories:
+  - UplinkUtility
+
+# Meds
+
+# Armor (body armor)
+
+- type: listing
+  id: UplinkArmorDesertRanger
+  name: desert ranger armor
+  description: A ranger combat armor covered by a coat.
+  productEntity: N14ClothingOuterRangerCoat
+  icon: { sprite: Nuclear14/Clothing/OuterClothing/Armor/falloutrangercoat.rsi, state: icon }
+  cost:
+    Telecrystal: 10
+  categories:
+    - UplinkArmor
+
+# Armor (helmets)
+
+- type: listing
+  id: UplinkArmorDesertRanger
+  name: desert ranger helmet
+  description: A ranger combat helmet.
+  productEntity: N14ClothingHeadHatRangerHelmet
+  icon: { sprite: Nuclear14/Clothing/Head/FalloutHelmets/rangerhelmet.rsi, state: icon }
+  cost:
+    Telecrystal: 4
+  categories:
+    - UplinkArmor
+
+- type: listing
+  id: UplinkArmorDesertRanger
+  name: ranger hat
+  description: A ranger hat, barely any protection but it looks good.
+  productEntity: N14ClothingHeadHatRanger
+  icon: { sprite: Nuclear14/Clothing/Head/FalloutHats/rangerhat.rsi, state: icon }
+  cost:
+    Telecrystal: 2
+  categories:
+    - UplinkArmor
+- 
+# Armor (masks)
+
+- type: listing
+  id: UplinkMaskGasmask
+  name: riot gasmask
+  description: A highly protective gasmask.
+  productEntity: ClothingMaskGasRiot
+  icon: { sprite: Nuclear14/Clothing/Mask/Gasmask/riotgasmask.rsi, state: icon }
+  cost:
+    Telecrystal: 10
+  categories:
+    - UplinkArmor

--- a/Resources/Prototypes/Nuclear14/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Markers/Spawners/jobs.yml
@@ -207,6 +207,18 @@
     layers:
       - state: green
       - state: passenger # TODO make new icons
+
+- type: entity
+  id: N14SpawnPointNCRRanger
+  parent: N14SpawnPointWastelander
+  name: NCR ranger
+  components:
+  - type: SpawnPoint
+    job_id: NCRRanger
+  - type: Sprite
+    layers:
+      - state: green
+      - state: passenger # TODO make new icons
       
 - type: entity
   id: N14SpawnPointNCRSoldier

--- a/Resources/Prototypes/Nuclear14/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -33,7 +33,7 @@
     proto: N14CartridgePistol10
 
 - type: entity
-  name: Magnum revolver
+  name: magnum revolver
   parent: BaseWeaponRevolver
   id: N14WeaponRevolverMagnun
   description: The Big Iron. Uses .44 magnum ammo.

--- a/Resources/Prototypes/Nuclear14/Loadouts/Roles/loadouts_ranger.yml
+++ b/Resources/Prototypes/Nuclear14/Loadouts/Roles/loadouts_ranger.yml
@@ -1,0 +1,148 @@
+- type: loadout
+  id: LoadoutNCRRangerArmor
+  category: Roles
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:LoadoutJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - N14ClothingOuterRangerVest
+    
+- type: loadout
+  id: LoadoutNCRRangerArmorV2
+  category: Roles
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:LoadoutJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - N14ClothingOuterRangerArmor
+    
+- type: loadout
+  id: LoadoutNCRRangerGun1
+  category: Roles
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:LoadoutJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - N14Weapon50NcrRifle
+    - MagazineBox50
+    
+- type: loadout
+  id: LoadoutNCRRangerGun2
+  category: Roles
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:LoadoutJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - N14WeaponCarbine
+    - LongMagazine5.56Rifle
+    - LongMagazine5.56Rifle
+    
+- type: loadout
+  id: LoadoutNCRRangerGun3
+  category: Roles
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:LoadoutJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - N14WeaponLeverRifle
+    - MagazineBox308
+    
+- type: loadout
+  id: LoadoutNCR5.56
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:LoadoutJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - LongMagazine5.56Rifle
+    - LongMagazine5.56Rifle
+    
+- type: loadout
+  id: LoadoutNCR50
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:LoadoutJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - MagazineBox50
+    
+- type: loadout
+  id: LoadoutNCR308
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:LoadoutJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - MagazineBox308
+    
+- type: loadout
+  id: LoadoutNCRmask1
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:LoadoutJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - ClothingMaskGasRiot
+
+- type: loadout
+  id: LoadoutNCRmask2
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:LoadoutJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - ClothingMaskGasCombat
+
+- type: loadout
+  id: LoadoutNCRhelmet
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:LoadoutJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - N14ClothingHeadHatRangerHelmet
+
+- type: loadout
+  id: LoadoutNCRhat
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:LoadoutJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - N14ClothingHeadHatRanger

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
@@ -1,0 +1,27 @@
+- type: job
+  id: NCRRanger
+  setPreference: true
+  name: republic ranger
+  description: the most experienced and robust soldiers form part of this elite group of the NCR army, lead troops or act by yourself under the orders of the republic.
+  playTimeTracker: NCRRanger
+  weight: 10
+  startingGear: NCRRangerGear
+  icon: "JobIconHeadOfSecurity"
+  requireAdminNotify: true
+  canBeAntag: false
+  accessGroups:
+  - NCR
+
+- type: startingGear
+  id: NCRRangerGear
+  equipment:
+    jumpsuit: N14ClothingUniformRangerV3
+    shoes: N14ClothingBootsCombat
+    belt: ClothingBeltRevolverfilled
+    id: N14IDBadgeNCRDesertRanger
+    back: N14ClothingBackpackMilitaryFilled
+    ears: ClothingHeadsetAltSecurity #placeholder
+  innerClothingSkirt: N14ClothingUniformRangerV3 #placeholder
+
+- type: playTimeTracker
+  id: NCRRanger

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/veteran_ranger.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/veteran_ranger.yml
@@ -1,0 +1,26 @@
+- type: job
+  id: NCRVeteranRanger
+  setPreference: true
+  name: desert ranger
+  description: Veterans from the NCR rangers and the old desert rangers, they are a elite spec ops group ready to operate at the wasteland, they may or not cooperate with the NCR army.
+  playTimeTracker: NCRVeteranRanger
+  weight: 10
+  startingGear: NCRVeteranRangerGear
+  icon: "JobIconHeadOfSecurity"
+  requireAdminNotify: true
+  canBeAntag: false
+  accessGroups:
+  - NCR
+
+- type: startingGear
+  id: NCRVeteranRangerGear
+  equipment:
+    jumpsuit: N14ClothingUniformRangerV1
+    shoes: N14ClothingBootsCombat
+    id: N14IDBadgeNCRDesertRanger
+    back: N14ClothingBackpackMilitaryFilled
+    ears: ClothingHeadsetAltSecurity #placeholder
+  innerClothingSkirt: N14ClothingUniformRangerV1 #placeholder
+
+- type: playTimeTracker
+  id: NCRVeteranRanger


### PR DESCRIPTION
added 2 jobs/roles:
republic ranger (all rounds role)
veteran ranger (special/event role)

the republic ranger arm ups through the loadout system.

![image](https://github.com/Vault-Overseers/nuclear-14/assets/134236674/7a4e307d-1fed-4593-b23f-9b79276899fe)

the veteran rangers depend of a uplink to choose their outfit and equipment.