### PR TITLE
Adds 45-70 / 50 / welding glasses and speedLoaders to crafting benches

### DIFF
--- a/Resources/Prototypes/Nuclear14/Entities/Structures/Misc/craftingbenches.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Structures/Misc/craftingbenches.yml
@@ -207,6 +207,7 @@
       - N14SprayPainter
       - N14RPED
       - N14MiningDrill
+      - N14ClothingEyesGlassesWelding
       # Kitchen
       - N14ButchersCleaver
       - N14KitchenKnife

--- a/Resources/Prototypes/Nuclear14/Entities/Structures/Misc/craftingbenches.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Structures/Misc/craftingbenches.yml
@@ -72,10 +72,12 @@
       - Magazine7.62Rifle
       - MagazineBox7.62
       - N14CartridgePistol9
+      - SpeedLoader9
       - N14MagazinePistol9mm
       - N14MagazineSMG9mm
       - MagazineBox9mm
       - N14CartridgePistol10
+      - SpeedLoader10
       - N14MagazinePistol10mm
       - N14MagazineSMG10mm
       - MagazineBox10mm
@@ -94,6 +96,7 @@
       - N14MagazinePistol22lr
       - MagazineBox22
       - N14Cartridge44Magnum
+      - SpeedLoader44
       - MagazineBox44
       - N14CartridgePistol45
       - N14MagazinePistol45
@@ -103,6 +106,9 @@
       - Magazine308Rifle
       - ClipMagazine308Rifle
       - MagazineBox308
+      - SpeedLoader45-70
+      - MagazineBox45-70
+      - MagazineBox50
 
 - type: entity
   parent: N14WorkbenchBase

--- a/Resources/Prototypes/Nuclear14/Entities/Structures/Misc/craftingbenches.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Structures/Misc/craftingbenches.yml
@@ -61,27 +61,21 @@
     idleState: icon
     runningState: icon # change this
     staticRecipes: # Ammo related only.
-      - N14Cartridge5.56Rifle
       - Magazine5.56Rifle
       - LongMagazine5.56Rifle
       - LMGMagazine5.56Rifle
       - MagazineBox5.56
-      - N14CartridgePistol5
       - N14MagazineMinigun5mm
-      - N14Cartridge7.62Rifle
       - Magazine7.62Rifle
       - MagazineBox7.62
-      - N14CartridgePistol9
       - SpeedLoader9
       - N14MagazinePistol9mm
       - N14MagazineSMG9mm
       - MagazineBox9mm
-      - N14CartridgePistol10
       - SpeedLoader10
       - N14MagazinePistol10mm
       - N14MagazineSMG10mm
       - MagazineBox10mm
-      - N14CartridgePistol12.7
       - N14MagazinePistol12mm
       - N14MagazineSMG12mm
       - N14TopMagazineSMG12mm
@@ -92,17 +86,13 @@
       - N14ShellShotgun20
       - N14MagazineShotgun20
       - MagazineBox20gauge
-      - N14CartridgePistol22
       - N14MagazinePistol22lr
       - MagazineBox22
-      - N14Cartridge44Magnum
       - SpeedLoader44
       - MagazineBox44
-      - N14CartridgePistol45
       - N14MagazinePistol45
       - Magazine45SubMachineGun
       - MagazineBox45
-      - N14Cartridge308Rifle
       - Magazine308Rifle
       - ClipMagazine308Rifle
       - MagazineBox308

--- a/Resources/Prototypes/Nuclear14/Recipes/Lathes/ammo.yml
+++ b/Resources/Prototypes/Nuclear14/Recipes/Lathes/ammo.yml
@@ -5,7 +5,7 @@
 # Cartridges 1,2,3 lead, 2,3,4 steel, 2,3 gunpowder for:
 # Small:
 # -22lr
-# -5mm 
+# -5mm
 # -9mm
 # -10mm
 # -.45
@@ -17,10 +17,11 @@
 # -5.56
 # -7.62
 # -.44
+# -.45-70 gov't
 
 # Big
 # -.308
-# -.50 
+# -.50
 
 
 # 5.56
@@ -33,7 +34,7 @@
     Lead: 2
     Steel: 3
     Gunpowder: 2
-    
+
 - type: latheRecipe
   id: Magazine5.56Rifle
   result: Magazine5.56Rifle
@@ -43,7 +44,7 @@
     Lead: 50
     Steel: 175
     Gunpowder: 50
-    
+
 - type: latheRecipe
   id: LongMagazine5.56Rifle
   result: LongMagazine5.56Rifle
@@ -53,7 +54,7 @@
     Lead: 70
     Steel: 205
     Gunpowder: 70
-    
+
 - type: latheRecipe
   id: LMGMagazine5.56Rifle
   result: LMGMagazine5.56Rifle
@@ -63,7 +64,7 @@
     Lead: 110
     Steel: 265
     Gunpowder: 110
-    
+
 - type: latheRecipe
   id: MagazineBox5.56
   result: MagazineBox5.56
@@ -85,7 +86,7 @@
     Lead: 1
     Steel: 2
     Gunpowder: 2
-    
+
 - type: latheRecipe
   id: N14MagazineMinigun5mm
   result: N14MagazineMinigun5mm
@@ -106,7 +107,7 @@
     Lead: 2
     Steel: 3
     Gunpowder: 2
-    
+
 - type: latheRecipe
   id: Magazine7.62Rifle
   result: Magazine7.62Rifle
@@ -116,7 +117,7 @@
     Lead: 60
     Steel: 190
     Gunpowder: 60
-    
+
 - type: latheRecipe
   id: MagazineBox7.62
   result: MagazineBox7.62
@@ -127,7 +128,7 @@
     Steel: 180
     Gunpowder: 120
     Cardboard: 10
-    
+
 # 9mm
 - type: latheRecipe
   id: N14CartridgePistol9
@@ -138,7 +139,7 @@
     Lead: 1
     Steel: 2
     Gunpowder: 2
-    
+
 - type: latheRecipe
   id: N14MagazinePistol9mm
   result: N14MagazinePistol9mm
@@ -148,7 +149,7 @@
     Lead: 24
     Steel: 148
     Gunpowder: 48
-    
+
 - type: latheRecipe
   id: N14MagazineSMG9mm
   result: N14MagazineSMG9mm
@@ -158,7 +159,17 @@
     Lead: 31
     Steel: 162
     Gunpowder: 62
-    
+
+- type: latheRecipe
+  id: SpeedLoader9
+  result: SpeedLoader9
+  category: N14Ammo
+  completetime: 5
+  materials:
+    Lead: 6
+    Steel: 22
+    Gunpowder: 12
+
 - type: latheRecipe
   id: MagazineBox9mm
   result: MagazineBox9mm
@@ -169,7 +180,7 @@
     Steel: 160
     Gunpowder: 160
     Cardboard: 10
-    
+
 # 10mm
 - type: latheRecipe
   id: N14CartridgePistol10
@@ -180,7 +191,7 @@
     Lead: 1
     Steel: 2
     Gunpowder: 2
-    
+
 - type: latheRecipe
   id: N14MagazinePistol10mm
   result: N14MagazinePistol10mm
@@ -190,7 +201,7 @@
     Lead: 10
     Steel: 120
     Gunpowder: 20
-    
+
 - type: latheRecipe
   id: N14MagazineSMG10mm
   result: N14MagazineSMG10mm
@@ -200,7 +211,17 @@
     Lead: 35
     Steel: 170
     Gunpowder: 70
-    
+
+- type: latheRecipe
+  id: SpeedLoader10
+  result: SpeedLoader10
+  category: N14Ammo
+  completetime: 5
+  materials:
+    Lead: 6
+    Steel: 22
+    Gunpowder: 12
+
 - type: latheRecipe
   id: MagazineBox10mm
   result: MagazineBox10mm
@@ -211,7 +232,7 @@
     Steel: 160
     Gunpowder: 160
     Cardboard: 10
-    
+
 # 12.7mm
 - type: latheRecipe
   id: N14CartridgePistol12.7
@@ -222,7 +243,7 @@
     Lead: 2
     Steel: 3
     Gunpowder: 2
-    
+
 - type: latheRecipe
   id: N14MagazinePistol12mm
   result: N14MagazinePistol12mm
@@ -232,7 +253,7 @@
     Lead: 20
     Steel: 130
     Gunpowder: 20
-    
+
 - type: latheRecipe
   id: N14MagazineSMG12mm
   result: N14MagazineSMG12mm
@@ -242,7 +263,7 @@
     Lead: 56
     Steel: 184
     Gunpowder: 56
-    
+
 - type: latheRecipe
   id: N14TopMagazineSMG12mm
   result: N14TopMagazineSMG12mm
@@ -252,7 +273,7 @@
     Lead: 80
     Steel: 220
     Gunpowder: 80
-    
+
 - type: latheRecipe
   id: MagazineBox12
   result: MagazineBox12
@@ -263,7 +284,7 @@
     Steel: 225
     Gunpowder: 150
     Cardboard: 10
-    
+
 # 12ga
 - type: latheRecipe
   id: N14ShellShotgun12
@@ -274,7 +295,7 @@
     Lead: 2
     Steel: 3
     Gunpowder: 2
-    
+
 - type: latheRecipe
   id: N14MagazineShotgun12
   result: N14MagazineShotgun12
@@ -285,7 +306,7 @@
     Paper: 24
     Steel: 100
     Gunpowder: 16
-    
+
 - type: latheRecipe
   id: MagazineBox12gauge
   result: MagazineBox12gauge
@@ -296,7 +317,7 @@
     Paper: 90
     Gunpowder: 60
     Cardboard: 10
-    
+
 # 20ga
 - type: latheRecipe
   id: N14ShellShotgun20
@@ -307,7 +328,7 @@
     Lead: 1
     Paper: 2
     Gunpowder: 2
-    
+
 - type: latheRecipe
   id: N14MagazineShotgun20
   result: N14MagazineShotgun20
@@ -318,7 +339,7 @@
     Steel: 100
     Paper: 40
     Gunpowder: 40
-    
+
 - type: latheRecipe
   id: MagazineBox20gauge
   result: MagazineBox20gauge
@@ -329,7 +350,7 @@
     Paper: 60
     Gunpowder: 60
     Cardboard: 10
-    
+
 # 22lr
 - type: latheRecipe
   id: N14CartridgePistol22
@@ -340,7 +361,7 @@
     Lead: 1
     Steel: 2
     Gunpowder: 2
-    
+
 - type: latheRecipe
   id: N14MagazinePistol22lr
   result: N14MagazinePistol22lr
@@ -350,7 +371,7 @@
     Lead: 80
     Steel: 260
     Gunpowder: 160
-    
+
 - type: latheRecipe
   id: MagazineBox22
   result: MagazineBox22
@@ -361,7 +382,7 @@
     Steel: 150
     Gunpowder: 150
     Cardboard: 10
-    
+
 # 44 magnmum
 - type: latheRecipe
   id: N14Cartridge44Magnum
@@ -372,7 +393,17 @@
     Lead: 2
     Steel: 3
     Gunpowder: 2
-    
+
+- type: latheRecipe
+  id: SpeedLoader44
+  result: SpeedLoader44
+  category: N14Ammo
+  completetime: 5
+  materials:
+    Lead: 10
+    Steel: 25
+    Gunpowder: 10
+
 - type: latheRecipe
   id: MagazineBox44
   result: MagazineBox44
@@ -383,7 +414,7 @@
     Steel: 166
     Gunpowder: 44
     Cardboard: 10
-    
+
 # .45 auto
 - type: latheRecipe
   id: N14CartridgePistol45
@@ -394,7 +425,7 @@
     Lead: 1
     Steel: 2
     Gunpowder: 2
-    
+
 - type: latheRecipe
   id: N14MagazinePistol45
   result: N14MagazinePistol45
@@ -404,7 +435,7 @@
     Lead: 18
     Steel: 136
     Gunpowder: 36
-    
+
 - type: latheRecipe
   id: Magazine45SubMachineGun
   result: Magazine45SubMachineGun
@@ -414,7 +445,7 @@
     Lead: 25
     Steel: 150
     Gunpowder: 50
-    
+
 - type: latheRecipe
   id: MagazineBox45
   result: MagazineBox45
@@ -425,7 +456,7 @@
     Steel: 150
     Gunpowder: 150
     Cardboard: 10
-    
+
 # .308
 - type: latheRecipe
   id: N14Cartridge308Rifle
@@ -436,7 +467,7 @@
     Lead: 3
     Steel: 4
     Gunpowder: 3
-    
+
 - type: latheRecipe
   id: Magazine308Rifle
   result: Magazine308Rifle
@@ -446,7 +477,7 @@
     Lead: 33
     Steel: 144
     Gunpowder: 33
-    
+
 - type: latheRecipe
   id: ClipMagazine308Rifle
   result: ClipMagazine308Rifle
@@ -456,7 +487,7 @@
     Lead: 24
     Steel: 132
     Gunpowder: 24
-    
+
 - type: latheRecipe
   id: MagazineBox308
   result: MagazineBox308
@@ -466,4 +497,38 @@
     Lead: 96
     Steel: 128
     Gunpowder: 96
+    Cardboard: 10
+
+# 45-70 gov't
+- type: latheRecipe
+  id: SpeedLoader45-70
+  result: SpeedLoader45-70
+  category: N14Ammo
+  completetime: 5
+  materials:
+    Lead: 24
+    Steel: 25
+    Gunpowder: 20
+
+- type: latheRecipe
+  id: MagazineBox45-70
+  result: MagazineBox45-70
+  category: N14Ammo
+  completetime: 5
+  materials:
+    Lead: 120
+    Steel: 150
+    Gunpowder: 100
+    Cardboard: 10
+
+# 50
+- type: latheRecipe
+  id: MagazineBox50
+  result: MagazineBox50
+  category: N14Ammo
+  completetime: 5
+  materials:
+    Lead: 150
+    Steel: 200
+    Gunpowder: 150
     Cardboard: 10

--- a/Resources/Prototypes/Nuclear14/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Nuclear14/Recipes/Lathes/tools.yml
@@ -176,6 +176,6 @@
   category: N14Tools
   completetime: 5
   materials:
-    SteeL: 50
-    glass: 200
-    plastic: 100
+    Steel: 50
+    Glass: 200
+    Plastic: 100

--- a/Resources/Prototypes/Nuclear14/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Nuclear14/Recipes/Lathes/tools.yml
@@ -169,3 +169,13 @@
   materials:
     Steel: 500
     Plastic: 100
+
+- type: latheRecipe
+  id: N14ClothingEyesGlassesWelding
+  result: N14ClothingEyesGlassesWelding
+  category: N14Tools
+  completetime: 5
+  materials:
+    SteeL: 50
+    glass: 200
+    plastic: 100


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Adds a few things into crafting.


## Changelog
:cl:
Adds: .45-70 ammobox to crafting
Adds: .50 ammobox to crafting
Adds: 9mm speedLoader to crafting
Adds: 10mm speedLoader to crafting
Adds: .44 speedLoader to crafting
Adds: .45-70 speedLoader to crafting
Removes: all single bullet cartridges from crafting
/:cl:
