### PR TITLE
Rebalance of NCR kits (Reopens #303)

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
@@ -468,3 +468,5 @@
       - id: N14CombatKnife
     sound:
       path: /Audio/Effects/unwrap.ogg
+
+# the knifes seem a bit redundant due to combat boots being able to hold their own knifes, will keep them for now

--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ncr.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ncr.yml
@@ -97,7 +97,7 @@
 - type: loadout
   id: LoadoutNCRKitSpecialRifleman
   category: Roles
-  cost: 10
+  cost: 8
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -111,7 +111,7 @@
 - type: loadout
   id: LoadoutNCRKitSpecialAssault
   category: Roles
-  cost: 10
+  cost: 8
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -125,7 +125,7 @@
 - type: loadout
   id: LoadoutNCRKitSpecialGunner
   category: Roles
-  cost: 10
+  cost: 8
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -139,7 +139,7 @@
 - type: loadout
   id: LoadoutNCRKitSpecialPointman
   category: Roles
-  cost: 10
+  cost: 8
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -153,7 +153,7 @@
 - type: loadout
   id: LoadoutRangerKitRifleman
   category: Roles
-  cost: 10
+  cost: 8
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -167,7 +167,7 @@
 - type: loadout
   id: LoadoutRangerKitMarksman
   category: Roles
-  cost: 10
+  cost: 8
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -181,7 +181,7 @@
 - type: loadout
   id: LoadoutRangerKitCQB
   category: Roles
-  cost: 10
+  cost: 8
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -195,7 +195,7 @@
 - type: loadout
   id: LoadoutVeteranRangerKitRifleman
   category: Roles
-  cost: 10
+  cost: 8
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -221,7 +221,7 @@
 - type: loadout
   id: LoadoutVeteranRangerKitTrailman
   category: Roles
-  cost: 10
+  cost: 8
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -234,7 +234,7 @@
 - type: loadout
   id: LoadoutVeteranRangerKitAssault
   category: Roles
-  cost: 10
+  cost: 8
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -247,7 +247,7 @@
 - type: loadout
   id: LoadoutVeteranRangerKitMarksman
   category: Roles
-  cost: 10
+  cost: 8
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -260,7 +260,7 @@
 - type: loadout
   id: LoadoutVeteranRangerKitCQB
   category: Roles
-  cost: 10
+  cost: 8
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement

--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
@@ -1,6 +1,6 @@
 # MARK: Ranger
 - type: loadout
-  id: LoadoutNCRRangerArmor
+  id: LoadoutNCRRangerVest
   category: Roles
   cost: 4
   exclusive: true
@@ -12,9 +12,33 @@
     - N14ClothingOuterRangerVest
 
 - type: loadout
-  id: LoadoutNCRRangerGun1
+  id: LoadoutNCRRangerArmorB
   category: Roles
   cost: 4
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - N14ClothingOuterRangerArmorB
+
+- type: loadout
+  id: LoadoutNCRRangerDuster
+  category: Roles
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - N14ClothingOuterRangerDuster
+
+- type: loadout
+  id: LoadoutNCRRangerGun1
+  category: Roles
+  cost: 3
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -40,7 +64,7 @@
 - type: loadout
   id: LoadoutNCRRangerGun2
   category: Roles
-  cost: 4
+  cost: 5
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -84,7 +108,7 @@
 - type: loadout
   id: LoadoutNCRRangerGun5
   category: Roles
-  cost: 4
+  cost: 3
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -154,7 +178,7 @@
 - type: loadout
   id: LoadoutNCR44
   category: Roles
-  cost: 4
+  cost: 2
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -259,7 +283,7 @@
 - type: loadout
   id: LoadoutNCRuniformV1
   category: Roles
-  cost: 2
+  cost: 1
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -272,7 +296,7 @@
 - type: loadout
   id: LoadoutNCRuniformV2
   category: Roles
-  cost: 2
+  cost: 1
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -285,7 +309,7 @@
 - type: loadout
   id: LoadoutNCRuniformV3
   category: Roles
-  cost: 2
+  cost: 1
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -398,7 +422,7 @@
 - type: loadout
   id: LoadoutNCR762
   category: Roles
-  cost: 4
+  cost: 2
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -413,7 +437,7 @@
 - type: loadout
   id: LoadoutNCR12gauge
   category: Roles
-  cost: 4
+  cost: 2
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -441,7 +465,7 @@
 - type: loadout
   id: LoadoutNCRuniformModif
   category: Roles
-  cost: 2
+  cost: 1
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -453,7 +477,7 @@
 - type: loadout
   id: LoadoutNCRuniformBlue
   category: Roles
-  cost: 2
+  cost: 1
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -461,7 +485,7 @@
         - NCRRangerVeteran
   items:
     - N14ClothingUniformRangerBlue
-
+# Armors until crafting comes in
 - type: loadout
   id: LoadoutNCRarmorFox
   category: Roles
@@ -516,3 +540,15 @@
     - N14ClothingOuterRangerPrice
     - N14ClothingHeadHatRangerHelmetPrice
     - ClothingMaskGasRangerPrice
+
+- type: loadout
+  id: LoadoutNCRHelmetModif
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRangerVeteran
+  items:
+    - N14ClothingHeadHatRangerHelmetEliteModif

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
@@ -25,10 +25,10 @@
   equipment:
     jumpsuit: N14ClothingUniformRangerPatrol
     shoes: N14ClothingBootsCombatFilled
-    belt: ClothingBeltRevolverfilled
+    belt: ClothingBeltRevolverdesertfilled
     eyes: ClothingEyesGlassesSunglasses
     neck: N14ClothingNeckCloakRangerPoncho
-    pocket1: MagazineBox44
+    pocket1: MagazineBox45-70
     pocket2: FlashlightSeclite
     outerClothing: N14ClothingOuterRangerArmor
     head: N14ClothingHeadHatRanger


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

> Gives the NCR Ranger a hunting revolver and .45-70 Gov't rather than the .44 magnum they currently spawn with.
> Also buffs the .44 ammo box in the NCR Ranger's loadout to cost 2 instead of 4 points to bring it in line with every other box of ammo.
> My reasoning is that the hunting revolver is a signature weapon of the Rangers. As Lophi said "its the big iron on their hip." Why should they be limited to using the magnum revolver. Balancing wise, .45-70 gov't does 2 more damage than .44 magnum so it's not exactly a MASSIVE jump anyway.

Re-do's the old PR with many more cherry picked loadout changes and some more options.

---