### PR TITLE
Ghoul race modifiers

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/Species/ghouls.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/Species/ghouls.yml
@@ -63,6 +63,22 @@
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: Ghoul
+  - type: PassiveDamage # Ghoul passive regen. Assuming one damage type, comes out to about 100 damage in 5 minutes. Not enough to really affect during combat, but sure makes them need a lot less stimpaks.
+    allowedStates:
+    - Alive
+    damageCap: 100
+    damage:
+      types:
+        Heat: -0.5
+        Radiation: 0.0146 # 50 rads per hour. Chem dependant
+      groups:
+        Brute: -0.5
+        Toxin: -0.05
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      100: Critical
+      150: Dead
   # - type: Special
 
 - type: entity


### PR DESCRIPTION
# Description

Ghoul now innately heals Brute, Burn and Toxin at rates of 0.5, 0.5 and 0.05 respectively.

Ghouls now suffer from slow degeneration of their mind via rads over time. They are now all chem dependent on RadAway.

Ghouls now die at 150 dmg instead of 200. Crit is still at 100.

---

_In the future when feral ghouls will be added. If left unattended after their death, they will devolve into a feral ghoul instead of dying._

---