### PR TITLE
Fixes speedLoaders

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Speedloaders/10mm.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Speedloaders/10mm.yml
@@ -6,7 +6,7 @@
   components:
   - type: Tag
     tags:
-      - SpeedLoader
+      - SpeedLoader10
   - type: SpeedLoader
   - type: BallisticAmmoProvider
     whitelist:

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Speedloaders/44.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Speedloaders/44.yml
@@ -6,7 +6,7 @@
   components:
   - type: Tag
     tags:
-      - SpeedLoader
+      - SpeedLoader44
   - type: SpeedLoader
   - type: BallisticAmmoProvider
     whitelist:

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Speedloaders/45-70.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Speedloaders/45-70.yml
@@ -6,7 +6,7 @@
   components:
   - type: Tag
     tags:
-      - SpeedLoader
+      - SpeedLoader45-70
   - type: SpeedLoader
   - type: BallisticAmmoProvider
     whitelist:

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Speedloaders/9mm.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Speedloaders/9mm.yml
@@ -6,7 +6,7 @@
   components:
   - type: Tag
     tags:
-      - SpeedLoader
+      - SpeedLoader9
   - type: SpeedLoader
   - type: BallisticAmmoProvider
     whitelist:

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -12,7 +12,7 @@
     whitelist:
       tags:
         - N14CartridgePistol9
-        - SpeedLoader
+        - SpeedLoader9
     proto: N14CartridgePistol9
   - type: Gun
     soundGunshot:
@@ -32,7 +32,7 @@
     whitelist:
       tags:
         - N14CartridgePistol10
-        - SpeedLoader
+        - SpeedLoader10
     proto: N14CartridgePistol10
   - type: Gun
     soundGunshot:
@@ -52,7 +52,7 @@
     whitelist:
       tags:
         - N14Cartridge44Magnum
-        - SpeedLoader
+        - SpeedLoader44
     proto: N14Cartridge44Magnum
   - type: Gun
     soundGunshot:
@@ -77,7 +77,7 @@
     whitelist:
       tags:
         - N14Cartridge44Magnum
-        - SpeedLoader
+        - SpeedLoader44
     proto: N14Cartridge44Magnum
 
 - type: entity
@@ -97,7 +97,7 @@
     whitelist:
       tags:
         - N14Cartridge45-70
-        - SpeedLoader
+        - SpeedLoader45-70
     proto: N14Cartridge45-70
 
 - type: entity
@@ -119,7 +119,7 @@
     whitelist:
       tags:
         - N14Cartridge45-70
-        - SpeedLoader
+        - SpeedLoader45-70
     proto: N14Cartridge45-70
 
 - type: entity
@@ -141,5 +141,5 @@
     whitelist:
       tags:
         - N14Cartridge45-70
-        - SpeedLoader
+        - SpeedLoader45-70
     proto: N14Cartridge45-70

--- a/Resources/Prototypes/_Nuclear14/tags.yml
+++ b/Resources/Prototypes/_Nuclear14/tags.yml
@@ -53,6 +53,18 @@
 - type: Tag
   id: SpeedLoaderInternal
 
+- type: Tag
+  id: SpeedLoader9
+
+- type: Tag
+  id: SpeedLoader10
+
+- type: Tag
+  id: SpeedLoader44
+
+- type: Tag
+  id: SpeedLoader45-70
+
 # Ammo tags(cartriges).
 - type: Tag
   id: N14CartridgePistol22


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

It seems they all had the same tags, which meant you could put any revolver speedLoader into any revolver and fire it wsithout issue.... This. Shouldn't happen...

---