### PR TITLE
Fixed leather armor special stat modifiers, gave various items special stat buffs

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Eyes/glasses.yml
@@ -20,6 +20,8 @@
     sprite: _Nuclear14/Clothing/Eyes/pilotgoggles.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Eyes/pilotgoggles.rsi
+  - type: ClothingSpecialModifier
+    charismaModifier: 1 
 
 - type: entity
   parent: ClothingEyesBase
@@ -55,3 +57,5 @@
   - type: Clothing
     sprite: _Nuclear14/Clothing/Eyes/sunglasses.rsi
   - type: VisionCorrection
+  - type: ClothingSpecialModifier
+    charismaModifier: 1 

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/hats.yml
@@ -11,6 +11,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/baseballcap.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/baseballcap.rsi
+  - type: ClothingSpecialModifier
+    perceptionModifier: 1 
 
 - type: entity
   parent: ClothingHeadHatTrucker
@@ -26,6 +28,8 @@
     sprite: Clothing/Head/Hats/cowboyhatbountyhunter.rsi
   - type: Clothing
     sprite: Clothing/Head/Hats/cowboyhatbountyhunter.rsi
+  - type: ClothingSpecialModifier
+    perceptionModifier: 1 
 
 - type: entity
   parent: ClothingHeadBase
@@ -37,6 +41,9 @@
     sprite: Clothing/Head/Hats/hoshat.rsi
   - type: Clothing
     sprite: Clothing/Head/Hats/hoshat.rsi
+  - type: ClothingSpecialModifier
+    perceptionModifier: 1 
+    charismaModifier: 1 
 
 - type: entity
   parent: ClothingHeadBase
@@ -60,6 +67,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/armyberet.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/armyberet.rsi
+  - type: ClothingSpecialModifier
+    perceptionModifier: 1 
 
 - type: entity
   parent: ClothingHeadBase
@@ -71,6 +80,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/armyberetairborne.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/armyberetairborne.rsi
+  - type: ClothingSpecialModifier
+    perceptionModifier: 1 
 
 - type: entity
   parent: ClothingHeadBase
@@ -82,6 +93,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/armyberetranger.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/armyberetranger.rsi
+  - type: ClothingSpecialModifier
+    perceptionModifier: 1 
 
 - type: entity
   parent: ClothingHeadBase
@@ -93,6 +106,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/armyberetspecial.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/armyberetspecial.rsi
+  - type: ClothingSpecialModifier
+    perceptionModifier: 1 
 
 - type: entity
   parent: ClothingHeadBase
@@ -104,6 +119,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/armycap.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/armycap.rsi
+  - type: ClothingSpecialModifier
+    perceptionModifier: 1 
 
 # Bandit
 - type: entity
@@ -116,6 +133,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/bandit.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/bandit.rsi
+  - type: ClothingSpecialModifier
+    perceptionModifier: 1 
 
 # Brotherhood
 - type: entity
@@ -128,6 +147,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/brotherhoodcap.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/brotherhoodcap.rsi
+  - type: ClothingSpecialModifier
+    perceptionModifier: 1 
 
 - type: entity
   parent: ClothingHeadBase
@@ -139,6 +160,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/brotherhoodberet.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/brotherhoodberet.rsi
+  - type: ClothingSpecialModifier
+    perceptionModifier: 1 
 
 - type: entity
   parent: ClothingHeadBase
@@ -150,6 +173,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/brotherhoodhat.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/brotherhoodhat.rsi
+  - type: ClothingSpecialModifier
+    perceptionModifier: 1 
 
 # Enclave
 - type: entity
@@ -162,6 +187,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/enclaveintel.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/enclaveintel.rsi
+  - type: ClothingSpecialModifier
+    perception Modifier: 1 
 
 - type: entity
   parent: ClothingHeadBase
@@ -173,6 +200,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/enclaveofficer.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/enclaveofficer.rsi
+  - type: ClothingSpecialModifier
+    perceptionModifier: 1 
 
 - type: entity
   parent: ClothingHeadBase
@@ -184,6 +213,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/enclavepeacekeeper.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/enclavepeacekeeper.rsi
+  - type: ClothingSpecialModifier
+    perceptionModifier: 1 
 
 - type: entity
   parent: ClothingHeadBase
@@ -195,6 +226,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/enclavescience.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/enclavescience.rsi
+  - type: ClothingSpecialModifier
+    perceptionModifier: 1 
 
 # NCR
 - type: entity
@@ -207,6 +240,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/ncrberetofficer.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/ncrberetofficer.rsi
+  - type: ClothingSpecialModifier
+    perceptionModifier: 1 
 
 - type: entity
   parent: ClothingHeadBase
@@ -218,6 +253,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/ncrberetmedical.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/ncrberetmedical.rsi
+  - type: ClothingSpecialModifier
+    perceptionModifier: 1 
 
 - type: entity
   parent: ClothingHeadBase
@@ -229,6 +266,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/ncrberetrecon.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/ncrberetrecon.rsi
+  - type: ClothingSpecialModifier
+    perceptionModifier: 1 
 
 - type: entity
   parent: ClothingHeadBase
@@ -240,6 +279,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/ncrberetsapper.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/ncrberetsapper.rsi
+  - type: ClothingSpecialModifier
+    perceptionModifier: 1 
 
 - type: entity
   parent: ClothingHeadBase
@@ -251,6 +292,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/ncrsidecap.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/ncrsidecap.rsi
+  - type: ClothingSpecialModifier
+    perceptionModifier: 1 
 
 - type: entity
   parent: ClothingHeadBase
@@ -262,6 +305,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhat.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhat.rsi
+  - type: ClothingSpecialModifier
+    charismaModifier: 1
 
 - type: entity
   parent: ClothingHeadBase
@@ -273,6 +318,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatB.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatB.rsi
+  - type: ClothingSpecialModifier
+    charismaModifier: 1
 
 - type: entity
   parent: ClothingHeadBase
@@ -284,6 +331,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatgrey.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatgrey.rsi
+  - type: ClothingSpecialModifier
+    charismaModifier: 1
 
 - type: entity
   parent: ClothingHeadBase
@@ -295,6 +344,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatgreybanded.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatgreybanded.rsi
+  - type: ClothingSpecialModifier
+    charismaModifier: 1
 
 - type: entity
   parent: ClothingHeadBase
@@ -306,6 +357,8 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatcowboy.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatcowboy.rsi
+  - type: ClothingSpecialModifier
+    charismaModifier: 1 
 
 # Tribal
 - type: entity
@@ -355,6 +408,8 @@
         Blunt: 0.9
         Slash: 0.9
         Heat: 0.9
+  - type: ClothingSpecialModifier
+    strengthModifier: 1 
 
 - type: entity
   parent: ClothingHeadBase
@@ -372,3 +427,5 @@
         Blunt: 0.9
         Slash: 0.8
         Heat: 0.8
+  - type: ClothingSpecialModifier
+    strengthModifier: 1 

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/hats.yml
@@ -188,7 +188,7 @@
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/enclaveintel.rsi
   - type: ClothingSpecialModifier
-    perception Modifier: 1 
+    perceptionModifier: 1 
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/helmets.yml
@@ -434,3 +434,5 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHelmets/midwest-brotherhood/bosheadset.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHelmets/midwest-brotherhood/bosheadset.rsi
+  - type: ClothingSpecialModifier
+    intelligenceModifier: 1

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Mask/bandanas.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Mask/bandanas.yml
@@ -95,5 +95,3 @@
     sprite: _Nuclear14/Clothing/Mask/Bandanas/patriotscarf.rsi
   - type: BreathMask
   - type: IngestionBlocker
-  - type: ClothingSpecialModifier
-    charismaModifier: 1 

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Mask/bandanas.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Mask/bandanas.yml
@@ -95,3 +95,5 @@
     sprite: _Nuclear14/Clothing/Mask/Bandanas/patriotscarf.rsi
   - type: BreathMask
   - type: IngestionBlocker
+  - type: ClothingSpecialModifier
+    charismaModifier: 1 

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Neck/cloaks.yml
@@ -90,3 +90,5 @@
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/Neck/yaoguai.rsi
+- type: ClothingSpecialModifier
+  strengthModifier: 1

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Neck/cloaks.yml
@@ -90,5 +90,3 @@
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/Neck/yaoguai.rsi
-- type: ClothingSpecialModifier
-  strengthModifier: 1

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Neck/scarfs.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Neck/scarfs.yml
@@ -116,3 +116,5 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+  - type: ClothingSpecialModifier
+    charismaModifier: 1 

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
@@ -15,14 +15,6 @@
         Slash: 0.7
         Piercing: 0.9
         Heat: 0.8
-  - type: ClothingSpecialModifier
-    strengthModifier: 1
-    perceptionModifier: 3
-    enduranceModifier: -2 # check negative
-    charismaModifier: 8 # to see we don't get more than 10
-    intelligenceModifier: -6 # to see we still have 1 after sum with base 5
-    # agilityModifier: 1 to check it doesn't show
-    luckModifier: 0 # to check it does not show
 
 - type: entity
   parent: ClothingOuterBase

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
@@ -25,6 +25,8 @@
     damageCoefficient: 0.5
   - type: ToggleableClothing
     clothingPrototype: N14ClothingHeadHelmetPowerArmorT45
+  - type: ClothingSpecialModifier
+    strengthModifier: 10 
 
 - type: entity
   parent: N14ClothingOuterPowerArmorT45
@@ -203,6 +205,8 @@
         Radiation: 0.9
   - type: ExplosionResistance
     damageCoefficient: 0.65
+  - type: ClothingSpecialModifier
+    strengthModifier: 10 
 
 - type: entity
   parent: N14ClothingOuterPowerArmorT45

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Shoes/falloutshoesbasic.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Shoes/falloutshoesbasic.yml
@@ -52,6 +52,8 @@
     sprite: _Nuclear14/Clothing/Shoes/FalloutShoes/wastelanderrags.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Shoes/FalloutShoes/wastelanderrags.rsi
+  - type: ClothingSpecialModifier
+    charismaModifier: -1 
 
 - type: entity
   parent: ClothingShoesBase
@@ -63,3 +65,5 @@
     sprite: _Nuclear14/Clothing/Shoes/FalloutShoes/raider.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Shoes/FalloutShoes/raider.rsi
+  - type: ClothingSpecialModifier
+    charismaModifier: -1 

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Uniform/falloutjumpsuits.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Uniform/falloutjumpsuits.yml
@@ -63,6 +63,8 @@
     sprite: _Nuclear14/Clothing/Uniforms/FalloutSuits/wastelanderrags.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Uniforms/FalloutSuits/wastelanderrags.rsi
+  - type: ClothingSpecialModifier
+    charismaModifier: -1
 
 - type: entity
   parent: ClothingUniformBase


### PR DESCRIPTION
All power armor now gives +10 Strength, effectively capping out the users strength
All Caps and berets give +1 Perception
All cowboy hats give +1 Charisma
The sheriffs hat gives +1 Charisma and Perception
Sunglasses give +1 Charisma
Wastelander rags and footrags give -1 Charisma
Various other +1 changes in perception, charisma, intellegence, and strength.