### PR TITLE
Decrease Radroach Health from 30 to 12

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/insects.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/insects.yml
@@ -181,7 +181,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      12: Dead
+      15: Dead
   - type: DamageStateVisuals
     states:
       Alive:

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/insects.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/insects.yml
@@ -55,8 +55,8 @@
     - id: N14FoodBloatflyAcidSac
       amount: 1
       prob: 0.75
-  
-  
+
+
 - type: entity
   name: giant ant
   parent: N14MobBaseHostileInsect
@@ -114,7 +114,7 @@
     damage:
       groups:
         Brute: 5
-        
+
 - type: entity
   name: giant fire ant
   parent: N14MobGiantAnt
@@ -150,7 +150,7 @@
     - id: N14FoodFireantNectar
       amount: 1
       prob: 0.75
-        
+
 - type: entity
   name: radroach
   id: N14MobRadroach
@@ -181,7 +181,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      30: Dead
+      12: Dead
   - type: DamageStateVisuals
     states:
       Alive:
@@ -203,7 +203,7 @@
     spawned:
     - id: N14FoodMeatRadroachFillet
       amount: 1
-        
+
 - type: entity
   name: radscorpion
   parent: N14MobBaseHostileInsect
@@ -273,12 +273,12 @@
         reagents:
         - ReagentId: Toxin
           Quantity: 3
-          
+
 - type: entity
   name: barkscorpion
   parent: N14MobRadscorpion
   id: N14MobRadscorpionBark
-  description: It's a giant bark radscorpion! Stingy sting. 
+  description: It's a giant bark radscorpion! Stingy sting.
   components:
   - type: Sprite
     drawdepth: Mobs


### PR DESCRIPTION
Rad roaches are currently very tanky, this change would allow them to be killed by all ammunition instantlty, except for 5mm, making them seem sqaushible and satisfying to kill. making them feel more like pests. More radroaches will be mapped to spawn to compensate for this change. 
