### PR TITLE
NCR troops backpacks

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
@@ -127,7 +127,6 @@
       - id: N14ClothingMaskPlate
       - id: ClothingBeltNCRPouches
       - id: N14WastelandFlagSpear
-      - id: N14ClothingBackpackSatchelNCR
       - id: N14WeaponPistol9mm
       - id: N14MagazinePistol9mm
       - id: N14MagazinePistol9mm
@@ -149,7 +148,6 @@
     items:
       - id: N14ClothingOuterNCRPouchedVest
       - id: ClothingBeltMedicalfilled
-      - id: N14ClothingBackpackSatchelNCR
       - id: N14weapon9mmSMG
       - id: N14MagazineSMG9mm
       - id: N14MagazineSMG9mm

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
@@ -29,7 +29,6 @@
     items:
       - id: N14ClothingOuterNCRVest
       - id: ClothingBeltNCRPouches
-      - id: N14ClothingBackpackNCR
       - id: N14WeaponService
       - id: Magazine5.56Rifle
       - id: Magazine5.56Rifle
@@ -56,7 +55,6 @@
     items:
       - id: N14ClothingOuterNCRVest
       - id: ClothingBeltNCR
-      - id: N14ClothingBackpackNCR
       - id: N14WeaponLMG
       - id: LMGMagazine5.56Rifle
       - id: LMGMagazine5.56Rifle
@@ -81,7 +79,6 @@
     items:
       - id: N14ClothingOuterNCRVest
       - id: ClothingBeltNCRBandolier
-      - id: N14ClothingBackpackSatchelNCR
       - id: N14WeaponSniperHunting
       - id: MagazineBox308
       - id: N14WeaponPistol9mm
@@ -105,7 +102,6 @@
     items:
       - id: N14ClothingOuterNCRVest
       - id: ClothingBeltNCRBandolier
-      - id: N14ClothingBackpackSatchelNCR
       - id: N14WeaponShotgun
       - id: MagazineBox12gauge
       - id: N14WeaponPistol9mm

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_cadet.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_cadet.yml
@@ -18,6 +18,7 @@
     jumpsuit: N14ClothingUniformNCR
     shoes: N14ClothingBootsLeather
     id: N14IDNCRDogtag
+    backpack: N14ClothingBackpackSatchelNCRFilled
   innerClothingSkirt: N14ClothingUniformNCR #placeholder
   satchel: N14ClothingBackpackSatchelNCRFilled
 

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_doctor.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_doctor.yml
@@ -27,6 +27,7 @@
     id: N14IDNCRDogtag
     pocket1: N14WeaponPistol9mm
     outerClothing: ClothingOuterCoatLab
+    backpack: N14ClothingBackpackSatchelNCRFilled
   innerClothingSkirt: N14ClothingUniformNCR
   satchel: N14ClothingBackpackSatchelNCRFilled
   duffelbag: N14ClothingBackpackDuffelFilled  # N14TODO: Doctors Bag

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_mp.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_mp.yml
@@ -27,6 +27,7 @@
     belt: N14ClothingBeltPoliceFilled
     outerClothing: N14ClothingOuterNCRLightPouchedVest
     id: N14IDNCRDogtag
+    backpack: N14ClothingBackpackSatchelNCRFilled
   innerClothingSkirt: N14ClothingMPUniformNCR #placeholder
   satchel: N14ClothingBackpackSatchelNCRFilled
 

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_nco.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_nco.yml
@@ -28,6 +28,7 @@
     belt: ClothingBeltNCR
     outerClothing: N14ClothingOuterNCRVest
     id: N14IDNCRDogtag
+    backpack: N14ClothingBackpackSatchelNCRFilled
   innerClothingSkirt: N14ClothingOfficerUniformNCR #placeholder
   satchel: N14ClothingBackpackSatchelNCRFilled
 

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_officer.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_officer.yml
@@ -25,6 +25,7 @@
     belt: ClothingBeltRevolverCaptainfilled
     eyes: ClothingEyesGlassesSunglasses
     id: N14IDNCRDogtag
+    backpack: N14ClothingBackpackSatchelNCRFilled
   innerClothingSkirt: N14ClothingOfficerUniformNCR #placeholder
   satchel: N14ClothingBackpackSatchelNCRFilled
 

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_quartermaster.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_quartermaster.yml
@@ -23,6 +23,7 @@
     jumpsuit: N14ClothingUniformNCR
     shoes: N14ClothingBootsLeather
     id: N14IDNCRDogtag
+    backpack: N14ClothingBackpackSatchelNCRFilled
   innerClothingSkirt: N14ClothingUniformNCR #placeholder
   satchel: N14ClothingBackpackSatchelNCRFilled
 

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_soldier.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_soldier.yml
@@ -23,6 +23,7 @@
     jumpsuit: N14ClothingUniformNCR
     shoes: N14ClothingBootsLeather
     id: N14IDNCRDogtag
+    backpack: N14ClothingBackpackSatchelNCRFilled
   innerClothingSkirt: N14ClothingUniformNCR #placeholder
   satchel: N14ClothingBackpackSatchelNCRFilled
 


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

For some reason NCR troops didnt spawn with backpacks and just got empty ones from kits. They can already choose which backpack they get in the menu so there is no need for them to be in kits.

---