### PR TITLE
Adds HEIAP and Rebalances western ammo

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/50.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/50.yml
@@ -8,6 +8,7 @@
     whitelist:
       tags:
         - N14Cartridge50
+        - N14Cartridge50HEIAP
     proto: N14Cartridge50
     capacity: 30
   - type: ContainerContainer
@@ -29,6 +30,19 @@
   components:
   - type: BallisticAmmoProvider
     proto: N14Cartridge50
+  - type: Sprite
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+
+- type: entity
+  parent: BaseMagazineBox50
+  id: MagazineBox50HEIAP
+  name: ammunition box (.50 anti materiel)
+  suffix: HEIAP
+  components:
+  - type: BallisticAmmoProvider
+    proto: N14Cartridge50HEIAP
   - type: Sprite
     layers:
     - state: base

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/50.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/50.yml
@@ -18,3 +18,25 @@
   - type: SpentAmmoVisuals
   - type: StaticPrice
     price: 20
+
+- type: entity
+  parent: BaseCartridge
+  id: N14Cartridge50HEIAP
+  name: cartridge (.50 anti-materiel)
+  suffix: HEIAP
+  components:
+  - type: Tag
+    tags:
+    - Cartridge
+    - N14Cartridge50HEIAP
+  - type: CartridgeAmmo
+    proto: N14Bullet50HEIAP
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Ammunition/Casings/large_casing.rsi
+    layers:
+    - state: base
+      map: ["enum.AmmoVisualLayers.Base"]
+  - type: Appearance
+  - type: SpentAmmoVisuals
+  - type: StaticPrice
+    price: 40

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/50.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/50.yml
@@ -12,6 +12,7 @@
     whitelist:
       tags:
         - N14Cartridge50
+        - N14Cartridge50HEIAP
     proto: N14Cartridge50
     capacity: 5
   - type: ContainerContainer
@@ -40,3 +41,12 @@
   components:
   - type: BallisticAmmoProvider
     proto: N14Cartridge50
+
+- type: entity
+  id: N14Magazine50AMRHEIAP
+  name: "magazine (.50 BMG HEIAP)"
+  parent: BaseMagazine50AMR
+  suffix: HEIAP
+  components:
+  - type: BallisticAmmoProvider
+    proto: N14Cartridge50HEIAP

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/44.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/44.yml
@@ -7,4 +7,5 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 30
+        Piercing: 35
+        Blunt: 5

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/45-70.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/45-70.yml
@@ -7,4 +7,5 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 35
+        Piercing: 45
+        Blunt: 5

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/50.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/50.yml
@@ -2,10 +2,31 @@
   noSpawn: true
   parent: BaseBullet
   id: N14Bullet50
-  name: bullet (.50 HEIAP anti-materiel)
+  name: bullet (.50 AP anti-materiel)
   components:
   - type: Projectile
     damage:
       types:
         Piercing: 60 # 20% decrease in power for AP
     ignoreResistances: true
+
+- type: entity
+  noSpawn: true
+  parent: BaseGrenadeProjectile
+  id: N14Bullet50HEIAP
+  name: bullet (.50 HEIAP anti-materiel)
+  components:
+  - type: IgniteOnCollide
+    fireStacks: 1
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 40 # medium decrease for explosion numerics
+    ignoreResistances: true
+  - type: ExplodeOnTrigger
+  - type: Explosive
+    explosionType: Default
+    maxIntensity: 2
+    intensitySlope: 6
+    totalIntensity: 5
+    maxTileBreak: 1

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -73,6 +73,7 @@
         whitelist:
           tags:
             - N14Magazine50AMR
+            - N14Magazine50AMRHEIAP
       gun_chamber:
         name: Chamber
         startingItem: N14Cartridge50
@@ -80,6 +81,7 @@
         whitelist:
           tags:
             - N14Cartridge50
+            - N14Cartridge50HEIAP
   - type: MagazineVisuals
     magState: mag
     steps: 1

--- a/Resources/Prototypes/_Nuclear14/tags.yml
+++ b/Resources/Prototypes/_Nuclear14/tags.yml
@@ -72,6 +72,9 @@
   id: N14Cartridge50
 
 - type: Tag
+  id: N14Cartridge50HEIAP
+
+- type: Tag
   id: N14ShellShotgun12
 
 - type: Tag
@@ -143,6 +146,9 @@
 
 - type: Tag
   id: N14Magazine50AMR
+
+- type: Tag
+  id: N14Magazine50AMRHEIAP
 
 - type: Tag
   id:  SpeedLoader


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Western ammo .44 and 45-70 gov't was underwhelming to say the least. They are rare and annoying to manage scaring off majority of players. Every normal gun was better in every single way even though the 45-70 was supposed to be on par with assault rifle for that matter. This should even it out a ltitle

Adds .50 HEIAP [ Less direct damage, but explodes for AOE damage, also catches people on fire sometimes]

---