### PR TITLE
Ore and Material adjustments

### DIFF
--- a/Resources/Prototypes/Nuclear14/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Objects/Materials/materials.yml
@@ -9,7 +9,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      Gunpowder: 100
+      Gunpowder: 10
   - type: Stack
     stackType: Gunpowder
     baseLayer: powder_lead
@@ -22,17 +22,14 @@
   - type: Item
     heldPrefix: powder_lead
   - type: Appearance
+  - type: Extractable
+    grindableSolutionName: gunpowder
   - type: SolutionContainerManager
     solutions:
-      powder:
+      gunpowder:
         reagents:
         - ReagentId: Gunpowder
           Quantity: 10
-  - type: Extractable
-    juiceSolution:
-      reagents:
-      - ReagentId: Gunpowder
-        Quantity: 10
   - type: ExaminableSolution
     solution: powder
   - type: Tag
@@ -63,7 +60,7 @@
   components:
   - type: PhysicalComposition
     materialComposition:
-      Sulfur: 100
+      Sulfur: 10
   - type: Stack
     stackType: Sulfur
     baseLayer: powder_brass
@@ -76,17 +73,14 @@
   - type: Item
     heldPrefix: powder_brass
   - type: Appearance
+  - type: Extractable
+    grindableSolutionName: sulfur
   - type: SolutionContainerManager
     solutions:
-      powder:
+      sulfur:
         reagents:
         - ReagentId: Sulfur
           Quantity: 10
-  - type: Extractable
-    juiceSolution:
-      reagents:
-      - ReagentId: Sulfur
-        Quantity: 10
 
 - type: entity
   parent: SulfurPowder
@@ -103,7 +97,7 @@
   components:
   - type: Stack
     count: 10
-    
+
 - type: entity
   parent: SheetPaper
   id: N14Paper

--- a/Resources/Prototypes/Nuclear14/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Objects/Materials/ore.yml
@@ -30,7 +30,7 @@
   # components:
     # - type: Stack
       # count: 1
-      
+
 - type: entity
   parent: OreBase
   id: SulfurOre
@@ -63,7 +63,7 @@
   # components:
     # - type: Stack
       # count: 1
-      
+
 - type: entity
   parent: OreBase
   id: FertilizerOre
@@ -79,7 +79,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      Fertilizer: 10
+      Fertilizer: 50
   - type: Extractable
     grindableSolutionName: fertilizer
   - type: SolutionContainerManager
@@ -87,7 +87,7 @@
       fertilizer:
         reagents:
         - ReagentId: Fertilizer
-          Quantity: 10
+          Quantity: 50
 
 - type: entity
   id: FertilizerOre1

--- a/Resources/Prototypes/Nuclear14/Entities/Structures/Walls/rock.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Structures/Walls/rock.yml
@@ -159,12 +159,24 @@
   id: N14RockGreyMining
   parent: N14RockGrey
   name: ore vein
-  suffix: higher ore yield .33
+  suffix: higher ore yield .44
   description: An asteroid.
   components:
   - type: OreVein
-    oreChance: 0.33
+    oreChance: 0.44
     oreRarityPrototypeId: RandomOreDistributionStandard
+  - type: Sprite
+    layers:
+      - state: rock_asteroid
+      - map: [ "enum.EdgeLayer.South" ]
+        state: rock_asteroid_south
+      - map: [ "enum.EdgeLayer.East" ]
+        state: rock_asteroid_east
+      - map: [ "enum.EdgeLayer.North" ]
+        state: rock_asteroid_north
+      - map: [ "enum.EdgeLayer.West" ]
+        state: rock_asteroid_west
+      - state: rock_coal
 
 - type: entity
   id: SteelRock

--- a/Resources/Prototypes/Nuclear14/gatherable.yml
+++ b/Resources/Prototypes/Nuclear14/gatherable.yml
@@ -2,7 +2,7 @@
 - type: ore
   id: Timber
   oreEntity: N14FloraTimber
-  
+
 - type: ore
   id: WoodPlank
   oreEntity: MaterialWoodPlank1
@@ -13,30 +13,29 @@
   oreEntity: LeadOre1
   minOreYield: 1
   maxOreYield: 3
-  
+
 - type: ore
   id: OreSulfur
   oreEntity: SulfurOre1
   minOreYield: 1
   maxOreYield: 3
-  
+
 - type: ore
   id: OreFertilizer
   oreEntity: FertilizerOre1
   minOreYield: 1
   maxOreYield: 3
-  
+
 - type: weightedRandomOre
   id: RandomOreDistributionStandard
   weights:
-    OreSteel: 10
-    OreCoal: 10
-    OreGold: 2
-    OreSilver: 1
+    OreSteel: 3
+    OreCoal: 6
+    OreQuartz: 3
     OreUranium: 1
     OreLead: 2
     OreSulfur: 2
-    OreFertilizer: 2
+    OreFertilizer: 3
 
 # Plants
 - type: ore
@@ -58,7 +57,7 @@
 - type: ore
   id: WildCabbage
   oreEntity: N14FloraProduceWildCabbage
-  
+
 - type: ore
   id: WildCarrot
   oreEntity: N14FloraProduceWildCarrot
@@ -66,27 +65,27 @@
 - type: ore
   id: WildCaveFungus
   oreEntity: N14FloraProduceWildCaveFungus
-  
+
 - type: ore
   id: WildCaveFungusRad
   oreEntity: N14FloraProduceWildCaveFungusRad
-  
+
 - type: ore
   id: WildCotton
   oreEntity: CottonBol
-  
+
 - type: ore
   id: WildCoyote
   oreEntity: N14FloraProduceWildCoyoteTobacco
-  
+
 - type: ore
   id: WildDatura
   oreEntity: N14FloraProduceWildDaturaFlower
-  
+
 - type: ore
   id: WildBarrelCactus
   oreEntity: N14FloraProduceWildBarrelCactusFruit
-  
+
 - type: ore
   id: WildGourd
   oreEntity: N14FloraProduceWildBuffaloGourd
@@ -94,19 +93,19 @@
 - type: ore
   id: WildJalapenoPepper
   oreEntity: N14FloraProduceWildJalapenoPepper
-  
+
 - type: ore
   id: WildMaize
   oreEntity: N14FloraProduceWildMaize
-  
+
 - type: ore
   id: MesquitePods
   oreEntity: N14FloraProduceWildMesquitePods
-  
+
 - type: ore
   id: WildMutfruit
   oreEntity: N14FloraProduceWildMutfruit
-  
+
 - type: ore
   id: WildNettle
   oreEntity: N14FloraProduceWildNettle
@@ -114,11 +113,11 @@
 - type: ore
   id: WildOnion
   oreEntity: N14FloraProduceWildOnion
-  
+
 - type: ore
   id: PinyonNuts
   oreEntity: N14FloraProduceWildPinyonNuts
-  
+
 - type: ore
   id: WildPrickly
   oreEntity: N14FloraProduceWildPricklyPearFruit
@@ -134,7 +133,7 @@
 - type: ore
   id: WildTarberries
   oreEntity: N14FloraProduceWildTarberries
-  
+
 - type: ore
   id: WildTato
   oreEntity: N14FloraProduceWildTato

--- a/Resources/Prototypes/Nuclear14/gatherable.yml
+++ b/Resources/Prototypes/Nuclear14/gatherable.yml
@@ -31,7 +31,7 @@
   weights:
     OreSteel: 3
     OreCoal: 6
-    OreQuartz: 3
+    OreSpaceQuartz: 3
     OreUranium: 1
     OreLead: 2
     OreSulfur: 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes to some minor issues with ores and balancing

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>



</details>

## Changelog
:cl:
add: gave ore rocks a temporary texture inherited from coal
tweak: tweaked ore grinding to actually be grinding and not juicing
balance: rebalanced fertilizer to give 50u of itself instead of 10u to match other ores refined
balance: rebalanced mining yield from .33 to .44 to give more chances to players to get all 4 ore types required for ammo on testbranch.
fix: fixed material composition numbers of `Gunpowder` and `Sulfur`
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->