### PR TITLE
Normal blood evaporates too

### DIFF
--- a/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
@@ -13,8 +13,10 @@ public abstract partial class SharedPuddleSystem
     private const string WaterIrradiated = "WaterIrradiated";
     [ValidatePrototypeId<ReagentPrototype>]
     private const string WastelandBlood = "WastelandBlood";
+    [ValidatePrototypeId<ReagentPrototype>]
+    private const string Blood = "Blood";
 
-    public static readonly string[] EvaporationReagents = [Water, WaterDirty, WaterIrradiated, WastelandBlood];
+    public static readonly string[] EvaporationReagents = [Water, WaterDirty, WaterIrradiated, WastelandBlood, Blood];
 
     public bool CanFullyEvaporate(Solution solution)
     {


### PR DESCRIPTION
# Description
Addendum to Peptide's https://github.com/Vault-Overseers/nuclear-14/issues/279#issue-2388251839  and https://github.com/Vault-Overseers/nuclear-14/pull/281#issue-2388506591
Makes regular blood, the stuff humans and players bleed, also evaporate like waster blood.

