### PR TITLE
NCR Ranger startingGear fix

### DIFF
--- a/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
+++ b/Resources/Prototypes/Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
@@ -5,7 +5,7 @@
   description: the most experienced and robust soldiers form part of this elite group of the NCR army, lead troops or act by yourself under the orders of the republic.
   playTimeTracker: NCRRanger
   weight: 5
-  startingGear: RangerGear
+  startingGear: NCRRangerGear
   icon: JobIconSecurityOfficer
   canBeAntag: false
   access:


### PR DESCRIPTION
# Description

Fixes a typo of `startingGear: RangerGear` to -> ` startingGear: NCRRangerGear`

</details>
