### PR TITLE
Crafting, Loadouts and Kits (AMR, BrushTube)

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Catalog/Fills/storage_fills_rp.yml
+++ b/Resources/Prototypes/_Nuclear14/Catalog/Fills/storage_fills_rp.yml
@@ -1583,9 +1583,6 @@
         - id: N14WeaponSniperHunting
           prob: 0.2
           orGroup: Weapon
-        - id: N14WeaponAntiMateriel
-          prob: 0.1
-          orGroup: Weapon
         - id: N14WeaponLeverCarbine
           prob: 0.1
           orGroup: Weapon

--- a/Resources/Prototypes/_Nuclear14/Catalog/Fills/storage_fills_timed.yml
+++ b/Resources/Prototypes/_Nuclear14/Catalog/Fills/storage_fills_timed.yml
@@ -1583,9 +1583,6 @@
         - id: N14WeaponSniperHunting
           prob: 0.2
           orGroup: Weapon
-        - id: N14WeaponAntiMateriel
-          prob: 0.1
-          orGroup: Weapon
         - id: N14WeaponLeverCarbine
           prob: 0.1
           orGroup: Weapon

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
@@ -455,7 +455,9 @@
     items:
       - id: ClothingBeltNCRPouches
       - id: N14WeaponAntiMateriel
-      - id: MagazineBox50
+      - id: N14Magazine50AMR
+      - id: N14Magazine50AMR
+      - id: N14Magazine50AMR
       - id: MagazineBox50
       - id: N14Stimpak
       - id: N14Stimpak

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
@@ -99,6 +99,7 @@
       - SpeedLoader45-70
       - SpeedLoader45-70Tube
       - MagazineBox45-70
+      - N14Magazine50AMR
       - MagazineBox50
 
 - type: entity

--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
@@ -394,7 +394,7 @@
 - type: loadout
   id: LoadoutNCRVetGun3
   category: Roles
-  cost: 4
+  cost: 6
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -403,6 +403,9 @@
         - NCRRangerVeteran
   items:
     - N14WeaponAntiMateriel
+    - N14Magazine50AMR
+    - N14Magazine50AMR
+    - N14Magazine50AMR
     - MagazineBox50
 
 - type: loadout
@@ -417,6 +420,9 @@
         - NCRRangerVeteran
   items:
     - N14WeaponBrushGun
+    - SpeedLoader45-70Tube
+    - SpeedLoader45-70Tube
+    - SpeedLoader45-70Tube
     - MagazineBox45-70
 
 - type: loadout

--- a/Resources/Prototypes/_Nuclear14/Recipes/Lathes/ammo.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Lathes/ammo.yml
@@ -533,6 +533,16 @@
 
 # 50
 - type: latheRecipe
+  id: N14Magazine50AMR
+  result: N14Magazine50AMR
+  category: N14Ammo
+  completetime: 5
+  materials:
+    Lead: 25
+    Steel: 50
+    Gunpowder: 25
+
+- type: latheRecipe
   id: MagazineBox50
   result: MagazineBox50
   category: N14Ammo


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Forgot to do this on the main app.

Also includes BrushGun speedLoader being added to a kit I forgot about.

Either way it removes AMR from loot pool and adds magazines to crafting.

---