### PR TITLE
NCR Ranger Veteran and loadout changes

### DIFF
--- a/Resources/Prototypes/Nuclear14/Catalog/Fills/Belts/belt.yml
+++ b/Resources/Prototypes/Nuclear14/Catalog/Fills/Belts/belt.yml
@@ -9,6 +9,33 @@
         - id: SpeedLoader44
         - id: SpeedLoader44
         - id: SpeedLoader44
+        - id: SpeedLoader44
+
+- type: entity
+  noSpawn: true
+  parent: ClothingBeltRevolver
+  id: ClothingBeltRevolvervetfilled
+  components:
+    - type: StorageFill
+      contents:
+        - id: N14WeaponRangerSequoia
+        - id: SpeedLoader45-70
+        - id: SpeedLoader45-70
+        - id: SpeedLoader45-70
+        - id: SpeedLoader45-70
+
+- type: entity
+  noSpawn: true
+  parent: ClothingBeltRevolver
+  id: ClothingBeltRevolverdesertfilled
+  components:
+    - type: StorageFill
+      contents:
+        - id: N14WeaponHunterRevolver
+        - id: SpeedLoader45-70
+        - id: SpeedLoader45-70
+        - id: SpeedLoader45-70
+        - id: SpeedLoader45-70
 
 - type: entity
   noSpawn: true

--- a/Resources/Prototypes/Nuclear14/Entities/Clothing/Mask/gasmasks.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Clothing/Mask/gasmasks.yml
@@ -45,6 +45,8 @@
   components:
   - type: Item
     size: Tiny
+  - type: FlashImmunity
+  - type: EyeProtection
   - type: Sprite
     sprite: Nuclear14/Clothing/Mask/Gasmask/combatgasmask.rsi
   - type: Clothing
@@ -65,6 +67,8 @@
   components:
   - type: Item
     size: Tiny
+  - type: FlashImmunity
+  - type: EyeProtection
   - type: Sprite
     sprite: Nuclear14/Clothing/Mask/Gasmask/riotgasmask.rsi
   - type: Clothing
@@ -85,6 +89,8 @@
   components:
   - type: Item
     size: Tiny
+  - type: FlashImmunity
+  - type: EyeProtection
   - type: Sprite
     sprite: Nuclear14/Clothing/Mask/Gasmask/rangergasmask.rsi
   - type: Clothing
@@ -105,6 +111,8 @@
   components:
   - type: Item
     size: Tiny
+  - type: FlashImmunity
+  - type: EyeProtection
   - type: Sprite
     sprite: Nuclear14/Clothing/Mask/Gasmask/rangeroldgasmask.rsi
   - type: Clothing
@@ -128,6 +136,8 @@
   components:
   - type: Item
     size: Tiny
+  - type: FlashImmunity
+  - type: EyeProtection
   - type: Sprite
     sprite: Nuclear14/Clothing/Mask/Gasmask/rangerdesertgasmask.rsi
   - type: Clothing
@@ -151,6 +161,8 @@
   components:
   - type: Item
     size: Tiny
+  - type: FlashImmunity
+  - type: EyeProtection
   - type: Sprite
     sprite: Nuclear14/Clothing/Mask/Gasmask/rangerweatheredgasmask.rsi
   - type: Clothing
@@ -173,6 +185,8 @@
   components:
   - type: Item
     size: Tiny
+  - type: FlashImmunity
+  - type: EyeProtection
   - type: Sprite
     sprite: Nuclear14/Clothing/Mask/Gasmask/rangerpricegasmask.rsi
   - type: Clothing
@@ -196,6 +210,7 @@
   components:
   - type: Item
     size: Tiny
+  - type: EyeProtection
   - type: Sprite
     sprite: Nuclear14/Clothing/Mask/Gasmask/rangerbrokengasmask.rsi
   - type: Clothing
@@ -218,6 +233,8 @@
   components:
   - type: Item
     size: Tiny
+  - type: FlashImmunity
+  - type: EyeProtection
   - type: Sprite
     sprite: Nuclear14/Clothing/Mask/Gasmask/rangerelitegasmask.rsi
   - type: Clothing

--- a/Resources/Prototypes/Nuclear14/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Markers/Spawners/jobs.yml
@@ -221,6 +221,18 @@
       - state: passenger # TODO make new icons
 
 - type: entity
+  id: N14SpawnPointNCRRangerVeteran
+  parent: N14SpawnPointWastelander
+  name: NCR ranger veteran
+  components:
+  - type: SpawnPoint
+    job_id: NCRRangerVeteran
+  - type: Sprite
+    layers:
+      - state: green
+      - state: passenger # TODO make new icons
+
+- type: entity
   id: N14SpawnPointNCRSoldier
   parent: N14SpawnPointWastelander
   name: NCR Soldier

--- a/Resources/Prototypes/Nuclear14/Entities/Objects/Misc/identification.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Objects/Misc/identification.yml
@@ -1,11 +1,10 @@
 # ID Cards
 - type: entity
-  parent: IDCardStandard
+  parent: Clothing
   id: N14IDCard
   name: identification card
   description: A key to open certain doors.
   noSpawn: true
-  abstract: true
   components:
   - type: Sprite
     sprite: Objects/Misc/id_cards.rsi

--- a/Resources/Prototypes/Nuclear14/Entities/Objects/Misc/identification.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Objects/Misc/identification.yml
@@ -5,6 +5,7 @@
   name: identification card
   description: A key to open certain doors.
   noSpawn: true
+  abstract: true
   components:
   - type: Sprite
     sprite: Objects/Misc/id_cards.rsi
@@ -166,6 +167,8 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: ncrdogtag
+  - type: PresetIdCard
+    job: NCRSoldier
 
 # Desert Rangers
 - type: entity
@@ -177,7 +180,8 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: ranger_recruit
-  job: RangerRecruit
+  - type: PresetIdCard
+    job: RangerRecruit
 
 - type: entity
   parent: N14IDPassportBlank
@@ -188,7 +192,8 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: ranger
-  job: NCRRanger
+  - type: PresetIdCard
+    job: NCRRanger
 
 - type: entity
   parent: N14IDPassportBlank
@@ -199,7 +204,8 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: ranger_elite
-  job: NCRRangerVeteran
+  - type: PresetIdCard
+    job: NCRRangerVeteran
 
 - type: entity
   parent: N14IDPassportBlank
@@ -210,7 +216,8 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: ranger_chief
-  job: NCRRangerVeteran
+  - type: PresetIdCard
+    job: NCRRangerVeteran
 
 # Townsfolk
 - type: entity

--- a/Resources/Prototypes/Nuclear14/Entities/Objects/Misc/identification.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Objects/Misc/identification.yml
@@ -1,6 +1,6 @@
 # ID Cards
 - type: entity
-  parent: Clothing
+  parent: IDCardStandard
   id: N14IDCard
   name: identification card
   description: A key to open certain doors.
@@ -33,7 +33,7 @@
     - state: idpassenger
   - type: PresetIdCard
     job: VaultDweller
-    
+
 - type: entity
   parent: N14IDCard
   id: N14IDCardVaultEngineer
@@ -45,7 +45,7 @@
     - state: idstationengineer
   - type: PresetIdCard
     job: VaultEngineer
-    
+
 - type: entity
   parent: N14IDCard
   id: N14IDCardVaultSecurity
@@ -57,7 +57,7 @@
     - state: idsecurityofficer
   - type: PresetIdCard
     job: VaultSecurity
-    
+
 - type: entity
   parent: N14IDCard
   id: N14IDCardVaultDoctor
@@ -69,7 +69,7 @@
     - state: idmedicaldoctor
   - type: PresetIdCard
     job: VaultDoctor
-    
+
 - type: entity
   parent: N14IDCard
   id: N14IDCardVaultOverseer
@@ -81,7 +81,7 @@
     - state: idmedicaldoctor
   - type: PresetIdCard
     job: Overseer
-    
+
 # Passports
 - type: entity
   parent: Clothing
@@ -99,7 +99,7 @@
     sprite: Nuclear14/Objects/Misc/identification.rsi
   - type: Item
     heldPrefix: default
-    
+
 - type: entity
   parent: N14IDPassportBlank
   id: N14IDPassport
@@ -109,13 +109,13 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: passport
-    
+
 - type: entity
   parent: N14IDPassport
   id: N14IDPassportCaravan
   name: caravan passport
   description: A stamped passport used by caravaneers as ID.
-    
+
 - type: entity
   parent: N14IDPassportBlank
   id: N14IDPassportPhoto
@@ -125,7 +125,7 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: passport_photo
-    
+
 - type: entity
   parent: N14IDPassportBlank
   id: N14IDPassportVIP
@@ -135,7 +135,7 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: passport_presidential
-    
+
 - type: entity
   parent: N14IDPassportBlank
   id: N14IDDoctor
@@ -145,7 +145,7 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: doctor
-    
+
 # Other Factions
 - type: entity
   parent: N14IDPassportBlank
@@ -156,7 +156,7 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: bos_holotag
-    
+
 - type: entity
   parent: N14IDPassportBlank
   id: N14IDNCRDogtag
@@ -177,7 +177,8 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: ranger_recruit
-    
+  job: RangerRecruit
+
 - type: entity
   parent: N14IDPassportBlank
   id: N14IDBadgeNCRDesertRanger
@@ -187,7 +188,8 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: ranger
-    
+  job: NCRRanger
+
 - type: entity
   parent: N14IDPassportBlank
   id: N14IDBadgeNCRDesertRangerElite
@@ -197,7 +199,8 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: ranger_elite
-    
+  job: NCRRangerVeteran
+
 - type: entity
   parent: N14IDPassportBlank
   id: N14IDBadgeNCRDesertRangerChief
@@ -207,14 +210,15 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: ranger_chief
-    
+  job: NCRRangerVeteran
+
 # Townsfolk
 - type: entity
   parent: N14IDPassportPhoto
   id: N14IDPassportTownsfolk
   name: passport
   description: A passport used by townsfolk as ID.
-  
+
 - type: entity
   parent: N14IDDoctor
   id: N14IDDoctorTown
@@ -230,7 +234,7 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: deputy
-    
+
 - type: entity
   parent: N14IDPassportBlank
   id: N14IDBadgeTownSheriff
@@ -240,7 +244,7 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: sheriff
-    
+
 - type: entity
   parent: N14IDPassportBlank
   id: N14IDBadgeTownMayor
@@ -250,7 +254,7 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: mayor
-    
+
 # Raiders / Tribes
 - type: entity
   parent: N14IDPassportBlank
@@ -261,7 +265,7 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: sawbone
-    
+
 - type: entity
   parent: N14IDPassportBlank
   id: N14IDTribeBulletsPendant
@@ -271,7 +275,7 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: raider
-    
+
 - type: entity
   parent: N14IDPassportBlank
   id: N14IDTribeEnforcerPendant
@@ -281,7 +285,7 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: enforcer
-    
+
 - type: entity
   parent: N14IDPassportBlank
   id: N14IDTribeBossPendant
@@ -291,7 +295,7 @@
   - type: Sprite
     sprite: Nuclear14/Objects/Misc/identification.rsi
     state: boss
-    
+
 # Fun / Misc
 - type: entity
   parent: N14IDDoctor

--- a/Resources/Prototypes/Nuclear14/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Objects/Specific/Kits/kits.yml
@@ -136,8 +136,8 @@
       - id: N14ClothingBackpackSatchelNCR
       - id: N14WeaponPistolColt
       - id: N14MagazinePistol45
-      - id: N14MagazinePistol45 
-      - id: N14CombatKnife         
+      - id: N14MagazinePistol45
+      - id: N14CombatKnife
     sound:
       path: /Audio/Effects/unwrap.ogg
 
@@ -261,7 +261,7 @@
     sound:
       path: /Audio/Effects/unwrap.ogg
 
-# Ranger
+# Desert Rangers
 
 - type: entity
   name: ranger rifleman kit
@@ -280,10 +280,8 @@
       - id: LongMagazine5.56Rifle
       - id: LongMagazine5.56Rifle
       - id: MagazineBox5.56
-      - id: N14WeaponRevolverMagnun
-      - id: SpeedLoader44
-      - id: SpeedLoader44
-      - id: MagazineBox44
+      - id: N14Stimpak
+      - id: BoxMRE
       - id: N14CombatKnife
     sound:
       path: /Audio/Effects/unwrap.ogg
@@ -305,10 +303,8 @@
       - id: Magazine7.62Rifle
       - id: Magazine7.62Rifle
       - id: MagazineBox7.62
-      - id: N14WeaponRevolverMagnun
-      - id: SpeedLoader44
-      - id: SpeedLoader44
-      - id: MagazineBox44
+      - id: N14Stimpak
+      - id: BoxMRE
       - id: N14CombatKnife
     sound:
       path: /Audio/Effects/unwrap.ogg
@@ -330,10 +326,8 @@
       - id: N14MagazineShotgun12
       - id: N14MagazineShotgun12
       - id: MagazineBox12gauge
-      - id: N14WeaponRevolverMagnun
-      - id: SpeedLoader44
-      - id: SpeedLoader44
-      - id: MagazineBox44
+      - id: N14Stimpak
+      - id: BoxMRE
       - id: N14CombatKnife
     sound:
       path: /Audio/Effects/unwrap.ogg
@@ -353,11 +347,10 @@
       - id: N14WeaponBrushGun
       - id: MagazineBox45-70
       - id: MagazineBox45-70
-      - id: N14WeaponHunterRevolver
-      - id: SpeedLoader45-70
-      - id: SpeedLoader45-70
-      - id: SpeedLoader45-70
       - id: MagazineBox45-70
+      - id: N14Stimpak
+      - id: N14Stimpak
+      - id: BoxMRE
       - id: N14CombatKnife
     sound:
       path: /Audio/Effects/unwrap.ogg
@@ -376,11 +369,10 @@
     items:
       - id: N14WeaponAntiMateriel
       - id: MagazineBox50
-      - id: N14WeaponHunterRevolver
-      - id: SpeedLoader45-70
-      - id: SpeedLoader45-70
-      - id: SpeedLoader45-70
-      - id: MagazineBox45-70
+      - id: MagazineBox50
+      - id: N14Stimpak
+      - id: N14Stimpak
+      - id: BoxMRE
       - id: N14CombatKnife
     sound:
       path: /Audio/Effects/unwrap.ogg
@@ -400,11 +392,10 @@
       - id: N14WeaponLeverCarbine
       - id: MagazineBox44
       - id: MagazineBox44
-      - id: N14WeaponHunterRevolver
-      - id: SpeedLoader45-70
-      - id: SpeedLoader45-70
-      - id: SpeedLoader45-70
-      - id: MagazineBox45-70
+      - id: MagazineBox44
+      - id: N14Stimpak
+      - id: N14Stimpak
+      - id: BoxMRE
       - id: N14CombatKnife
     sound:
       path: /Audio/Effects/unwrap.ogg
@@ -426,11 +417,9 @@
       - id: LongMagazine5.56Rifle
       - id: LongMagazine5.56Rifle
       - id: MagazineBox5.56
-      - id: N14WeaponHunterRevolver
-      - id: SpeedLoader45-70
-      - id: SpeedLoader45-70
-      - id: SpeedLoader45-70
-      - id: MagazineBox45-70
+      - id: N14Stimpak
+      - id: N14Stimpak
+      - id: BoxMRE
       - id: N14CombatKnife
     sound:
       path: /Audio/Effects/unwrap.ogg
@@ -452,11 +441,9 @@
       - id: Magazine7.62Rifle
       - id: Magazine7.62Rifle
       - id: MagazineBox7.62
-      - id: N14WeaponHunterRevolver
-      - id: SpeedLoader45-70
-      - id: SpeedLoader45-70
-      - id: SpeedLoader45-70
-      - id: MagazineBox45-70
+      - id: N14Stimpak
+      - id: N14Stimpak
+      - id: BoxMRE
       - id: N14CombatKnife
     sound:
       path: /Audio/Effects/unwrap.ogg
@@ -478,11 +465,10 @@
       - id: N14MagazineShotgun20
       - id: N14MagazineShotgun20
       - id: MagazineBox20gauge
-      - id: N14WeaponHunterRevolver
-      - id: SpeedLoader45-70
-      - id: SpeedLoader45-70
-      - id: SpeedLoader45-70
-      - id: MagazineBox45-70
+      - id: N14CombatKnife
+      - id: N14Stimpak
+      - id: N14Stimpak
+      - id: BoxMRE
       - id: N14CombatKnife
     sound:
       path: /Audio/Effects/unwrap.ogg

--- a/Resources/Prototypes/Nuclear14/Entities/Objects/Specific/Medical/chemicals.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Objects/Specific/Medical/chemicals.yml
@@ -32,6 +32,9 @@
   - type: WelderRefinable
     refineResult:
     - SheetPlastic1
+  - type: Tag
+    tags:
+    - Syringe
 
 - type: entity
   name: doctors syringe

--- a/Resources/Prototypes/Nuclear14/Loadouts/Roles/loadouts_ncr.yml
+++ b/Resources/Prototypes/Nuclear14/Loadouts/Roles/loadouts_ncr.yml
@@ -198,6 +198,7 @@
     - !type:LoadoutJobRequirement
       jobs:
         - RangerVeteran
+        - NCRRangerVeteran
   items:
     - KitRiflemanRangerVeteran
 
@@ -210,6 +211,7 @@
     - !type:LoadoutJobRequirement
       jobs:
         - RangerVeteran
+        - NCRRangerVeteran
   items:
     - KitHeavySniperRangerVeteran
 
@@ -222,6 +224,7 @@
     - !type:LoadoutJobRequirement
       jobs:
         - RangerVeteran
+        - NCRRangerVeteran
   items:
     - KitTrailmanRangerVeteran
 
@@ -234,6 +237,7 @@
     - !type:LoadoutJobRequirement
       jobs:
         - RangerVeteran
+        - NCRRangerVeteran
   items:
     - KitAssaultRangerVeteran
 
@@ -246,6 +250,7 @@
     - !type:LoadoutJobRequirement
       jobs:
         - RangerVeteran
+        - NCRRangerVeteran
   items:
     - KitMarksmanRangerVeteran
 
@@ -258,6 +263,7 @@
     - !type:LoadoutJobRequirement
       jobs:
         - RangerVeteran
+        - NCRRangerVeteran
   items:
     - KitCQBRangerVeteran
 

--- a/Resources/Prototypes/Nuclear14/Loadouts/Roles/loadouts_ncr.yml
+++ b/Resources/Prototypes/Nuclear14/Loadouts/Roles/loadouts_ncr.yml
@@ -160,6 +160,7 @@
       jobs:
         - RangerRecruit
         - Ranger
+        - NCRRanger
   items:
     - KitRiflemanRanger
 
@@ -173,6 +174,7 @@
       jobs:
         - RangerRecruit
         - Ranger
+        - NCRRanger
   items:
     - KitMarksmanRanger
 
@@ -186,6 +188,7 @@
       jobs:
         - RangerRecruit
         - Ranger
+        - NCRRanger
   items:
     - KitCQBRanger
 

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
@@ -4,10 +4,9 @@
   name: republic ranger
   description: the most experienced and robust soldiers form part of this elite group of the NCR army, lead troops or act by yourself under the orders of the republic.
   playTimeTracker: NCRRanger
-  weight: 10
+  weight: 5
   startingGear: NCRRangerGear
-  icon: "JobIconHeadOfSecurity"
-  requireAdminNotify: true
+  icon: JobIconSecurityOfficer
   canBeAntag: false
   accessGroups:
   - NCR
@@ -15,9 +14,15 @@
 - type: startingGear
   id: NCRRangerGear
   equipment:
-    jumpsuit: N14ClothingUniformRangerV3
+    jumpsuit: N14ClothingUniformRangerPatrol
     shoes: N14ClothingBootsCombat
     belt: ClothingBeltRevolverfilled
+    eyes: ClothingEyesGlassesSunglasses
+    neck: N14ClothingNeckCloakRangerPoncho
+    pocket1: MagazineBox 44
+    pocket2: FlashlightSeclite
+    outerClothing: N14ClothingOuterRangerArmor
+    head: N14ClothingHeadHatRanger
     id: N14IDBadgeNCRDesertRanger
     back: N14ClothingBackpackMilitaryFilled
   innerClothingSkirt: N14ClothingUniformRangerV3 #placeholder

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
@@ -8,8 +8,11 @@
   startingGear: NCRRangerGear
   icon: JobIconSecurityOfficer
   canBeAntag: false
-  accessGroups:
-  - NCR
+  access:
+  - NCRCadet
+  - NCRSoldier
+  - NCRNCO
+  - NCRRanger
 
 - type: startingGear
   id: NCRRangerGear

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
@@ -1,7 +1,7 @@
 - type: job
   id: NCRRanger
   setPreference: true
-  name: republic ranger
+  name: Republic Ranger
   description: the most experienced and robust soldiers form part of this elite group of the NCR army, lead troops or act by yourself under the orders of the republic.
   playTimeTracker: NCRRanger
   weight: 5
@@ -19,7 +19,7 @@
     belt: ClothingBeltRevolverfilled
     eyes: ClothingEyesGlassesSunglasses
     neck: N14ClothingNeckCloakRangerPoncho
-    pocket1: MagazineBox 44
+    pocket1: MagazineBox44
     pocket2: FlashlightSeclite
     outerClothing: N14ClothingOuterRangerArmor
     head: N14ClothingHeadHatRanger

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
@@ -5,7 +5,7 @@
   description: the most experienced and robust soldiers form part of this elite group of the NCR army, lead troops or act by yourself under the orders of the republic.
   playTimeTracker: NCRRanger
   weight: 5
-  startingGear: NCRRangerGear
+  startingGear: RangerGear
   icon: JobIconSecurityOfficer
   canBeAntag: false
   access:
@@ -29,6 +29,3 @@
     id: N14IDBadgeNCRDesertRanger
     back: N14ClothingBackpackMilitaryFilled
   innerClothingSkirt: N14ClothingUniformRangerV3 #placeholder
-
-- type: playTimeTracker
-  id: NCRRanger

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
@@ -29,3 +29,6 @@
     id: N14IDBadgeNCRDesertRanger
     back: N14ClothingBackpackMilitaryFilled
   innerClothingSkirt: N14ClothingUniformRangerV3 #placeholder
+
+- type: playTimeTracker
+  id: NCRRanger

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger_veteran.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger_veteran.yml
@@ -3,7 +3,7 @@
   setPreference: true
   name: Republic Ranger Veteran
   description: the most experienced and robust soldiers form part of this elite group of the NCR army, lead troops or act by yourself under the orders of the republic.
-  playTimeTracker: RangerVeteran
+  playTimeTracker: NCRRangerVeteran
   weight: 10
   startingGear: NCRRangerGearVeteran
   icon: "JobIconHeadOfSecurity"
@@ -29,3 +29,6 @@
     id: N14IDBadgeNCRDesertRangerElite
     back: N14ClothingBackpackMilitaryFilled
   innerClothingSkirt: N14ClothingUniformRangerModif #placeholder
+
+- type: playTimeTracker
+  id: NCRRangerVeteran

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger_veteran.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger_veteran.yml
@@ -1,0 +1,34 @@
+- type: job
+  id: NCRRangerVeteran
+  setPreference: true
+  name: Republic Ranger Veteran
+  description: the most experienced and robust soldiers form part of this elite group of the NCR army, lead troops or act by yourself under the orders of the republic.
+  playTimeTracker: NCRRangerVeteran
+  weight: 10
+  startingGear: NCRRangerGearVeteran
+  icon: "JobIconHeadOfSecurity"
+  requireAdminNotify: true
+  canBeAntag: false
+  accessGroups:
+  - NCR
+
+- type: startingGear
+  id: NCRRangerGearVeteran
+  equipment:
+    jumpsuit: N14ClothingUniformRangerVeteran
+    shoes: N14ClothingBootsCombat
+    gloves: N14ClothingHandsGlovesCombat
+    belt: ClothingBeltRevolvervetfilled
+    mask: ClothingMaskGasRangerOld
+    eyes: ClothingEyesGlassesSunglasses
+    neck: N14ClothingNeckCloakRanger
+    pocket1: MagazineBox45-70
+    pocket2: FlashlightSeclite
+    outerClothing: N14ClothingOuterRangerCombat
+    head: N14ClothingHeadHatRangerHelmetOld
+    id: N14IDBadgeNCRDesertRangerVeteran
+    back: N14ClothingBackpackMilitaryFilled
+  innerClothingSkirt: N14ClothingUniformRangerModif #placeholder
+
+- type: playTimeTracker
+  id: NCRRangerVeteran

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger_veteran.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger_veteran.yml
@@ -3,7 +3,7 @@
   setPreference: true
   name: Republic Ranger Veteran
   description: the most experienced and robust soldiers form part of this elite group of the NCR army, lead troops or act by yourself under the orders of the republic.
-  playTimeTracker: NCRRangerVeteran
+  playTimeTracker: RangerVeteran
   weight: 10
   startingGear: NCRRangerGearVeteran
   icon: "JobIconHeadOfSecurity"
@@ -29,6 +29,3 @@
     id: N14IDBadgeNCRDesertRangerElite
     back: N14ClothingBackpackMilitaryFilled
   innerClothingSkirt: N14ClothingUniformRangerModif #placeholder
-
-- type: playTimeTracker
-  id: NCRRangerVeteran

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger_veteran.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger_veteran.yml
@@ -26,7 +26,7 @@
     pocket2: FlashlightSeclite
     outerClothing: N14ClothingOuterRangerCombat
     head: N14ClothingHeadHatRangerHelmetOld
-    id: N14IDBadgeNCRDesertRangerVeteran
+    id: N14IDBadgeNCRDesertRangerElite
     back: N14ClothingBackpackMilitaryFilled
   innerClothingSkirt: N14ClothingUniformRangerModif #placeholder
 

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger.yml
@@ -23,6 +23,9 @@
     shoes: N14ClothingBootsLeather
     belt: ClothingBeltRevolverdesertfilled
     mask: ClothingMaskGasRangerDesert
+    pocket1: MagazineBox45-70
+    pocket2: FlashlightSeclite
+    eyes: ClothingEyesGlassesSunglasses
     outerClothing: N14ClothingOuterRangerCombatDesert
     id: N14IDBadgeNCRDesertRanger
   innerClothingSkirt: N14ClothingOfficerUniformNCR #placeholder

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger.yml
@@ -1,6 +1,6 @@
 - type: job
   id: Ranger
-  setPreference: true
+  setPreference: false
   name: desert ranger
   description: job-description-ranger-ranking
   playTimeTracker: Ranger
@@ -21,7 +21,7 @@
     back: N14ClothingBackpackMilitaryFilled
     jumpsuit: N14ClothingUniformRangerV2
     shoes: N14ClothingBootsLeather
-    belt: ClothingBeltRevolver
+    belt: ClothingBeltRevolverdesertfilled
     mask: ClothingMaskGasRangerDesert
     outerClothing: N14ClothingOuterRangerCombatDesert
     id: N14IDBadgeNCRDesertRanger

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger.yml
@@ -21,6 +21,7 @@
     back: N14ClothingBackpackMilitaryFilled
     jumpsuit: N14ClothingUniformRangerV2
     shoes: N14ClothingBootsLeather
+    gloves: N14ClothingHandsGlovesBlackLeather
     belt: ClothingBeltRevolverdesertfilled
     mask: ClothingMaskGasRangerDesert
     pocket1: MagazineBox45-70

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger_chief.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger_chief.yml
@@ -1,34 +1,33 @@
 - type: job
-  id: RangerVeteran
+  id: RangerChief #admin lead
   setPreference: false
-  name: veteran desert ranger
+  name: chief desert ranger
   description: job-description-ranger-veteran
   playTimeTracker: RangerVeteran
-  weight: 10
-  startingGear: RangerVeteranGear
-  icon: "JobIconHeadOfSecurity"
-  supervisors: job-supervisors-ncr-captain
+  weight: 20
+  startingGear: RangerChiefGear
+  icon: "JobIconCaptain"
   requireAdminNotify: true
   canBeAntag: false
   accessGroups:
   - NCR
 
 - type: startingGear
-  id: RangerVeteranGear
+  id: RangerChiefGear
   equipment:
     head: N14ClothingHeadHatRangerHelmetElite
     back: N14ClothingBackpackMilitaryFilled
-    jumpsuit: N14ClothingUniformRangerV3
-    shoes: N14ClothingBootsCombat
+    jumpsuit: N14ClothingUniformRangerVeteran
+    shoes: N14ClothingBootsCombatMK2
     gloves: N14ClothingHandsGlovesCombat
-    belt: ClothingBeltRevolverdesertfilled
+    belt: ClothingBeltRevolvervetfilled
     mask: ClothingMaskGasRangerElite
     pocket1: MagazineBox45-70
     pocket2: FlashlightSeclite
     eyes: ClothingEyesGlassesSunglasses
-    outerClothing: N14ClothingOuterRangerEliteOld
-    id: N14IDBadgeNCRDesertRangerElite
-  innerClothingSkirt: N14ClothingOfficerUniformNCR #placeholder
+    outerClothing: N14ClothingOuterRangerElite
+    id: N14IDBadgeNCRDesertRangerChief
+  innerClothingSkirt: N14ClothingUniformRangerVeteran #placeholder
 
 - type: playTimeTracker
   id: RangerVeteran

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger_chief.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger_chief.yml
@@ -28,6 +28,3 @@
     outerClothing: N14ClothingOuterRangerElite
     id: N14IDBadgeNCRDesertRangerChief
   innerClothingSkirt: N14ClothingUniformRangerVeteran #placeholder
-
-- type: playTimeTracker
-  id: RangerVeteran

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger_chief.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger_chief.yml
@@ -3,7 +3,7 @@
   setPreference: false
   name: chief desert ranger
   description: job-description-ranger-veteran
-  playTimeTracker: RangerVeteran
+  playTimeTracker: RangerChief
   weight: 20
   startingGear: RangerChiefGear
   icon: "JobIconCaptain"
@@ -28,3 +28,6 @@
     outerClothing: N14ClothingOuterRangerElite
     id: N14IDBadgeNCRDesertRangerChief
   innerClothingSkirt: N14ClothingUniformRangerVeteran #placeholder
+
+- type: playTimeTracker
+  id: RangerChief

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger_entity.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger_entity.yml
@@ -1,0 +1,74 @@
+- type: entity
+  noSpawn: true
+  parent: MobHuman
+  id: N14MobHumanRanger
+  name: Desert Ranger
+  components:
+    - type: RandomHumanoidAppearance
+      randomizeName: false
+    - type: Loadout
+      prototypes: [RangerGear]
+    - type: RandomMetadata
+      nameSegments:
+      - NamesFirstMilitary
+      - NamesLastMilitary
+    - type: NpcFactionMember
+      factions:
+      - SimpleNeutral
+
+- type: entity
+  noSpawn: true
+  parent: MobHuman
+  id: N14MobHumanRangerRecruit
+  name: Desert Ranger Recruit
+  components:
+    - type: RandomHumanoidAppearance
+      randomizeName: false
+    - type: Loadout
+      prototypes: [RangerRecruitGear]
+    - type: RandomMetadata
+      nameSegments:
+      - NamesFirstMilitary
+      - NamesLastMilitary
+    - type: NpcFactionMember
+      factions:
+      - SimpleNeutral
+
+- type: entity
+  noSpawn: true
+  parent: MobHuman
+  id: N14MobHumanRangerVeteran
+  name: Desert Ranger Veteran
+  components:
+    - type: RandomHumanoidAppearance
+      randomizeName: false
+    - type: Loadout
+      prototypes: [RangerVeteranGear]
+    - type: RandomMetadata
+      nameSegments:
+      - NamesFirstMilitaryLeader
+      - NamesLastMilitary
+    - type: NpcFactionMember
+      factions:
+      - SimpleNeutral
+
+- type: entity
+  noSpawn: true
+  parent: MobHuman
+  id: N14MobHumanRangerChief
+  name: Desert Ranger Chief
+  components:
+    - type: RandomHumanoidAppearance
+      randomizeName: false
+    - type: Loadout
+      prototypes: [RangerChiefGear]
+    - type: RandomMetadata
+      nameSegments:
+      - NamesFirstMilitaryLeader
+      - NamesLastMilitary
+    - type: AutoImplant
+      implants:
+      - DeathAcidifierImplant
+    - type: NpcFactionMember
+      factions:
+      - SimpleNeutral

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger_entity.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger_entity.yml
@@ -1,5 +1,4 @@
 - type: entity
-  noSpawn: true
   parent: MobHuman
   id: N14MobHumanRanger
   name: Desert Ranger
@@ -17,7 +16,6 @@
       - SimpleNeutral
 
 - type: entity
-  noSpawn: true
   parent: MobHuman
   id: N14MobHumanRangerRecruit
   name: Desert Ranger Recruit
@@ -35,7 +33,6 @@
       - SimpleNeutral
 
 - type: entity
-  noSpawn: true
   parent: MobHuman
   id: N14MobHumanRangerVeteran
   name: Desert Ranger Veteran
@@ -53,7 +50,6 @@
       - SimpleNeutral
 
 - type: entity
-  noSpawn: true
   parent: MobHuman
   id: N14MobHumanRangerChief
   name: Desert Ranger Chief

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger_recruit.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger_recruit.yml
@@ -1,6 +1,6 @@
 - type: job
   id: RangerRecruit
-  setPreference: true
+  setPreference: false
   name: recruit desert ranger
   description: job-description-ranger-recruit
   playTimeTracker: RangerRecruit
@@ -20,7 +20,7 @@
     back: N14ClothingBackpackMilitaryFilled
     jumpsuit: N14ClothingUniformRangerV1
     shoes: N14ClothingBootsLeather
-    belt: ClothingBeltRevolver
+    belt: ClothingBeltRevolverdesertfilled
     outerClothing: N14ClothingOuterRangerCombat
     id: N14IDBadgeNCRDesertRangerRecruit
   innerClothingSkirt: N14ClothingOfficerUniformNCR #placeholder

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger_recruit.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger_recruit.yml
@@ -27,6 +27,3 @@
     outerClothing: N14ClothingOuterRangerCombat
     id: N14IDBadgeNCRDesertRangerRecruit
   innerClothingSkirt: N14ClothingOfficerUniformNCR #placeholder
-
-- type: playTimeTracker
-  id: RangerRecruit

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger_recruit.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger_recruit.yml
@@ -21,6 +21,9 @@
     jumpsuit: N14ClothingUniformRangerV1
     shoes: N14ClothingBootsLeather
     belt: ClothingBeltRevolverdesertfilled
+    pocket1: MagazineBox45-70
+    pocket2: FlashlightSeclite
+    eyes: ClothingEyesGlassesSunglasses
     outerClothing: N14ClothingOuterRangerCombat
     id: N14IDBadgeNCRDesertRangerRecruit
   innerClothingSkirt: N14ClothingOfficerUniformNCR #placeholder

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger_recruit.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger_recruit.yml
@@ -27,3 +27,6 @@
     outerClothing: N14ClothingOuterRangerCombat
     id: N14IDBadgeNCRDesertRangerRecruit
   innerClothingSkirt: N14ClothingOfficerUniformNCR #placeholder
+
+- type: playTimeTracker
+  id: RangerRecruit

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger_veteran.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/Rangers/ranger_veteran.yml
@@ -1,6 +1,6 @@
 - type: job
   id: RangerVeteran
-  setPreference: true
+  setPreference: false
   name: veteran desert ranger
   description: job-description-ranger-veteran
   playTimeTracker: RangerVeteran
@@ -21,7 +21,7 @@
     jumpsuit: N14ClothingUniformRangerVeteran
     shoes: N14ClothingBootsCombat
     gloves: N14ClothingHandsGlovesCombat
-    belt: ClothingBeltRevolver
+    belt: ClothingBeltRevolverdesertfilled
     mask: ClothingMaskGasRangerElite
     outerClothing: N14ClothingOuterRangerEliteOld
     id: N14IDBadgeNCRDesertRangerElite

--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/factions.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/factions.yml
@@ -38,7 +38,7 @@
   - NCROfficer
   - NCRSoldier
   - NCRRanger
-
+  - NCRRangerVeteran
 
 - type: department
   id: Rangers


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Made some required changes to the NCR ranger loadouts and added the veteran to act like an officer.

For mappers: You should generally include 3 rangers in NCR bases and their own little hidey hole for stuff that normal soldiers shouldn't have. General idea is 2 rangers and 1 vet to lead 'em on a whitelist basis.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>



</details>

## Changelog
:cl:
add: Added Republic Ranger Veteran
tweak: Tweaked ranger kits
balance: Rebalanced some kits
balance: Rebalanced some loadouts
fix: Fixed the names and hid the desert rangers in preferences
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->