### PR TITLE
Adds ID locked doors

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Access/bosmidwest.yml
+++ b/Resources/Prototypes/_Nuclear14/Access/bosmidwest.yml
@@ -1,13 +1,18 @@
 - type: accessLevel
-  id: KnightCommander
-  name: id-card-access-level-midwest-knight-commander
+  id: PaladinCommander
+  name: id-card-access-level-midwest-paladin-commander
 
 - type: accessLevel
-  id: ScribeMidwest
-  name: id-card-access-level-midwest-scribe
+  id: Paladin
+  name: id-card-access-level-midwest-paladin
+
+- type: accessLevel
+  id: BoSMidwest
+  name: id-card-access-level-midwest
 
 - type: accessGroup
   id: BOSMidwest
   tags:
-  - KnightCommander
-  - ScribeMidwest
+  - PaladinCommander
+  - Paladin
+  - BoSMidwest

--- a/Resources/Prototypes/_Nuclear14/Access/ncr.yml
+++ b/Resources/Prototypes/_Nuclear14/Access/ncr.yml
@@ -11,12 +11,8 @@
   name: id-card-access-level-ncr-nco
 
 - type: accessLevel
-  id: NCRSoldier
-  name: id-card-access-level-ncr-soldier
-
-- type: accessLevel
-  id: NCRCadet
-  name: id-card-access-level-ncr-cadet
+  id: NCR
+  name: id-card-access-level-ncr
 
 - type: accessGroup
   id: NCR
@@ -24,5 +20,4 @@
   - NCROfficer
   - NCRRanger
   - NCRNCO
-  - NCRSoldier
-  - NCRCadet
+  - NCR

--- a/Resources/Prototypes/_Nuclear14/Entities/Markers/Spawners/latejoin.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Markers/Spawners/latejoin.yml
@@ -30,5 +30,5 @@
   suffix: BOS Midwest Commander
   components:
   - type: SpawnPoint
-    job_id: BoSMidKnightCommander
+    job_id: BoSMidPaladinCommander
     spawn_type: LateJoin

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/identification.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/identification.yml
@@ -84,7 +84,7 @@
 
 # Passports
 - type: entity
-  parent: Clothing
+  parent: N14IDCard
   id: N14IDPassportBlank
   name: blank passport
   description: A blank passport used by wastelanders.
@@ -92,15 +92,9 @@
   - type: Sprite
     sprite: _Nuclear14/Objects/Misc/identification.rsi
     state: passport_blank
-    scale: 0.6, 0.6
+    scale: 0.7, 0.7
   - type: Clothing
-    slots:
-    - idcard
     sprite: _Nuclear14/Objects/Misc/identification.rsi
-  - type: Item
-    heldPrefix: default
-  - type: StationRecordKeyStorage
-  - type: IdCard
 
 - type: entity
   parent: N14IDPassportBlank
@@ -158,6 +152,34 @@
   - type: Sprite
     sprite: _Nuclear14/Objects/Misc/identification.rsi
     state: bos_holotag
+  - type: PresetIdCard
+    job: BoSMidScribe
+
+- type: entity
+  parent: N14IDPassportBlank
+  id: N14IDBrotherhoodHolotagPaladin
+  name: holotag
+  description: An ID holotag worn by the Paladins of the Brotherhood of Steel.
+  suffix: Paladin
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Objects/Misc/identification.rsi
+    state: bos_holotag
+  - type: PresetIdCard
+    job: BoSMidPaladin
+
+- type: entity
+  parent: N14IDPassportBlank
+  id: N14IDBrotherhoodHolotagCommander
+  name: holotag
+  description: An ID holotag worn by the Paladin Commander of the Brotherhood of Steel.
+  suffix: Commander
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Objects/Misc/identification.rsi
+    state: bos_holotag
+  - type: PresetIdCard
+    job: BoSMidPaladinCommander
 
 - type: entity
   parent: N14IDPassportBlank
@@ -170,6 +192,32 @@
     state: ncrdogtag
   - type: PresetIdCard
     job: NCRSoldier
+
+- type: entity
+  parent: N14IDPassportBlank
+  id: N14IDNCRDogtagNCO
+  name: dogtag
+  description: An ID dogtag worn by decently ranking members of the NCR.
+  suffix: NCO
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Objects/Misc/identification.rsi
+    state: ncrdogtag
+  - type: PresetIdCard
+    job: NCRNCO
+
+- type: entity
+  parent: N14IDPassportBlank
+  id: N14IDNCRDogtagOfficer
+  name: dogtag
+  description: An ID dogtag worn by high ranking members of the NCR.
+  suffix: Officer
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Objects/Misc/identification.rsi
+    state: ncrdogtag
+  - type: PresetIdCard
+    job: NCROfficer
 
 # Desert Rangers
 - type: entity
@@ -197,6 +245,12 @@
     job: NCRRanger
 
 - type: entity
+  parent: N14IDBadgeNCRDesertRanger
+  id: N14IDBadgeNCRRanger
+  description: An ID badge worn by Republic Rangers.
+  suffix: NCR
+
+- type: entity
   parent: N14IDPassportBlank
   id: N14IDBadgeNCRDesertRangerElite
   name: ranger elite badge
@@ -207,6 +261,12 @@
     state: ranger_elite
   - type: PresetIdCard
     job: NCRRangerVeteran
+
+- type: entity
+  parent: N14IDBadgeNCRDesertRangerElite
+  id: N14IDBadgeNCRRangerElite
+  description: An ID badge worn by Elite Republic Rangers.
+  suffix: NCR
 
 - type: entity
   parent: N14IDPassportBlank

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/access.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/access.yml
@@ -1,0 +1,10 @@
+# NCR
+- type: entity
+  parent: AirlockGlass
+  id: N14DoorWoodSecureNCRLocked
+  suffix: NCR, Locked
+  components:
+  - type: AccessReader
+    access: [["NCR"]]
+  - type: Wires
+    layoutId: AirlockService

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/access.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/access.yml
@@ -1,10 +1,101 @@
 # NCR
 - type: entity
-  parent: AirlockGlass
+  parent: N14DoorWoodSecureNCR
   id: N14DoorWoodSecureNCRLocked
   suffix: NCR, Locked
   components:
   - type: AccessReader
     access: [["NCR"]]
   - type: Wires
-    layoutId: AirlockService
+    layoutId: AirlockSecurity
+
+- type: entity
+  parent: N14DoorWoodSecureNCR
+  id: N14DoorWoodSecureNCRLockedNCO
+  suffix: NCR, Locked, NCO
+  components:
+  - type: AccessReader
+    access: [["NCRNCO"]]
+  - type: Wires
+    layoutId: AirlockSecurity
+
+- type: entity
+  parent: N14DoorWoodSecureNCR
+  id: N14DoorWoodSecureNCRLockedOfficer
+  suffix: NCR, Locked, Officer
+  components:
+  - type: AccessReader
+    access: [["NCROfficer"]]
+  - type: Wires
+    layoutId: AirlockSecurity
+
+- type: entity
+  parent: N14DoorWoodSecureNCR
+  id: N14DoorWoodSecureNCRLockedRanger
+  suffix: NCR, Locked, Ranger
+  components:
+  - type: AccessReader
+    access: [["NCRRanger"]]
+  - type: Wires
+    layoutId: HighSec
+
+# BOS
+- type: entity
+  parent: N14DoorBunker
+  id: N14DoorBunkerLockedBOSMidwest
+  suffix: BOSMidwest, Locked
+  components:
+  - type: AccessReader
+    access: [["BoSMidwest"]]
+  - type: Wires
+    layoutId: HighSec
+
+- type: entity
+  parent: N14DoorBunkerGlass
+  id: N14DoorBunkerGlassLockedBOSMidwest
+  suffix: BOSMidwest, Locked
+  components:
+  - type: AccessReader
+    access: [["BoSMidwest"]]
+  - type: Wires
+    layoutId: HighSec
+
+- type: entity
+  parent: N14DoorBunker
+  id: N14DoorBunkerLockedPaladin
+  suffix: BOSMidwest, Locked, Paladin
+  components:
+  - type: AccessReader
+    access: [["Paladin"]]
+  - type: Wires
+    layoutId: HighSec
+
+- type: entity
+  parent: N14DoorBunkerGlass
+  id: N14DoorBunkerGlassLockedPaladin
+  suffix: BOSMidwest, Locked, Paladin
+  components:
+  - type: AccessReader
+    access: [["Paladin"]]
+  - type: Wires
+    layoutId: HighSec
+
+- type: entity
+  parent: N14DoorBunker
+  id: N14DoorBunkerLockedPaladinCommander
+  suffix: BOSMidwest, Locked, Commander
+  components:
+  - type: AccessReader
+    access: [["PaladinCommander"]]
+  - type: Wires
+    layoutId: HighSec
+
+- type: entity
+  parent: N14DoorBunkerGlass
+  id: N14DoorBunkerGlassLockedPaladinCommander
+  suffix: BOSMidwest, Locked, Commander
+  components:
+  - type: AccessReader
+    access: [["PaladinCommander"]]
+  - type: Wires
+    layoutId: HighSec

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/BrotherhoodMidwest/knight.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/BrotherhoodMidwest/knight.yml
@@ -11,8 +11,8 @@
   startingGear: BoSMidKnightGear
   icon: "JobIconPassenger"
   canBeAntag: false
-  accessGroups:
-  - BOSMidwest
+  access:
+  - BoSMidwest
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/BrotherhoodMidwest/paladin-commander.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/BrotherhoodMidwest/paladin-commander.yml
@@ -27,7 +27,7 @@
     back: N14ClothingBackpackMilitary
     shoes: N14ClothingBootsCombatFilled
     hands: N14ClothingHandsGlovesCombat
-    id: N14IDBrotherhoodHolotag
+    id: N14IDBrotherhoodHolotagCommander
     ears: N14ClothingHeadsetBOSMidwest
     belt: ClothingBeltMilitary
 

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/BrotherhoodMidwest/paladin.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/BrotherhoodMidwest/paladin.yml
@@ -11,15 +11,16 @@
   startingGear: BoSMidPaladinGear
   icon: "JobIconPassenger"
   canBeAntag: false
-  accessGroups:
-  - BOSMidwest
+  access:
+  - BoSMidwest
+  - Paladin
   special:
   - !type:AddComponentSpecial
     components:
       - type: NpcFactionMember
         factions:
           - BrotherhoodMidwest
-  
+
 - type: startingGear
   id: BoSMidPaladinGear
   equipment:
@@ -29,7 +30,7 @@
     head:  N14ClothingHeadHatBrotherhoodFieldCap
     outerClothing: N14ClothingOuterMidwestArmorMK2
     hands: N14ClothingHandsGlovesCombat
-    id: N14IDBrotherhoodHolotag
+    id: N14IDBrotherhoodHolotagPaladin
     ears: N14ClothingHeadsetBOSMidwest #placeholder
     belt: ClothingBeltMilitary
 

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/BrotherhoodMidwest/scribe.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/BrotherhoodMidwest/scribe.yml
@@ -12,7 +12,7 @@
   icon: "JobIconPassenger"
   supervisors: job-supervisors-bos-mid
   access:
-  - ScribeMidwest
+  - BoSMidwest
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/BrotherhoodMidwest/squire.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/BrotherhoodMidwest/squire.yml
@@ -7,8 +7,8 @@
   startingGear: BoSMidSquireGear
   icon: "JobIconPassenger"
   canBeAntag: false
-  accessGroups:
-  - BOSMidwest
+  access:
+  - BoSMidwest
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_cadet.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_cadet.yml
@@ -9,7 +9,7 @@
   supervisors: job-supervisors-ncr-nco
   canBeAntag: false
   access:
-  - NCRCadet
+  - NCR
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_doctor.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_doctor.yml
@@ -13,15 +13,14 @@
   supervisors: job-supervisors-ncr-nco
   canBeAntag: false
   access:
-  - NCRCadet
-  - NCRSoldier
+  - NCR
   special:
   - !type:AddComponentSpecial
     components:
       - type: NpcFactionMember
         factions:
           - NCR
-  
+
 - type: startingGear
   id: NCRDoctorGear
   equipment:

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_mp.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_mp.yml
@@ -13,8 +13,7 @@
   supervisors: job-supervisors-ncr
   canBeAntag: false
   access:
-  - NCRCadet
-  - NCRSoldier
+  - NCR
   - NCRNCO
   special:
   - !type:AddComponentSpecial
@@ -32,7 +31,7 @@
     shoes: N14ClothingBootsLeather
     belt: N14ClothingBeltPoliceFilled
     outerClothing: N14ClothingOuterNCRLightPouchedVest
-    id: N14IDNCRDogtag
+    id: N14IDNCRDogtagNCO
     backpack: N14ClothingBackpackSatchelNCRFilled
   innerClothingSkirt: N14ClothingMPUniformNCR #placeholder
   satchel: N14ClothingBackpackSatchelNCRFilled

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_nco.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_nco.yml
@@ -13,8 +13,7 @@
   supervisors: job-supervisors-ncr
   canBeAntag: false
   access:
-  - NCRCadet
-  - NCRSoldier
+  - NCR
   - NCRNCO
   special:
   - !type:AddComponentSpecial
@@ -33,7 +32,7 @@
     neck: N14ClothingNeckMantleNCR
     belt: ClothingBeltNCR
     outerClothing: N14ClothingOuterNCRVest
-    id: N14IDNCRDogtag
+    id: N14IDNCRDogtagNCO
     backpack: N14ClothingBackpackSatchelNCRFilled
   innerClothingSkirt: N14ClothingOfficerUniformNCR #placeholder
   satchel: N14ClothingBackpackSatchelNCRFilled

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_officer.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_officer.yml
@@ -30,7 +30,7 @@
     shoes: N14ClothingBootsLeather
     belt: ClothingBeltRevolverCaptainfilled
     eyes: ClothingEyesGlassesSunglasses
-    id: N14IDNCRDogtag
+    id: N14IDNCRDogtagOfficer
     backpack: N14ClothingBackpackSatchelNCRFilled
   innerClothingSkirt: N14ClothingOfficerUniformNCR #placeholder
   satchel: N14ClothingBackpackSatchelNCRFilled

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_quartermaster.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_quartermaster.yml
@@ -13,8 +13,8 @@
   supervisors: job-supervisors-ncr-nco
   canBeAntag: false
   access:
-  - NCRCadet
-  - NCRSoldier
+  - NCR
+  - NCRNCO
   special:
   - !type:AddComponentSpecial
     components:
@@ -28,7 +28,7 @@
     head: N14ClothingHeadHatNCRBeretQM
     jumpsuit: N14ClothingUniformNCR
     shoes: N14ClothingBootsLeather
-    id: N14IDNCRDogtag
+    id: N14IDNCRDogtagNCO
     backpack: N14ClothingBackpackSatchelNCRFilled
   innerClothingSkirt: N14ClothingUniformNCR #placeholder
   satchel: N14ClothingBackpackSatchelNCRFilled

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_soldier.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_soldier.yml
@@ -13,8 +13,7 @@
   supervisors: job-supervisors-ncr-nco
   canBeAntag: false
   access:
-  - NCRCadet
-  - NCRSoldier
+  - NCR
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
@@ -15,8 +15,7 @@
   requireAdminNotify: true
   canBeAntag: false
   access:
-  - NCRCadet
-  - NCRSoldier
+  - NCR
   - NCRNCO
   - NCRRanger
   special:
@@ -38,7 +37,7 @@
     pocket2: FlashlightSeclite
     outerClothing: N14ClothingOuterRangerArmor
     head: N14ClothingHeadHatRanger
-    id: N14IDBadgeNCRDesertRanger
+    id: N14IDBadgeNCRRanger
     back: N14ClothingBackpackMilitaryFilled
   innerClothingSkirt: N14ClothingUniformRangerV3 #placeholder
   satchel: N14ClothingBackpackSatchelMilitaryFilled

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/republic_ranger_veteran.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/republic_ranger_veteran.yml
@@ -37,7 +37,7 @@
     pocket2: FlashlightSeclite
     outerClothing: N14ClothingOuterRangerCombat
     head: N14ClothingHeadHatRangerHelmetOld
-    id: N14IDBadgeNCRDesertRangerElite
+    id: N14IDBadgeNCRRangerElite
     back: N14ClothingBackpackMilitaryFilled
   innerClothingSkirt: N14ClothingUniformRangerModif #placeholder
   satchel: N14ClothingBackpackSatchelMilitaryFilled

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Rangers/ranger.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Rangers/ranger.yml
@@ -9,8 +9,7 @@
   supervisors: job-supervisors-ranger-veteran
   canBeAntag: false
   access:
-  - NCRCadet
-  - NCRSoldier
+  - NCR
   - NCRNCO
   - NCRRanger
   special:

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Rangers/ranger_recruit.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Rangers/ranger_recruit.yml
@@ -9,8 +9,7 @@
   supervisors: job-supervisors-ranger
   canBeAntag: false
   access:
-  - NCRCadet
-  - NCRSoldier
+  - NCR
   - NCRRanger
   special:
   - !type:AddComponentSpecial


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR aims to adds locked doors for factions to prevent bumrushing and ease the general flow of the game.

- Adds ID access doors for the NCR and BoSMidwest
- Refactors the ID access system of the 2 factions
- Adds new ID levels with different accesses 
for the NCR (NCR,NCRNCO,NCROfficer,NCRRanger)
for the BoSMidwest (BoSMidwest, Paladin, Commander)

John Bumrusher can't get into the base that easily anymore.