### PR TITLE
Adjusts ghoul rads to deal OT damage

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/Species/ghouls.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/Species/ghouls.yml
@@ -69,12 +69,12 @@
     damageCap: 100
     damage:
       types:
-        Heat: -0.5
-        Radiation: 0.0146 # 50 rads per hour. Chem dependant
+        Heat: -1
+        Radiation: 0.06 # a little less than ~50 rads per hour. Chem dependant
       groups:
-        Brute: -0.5
-        Toxin: -0.05
-  - type: MobThresholds
+        Brute: -1
+        Toxin: -0.1
+  - type: MobThresholds 
     thresholds:
       0: Alive
       100: Critical


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

After extensive testing it seems that `type: PassiveDamage` automatically assigns 0.05 healing to set damage types and groups per tick. Meaning 0.5 becomes 0.3 and 0.01 becomes -0.05 for some reason. This adjusts damage just enough so ghoul is taking 0.01 damage per second. Which should be a little under the intended 50 rads per hour. This will be more around 36. If its too low I will double it.

---