### PR TITLE
Fix missing headset channels

### DIFF
--- a/Resources/Locale/en-US/_Nuclear14/headset-component.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/headset-component.ftl
@@ -9,3 +9,6 @@ chat-radio-vault-security = Vault Security
 chat-radio-vault-common = Vault Common
 chat-radio-caravan = Caravan Company
 chat-radio-bosmidwest = Brotherhood Midwest
+chat-radio-boswashington = Brotherhood Washington
+chat-radio-enclave = Enclave
+chat-radio-ncr = NCR


### PR DESCRIPTION
This was missing.
From there:
https://github.com/Vault-Overseers/nuclear-14/blob/master/Resources/Prototypes/_Nuclear14/radio_channels.yml