### PR TITLE
Fix Nav Smash For Boss Enemies

### DIFF
--- a/Resources/Prototypes/Nuclear14/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Mobs/NPCs/animals.yml
@@ -95,7 +95,7 @@
     damage:
       groups:
         Brute: 5
-        
+
 - type: entity
   name: gecko
   id: N14MobGecko
@@ -147,7 +147,7 @@
     spawned:
     - id: N14FoodMeatGecko
       amount: 3
-        
+
 - type: entity
   name: nightstalker cub
   id: N14MobNightstalkerCub
@@ -203,7 +203,7 @@
         reagents:
         - ReagentId: Toxin
           Quantity: 2.5
-          
+
 - type: entity
   name: nightstalker
   id: N14MobNightstalker
@@ -281,7 +281,7 @@
       fix1:
         shape:
           !type:PhysShapeCircle
-            radius: 0.5
+            radius: 0.49
         density: 100
         mask:
         - MobMask
@@ -312,6 +312,7 @@
     damage:
       types:
         Slash: 15
+        Structural: 5
     range: 1.25
   - type: MovementSpeedModifier
     baseWalkSpeed : 3
@@ -363,6 +364,7 @@
     damage:
       types:
         Slash: 15
+        Structural: 5
     range: 1.5
   - type: MovementSpeedModifier
     baseWalkSpeed : 3
@@ -405,6 +407,7 @@
     damage:
       types:
         Slash: 22
+        Structural: 10
   - type: MobThresholds
     thresholds:
       0: Alive
@@ -417,7 +420,7 @@
         Base: deathclaw # TODO: Crit sprite
       Dead:
         Base: dead
-        
+
 - type: entity
   name: metal deathclaw
   id: N14MobDeathclawMetal

--- a/Resources/Prototypes/Nuclear14/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Mobs/NPCs/animals.yml
@@ -371,12 +371,10 @@
     baseSprintSpeed : 4
   - type: Hands
   - type: Puller
-  - type: Tool
-    speed: 1.5
-    qualities:
-      - Prying
-    useSound:
-      path: /Audio/Items/crowbar.ogg
+  - type: Prying
+    speedModifier: 0.75
+    pryPowered: true
+    force: true
   - type: Insulated
   - type: GhostRole
     prob: 0.5
@@ -442,6 +440,7 @@
     damage:
       types:
         Slash: 20
+        Structural: 10
   - type: MobThresholds
     thresholds:
       0: Alive

--- a/Resources/Prototypes/Nuclear14/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Mobs/NPCs/animals.yml
@@ -371,10 +371,17 @@
     baseSprintSpeed : 4
   - type: Hands
   - type: Puller
+  - type: Tool
+    speed: 1.5
+    qualities:
+      - Prying
   - type: Prying
-    speedModifier: 0.75
-    pryPowered: true
-    force: true
+    pryPowered: !type:Bool
+        true
+    force: !type:Bool
+      true
+    useSound:
+      path: /Audio/Items/crowbar.ogg
   - type: Insulated
   - type: GhostRole
     prob: 0.5


### PR DESCRIPTION
Mobs in N14 weren't obeying their AI orders to smash obstacles if they get in the way of players, because every obstacle players could put up was immune to mobs smashing them. I gave the big guys(Yao guai and deathclaws) structural damage so that they will attempt to smash through mid sized obstacles, and the albino deathclaw has enough structural to attempt to destroy metal barriers. This should prevent situations where players infinitely stall because mobs can't reach them. 

Also while I was at it, I have fixed the issue of yao guai getting stuck in doors(Thou shalt not make a mob fixture with a radius equal to, or greater than 0.5)