### PR TITLE
Allows player rotation in stools and officer chairs

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Furniture/chairs.yml
@@ -45,7 +45,7 @@
     state: wooden_chair_settler
     
 - type: entity
-  parent: SeatBase
+  parent: StoolBase
   id: N14ChairStoolBarBlack
   description: A black bar stool.
   components:
@@ -55,7 +55,7 @@
     snapCardinals: true
     
 - type: entity
-  parent: N14ChairStoolBarBlack
+  parent: StoolBase
   id: N14ChairStoolBarTan
   description: A tan bar stool.
   components:
@@ -63,7 +63,7 @@
     state: bar_tan
     
 - type: entity
-  parent: N14ChairStoolBarBlack
+  parent: StoolBase
   id: N14ChairStoolBarRed
   description: A red bar stool.
   components:
@@ -161,7 +161,7 @@
     
     
 - type: entity
-  parent: N14ChairMetalGreen
+  parent: OfficeChairBase
   id: N14ChairOfficeRed
   name: office chair
   suffix: red
@@ -171,7 +171,7 @@
     state: office_chair
     
 - type: entity
-  parent: N14ChairOfficeRed
+  parent: OfficeChairBase
   id: N14ChairOfficeRedBroken
   suffix: red, broken
   components:
@@ -180,7 +180,7 @@
     
     
 - type: entity
-  parent: N14ChairMetalGreen
+  parent: OfficeChairBase
   id: N14ChairOfficeBlue
   name: office chair
   suffix: blue
@@ -199,7 +199,7 @@
     
     
 - type: entity
-  parent: N14ChairMetalGreen
+  parent: OfficeChairBase
   id: N14ChairOfficeGreen
   name: office chair
   suffix: green
@@ -209,7 +209,7 @@
     state: office_chair_green
     
 - type: entity
-  parent: N14ChairOfficeRed
+  parent: OfficeChairBase
   id: N14ChairOfficeGreenBroken
   suffix: green, broken
   components:
@@ -218,7 +218,7 @@
     
     
 - type: entity
-  parent: N14ChairOfficeRed
+  parent: OfficeChairBase
   id: N14ChairOfficeErgonomic
   suffix: ergo
   components:

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Furniture/chairs.yml
@@ -60,6 +60,7 @@
   description: A tan bar stool.
   components:
   - type: Sprite
+    sprite: _Nuclear14/Structures/Furniture/bedsandchairs.rsi
     state: bar_tan
     
 - type: entity
@@ -176,6 +177,7 @@
   suffix: red, broken
   components:
   - type: Sprite
+    sprite: _Nuclear14/Structures/Furniture/chairs.rsi
     state: office_chair_broken
     
     
@@ -195,6 +197,7 @@
   suffix: blue, broken
   components:
   - type: Sprite
+    sprite: _Nuclear14/Structures/Furniture/chairs.rsi
     state: office_chair_blue_broken
     
     
@@ -214,6 +217,7 @@
   suffix: green, broken
   components:
   - type: Sprite
+    sprite: _Nuclear14/Structures/Furniture/chairs.rsi
     state: office_chair_green_broken
     
     
@@ -223,6 +227,7 @@
   suffix: ergo
   components:
   - type: Sprite
+    sprite: _Nuclear14/Structures/Furniture/chairs.rsi
     state: ergo_chair
     
 - type: entity


### PR DESCRIPTION
# Description
Swaps the parents of multiple N14 chairs to allow  players sitting in office chairs and stools to rotate themselves while buckled in.
---

# Changelog

- Change parents to SS14 bases for stools and office chairs.

---

![speeeeeeeeeen](https://github.com/Vault-Overseers/nuclear-14/assets/156849123/072e02c5-e3bf-4fa7-b08f-66265c740e87)



