### PR TITLE
NCR Ranger revolver replacement and loadout buff

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
@@ -154,7 +154,7 @@
 - type: loadout
   id: LoadoutNCR44
   category: Roles
-  cost: 4
+  cost: 2
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
@@ -20,10 +20,10 @@
   equipment:
     jumpsuit: N14ClothingUniformRangerPatrol
     shoes: N14ClothingBootsCombat
-    belt: ClothingBeltRevolverfilled
+    belt: ClothingBeltRevolverdesertfilled
     eyes: ClothingEyesGlassesSunglasses
     neck: N14ClothingNeckCloakRangerPoncho
-    pocket1: MagazineBox44
+    pocket1: MagazineBox45-70
     pocket2: FlashlightSeclite
     outerClothing: N14ClothingOuterRangerArmor
     head: N14ClothingHeadHatRanger


### PR DESCRIPTION

# Description
Gives the NCR Ranger a hunting revolver and .45-70 Gov't rather than the .44 magnum they currently spawn with.
Also buffs the .44 ammo box in the NCR Ranger's loadout to cost 2 instead of 4 points to bring it in line with every other box of ammo. 

My reasoning is that the hunting revolver is a signature weapon of the Rangers. As Lophi said "its the big iron on their hip." Why should they be limited to using the magnum revolver. Balancing wise, .45-70 gov't does 2 more damage than .44 magnum so it's not exactly a MASSIVE jump. 
---

# TODO

- [x] Replace NCR Ranger magnum holster with hunting revolver holster. Also changes the box they start with to .45-70 gov't.
- [x] Buff loadout .44 magnum ammo

---
