### PR TITLE
Changes Deathclaw damage slowdown thresholds

### DIFF
--- a/Resources/Prototypes/Nuclear14/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Nuclear14/Entities/Mobs/NPCs/animals.yml
@@ -347,6 +347,10 @@
     thresholds:
       0: Alive
       500: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      250: 0.7
+      400: 0.5
   - type: DamageStateVisuals
     states:
       Alive:


### PR DESCRIPTION
Increases the amount of damage deathclaws have to take before getting affected by damage slowdown.

Deathclaws are meant to be these massive, fearsome BEASTS of the wasteland that everyone should be afraid of. As of right now, they get shot 2-3 times and are now at a 50% movespeed penalty for the rest of their 450 health. Coupled with a lack of a wideswing this makes deathclaws actually sort of weak and even able to be killed with melee weapons alone by a robust player. This change changes their slowdown to begin later so they have more time to close distance.

Space dragons in WizDen also had this problem and were given the same buff to make them more of a threat.

This is the first time I've made a contribution on any fork. If there's anything wrong with the edits I made, I'd appreciate if they could be pointed out.
This is technically try 2 since I forgot to make a branch first.