### PR TITLE
Water generation and Mob Fixes

### DIFF
--- a/Resources/Locale/en-US/_Nuclear14/reagents.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/reagents.ftl
@@ -163,10 +163,17 @@ reagent-name-tea-fireantnectar = fire ant nectar
 reagent-desc-tea-fireantnectar = Crystalised nectar from a fire ant. Sugary.
 
 
-# Chems
+# Venoms
 reagent-name-firetoxin = fire toxin
 reagent-desc-firetoxin = The hot stuff from firey creatures.
 
+reagent-name-nightstalker-venom = nightstalker venom
+reagent-desc-nightstalker-venom = The venom of a nightstalker. While not nearly as potent as cazador venom, it can still knock you down to your knees.
+
+reagent-name-cazador-venom = cazador venom
+reagent-desc-cazador-venom = The venom of a cazador. Quick death is near guaranteed.
+
+# Chems
 reagent-name-healing-powder = healing powder
 reagent-desc-healing-powder = A powder made from crushed plants.
 

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
@@ -257,6 +257,12 @@
         reagents:
         - ReagentId: Toxin
           Quantity: 2.5
+  - type: Udder
+    reagentId: Toxin
+    solutionName: melee
+    quantityPerUpdate: 0.5
+    growthDelay: 5
+    hungerUsage: 0.5
 
 - type: entity
   name: nightstalker
@@ -326,6 +332,12 @@
         reagents:
         - ReagentId: Toxin
           Quantity: 5
+  - type: Udder
+    reagentId: Toxin
+    solutionName: melee
+    quantityPerUpdate: 2.5
+    growthDelay: 5
+    hungerUsage: 2.5
   - type: Reproductive
     breedChance: 0.05
     birthPopup: reproductive-laid-egg-popup
@@ -635,9 +647,9 @@
           Quantity: 30
   - type: Udder
     reagentId: N14MilkBrahmin
-    targetSolution: udder
-    quantity: 25
-    updateRate: 30
+    quantityperUpdate: 25
+    growthDelay: 60
+    hungerUsage: 10
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: WastelandAnimal
@@ -695,9 +707,9 @@
           Quantity: 30
   - type: Udder
     reagentId: N14MilkBighorner
-    targetSolution: udder
-    quantity: 25
-    updateRate: 30
+    quantityperUpdate: 25
+    growthDelay: 90
+    hungerUsage: 7.5
   - type: Reproductive
     breedChance: 0.05
     birthPopup: reproductive-birth-popup
@@ -744,9 +756,9 @@
           Quantity: 30
   - type: Udder
     reagentId: N14MilkRadstag
-    targetSolution: udder
-    quantity: 25
-    updateRate: 30
+    quantityperUpdate: 10
+    growthDelay: 40
+    hungerUsage: 5
   - type: Reproductive
     breedChance: 0.05
     birthPopup: reproductive-birth-popup

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
@@ -1,5 +1,5 @@
 # See basemob.yml for parent entities
-
+#MARK: Molerat
 - type: entity
   name: molerat
   id: N14MobMolerat
@@ -39,11 +39,13 @@
       Dead:
         Base: dead
   - type: MeleeWeapon
+    altDisarm: false
     hidden: true
     soundHit:
         path: /Audio/Effects/bite.ogg
-    angle: 0
+    angle: 60
     animation: WeaponArcBite
+    wideAnimation: WeaponArcBite
     damage:
       groups:
         Brute: 3
@@ -62,6 +64,7 @@
     tags:
     - Molerat
 
+#MARK: Feral Dog
 - type: entity
   name: feral dog
   id: N14MobDogFeral
@@ -101,11 +104,13 @@
       Dead:
         Base: dead
   - type: MeleeWeapon
+    altDisarm: false
     hidden: true
     soundHit:
         path: /Audio/Effects/bite.ogg
-    angle: 0
+    angle: 60
     animation: WeaponArcBite
+    wideAnimation: WeaponArcBite
     damage:
       groups:
         Brute: 5
@@ -124,6 +129,7 @@
     tags:
     - DogFeral
 
+#MARK: Gecko
 - type: entity
   name: gecko
   id: N14MobGecko
@@ -163,11 +169,13 @@
       Dead:
         Base: dead
   - type: MeleeWeapon
+    altDisarm: false
     hidden: true
     soundHit:
         path: /Audio/Effects/bite.ogg
-    angle: 0
+    angle: 60
     animation: WeaponArcBite
+    wideAnimation: WeaponArcBite
     damage:
       types:
         Slash: 5
@@ -193,6 +201,7 @@
     tags:
     - Gecko
 
+#MARK: Nightstalker Cub
 - type: entity
   name: nightstalker cub
   id: N14MobNightstalkerCub
@@ -241,11 +250,13 @@
       Dead:
         Base: dead
   - type: MeleeWeapon
+    altDisarm: false
     hidden: true
     soundHit:
         path: /Audio/Effects/bite.ogg
-    angle: 0
+    angle: 60
     animation: WeaponArcBite
+    wideAnimation: WeaponArcBite
     damage:
       groups:
         Brute: 1
@@ -254,16 +265,28 @@
   - type: SolutionContainerManager
     solutions:
       melee:
+        maxVol: 2.5
         reagents:
         - ReagentId: Toxin
           Quantity: 2.5
+      udder:
+        maxVol: 5
+        reagents:
+        - ReagentId: Toxin
+          Quantity: 5
   - type: Udder
     reagentId: Toxin
-    solutionName: melee
-    quantityPerUpdate: 0.5
-    growthDelay: 5
-    hungerUsage: 0.5
+    quantityPerUpdate: 1
+    growthDelay: 30
+    hungerUsage: 2
+  - type: SolutionRegeneration
+    solution: melee
+    generated:
+      reagents:
+      - ReagentId: Toxin
+        Quantity: 0.1
 
+#MARK: Nightstalker
 - type: entity
   name: nightstalker
   id: N14MobNightstalker
@@ -316,11 +339,13 @@
       Dead:
         Base: dead
   - type: MeleeWeapon
+    altDisarm: false
     hidden: true
     soundHit:
         path: /Audio/Effects/bite.ogg
-    angle: 0
+    angle: 60
     animation: WeaponArcBite
+    wideAnimation: WeaponArcBite
     damage:
       groups:
         Brute: 3
@@ -329,15 +354,26 @@
   - type: SolutionContainerManager
     solutions:
       melee:
+        maxVol: 5
         reagents:
         - ReagentId: Toxin
           Quantity: 5
+      udder:
+        maxVol: 10
+        reagents:
+        - ReagentId: Toxin
+          Quantity: 10
   - type: Udder
     reagentId: Toxin
-    solutionName: melee
-    quantityPerUpdate: 2.5
-    growthDelay: 5
-    hungerUsage: 2.5
+    quantityPerUpdate: 1
+    growthDelay: 30
+    hungerUsage: 2
+  - type: SolutionRegeneration
+    solution: melee
+    generated:
+      reagents:
+      - ReagentId: Toxin
+        Quantity: 0.1
   - type: Reproductive
     breedChance: 0.05
     birthPopup: reproductive-laid-egg-popup
@@ -356,6 +392,7 @@
     tags:
     - Nightstalker
 
+#MARK: Yao Guai
 - type: entity
   name: yao guai
   id: N14MobYaoguai
@@ -398,11 +435,13 @@
       Dead:
         Base: dead
   - type: MeleeWeapon
+    altDisarm: false
     hidden: true
     soundHit:
         path: /Audio/Effects/bite.ogg
-    angle: 0
+    angle: 60
     animation: WeaponArcBite
+    wideAnimation: WeaponArcBite
     damage:
       types:
         Slash: 15
@@ -427,7 +466,8 @@
     tags:
     - Yaoguai
 
-# Scaley Animals
+#MARK:Scaley Animals
+#MARK: Deathclaw
 - type: entity
   name: deathclaw
   id: N14MobDeathclaw
@@ -474,11 +514,13 @@
       Dead:
         Base: dead
   - type: MeleeWeapon
+    altDisarm: false
     hidden: true
     soundHit:
       collection: AlienClaw
-    angle: 0
+    angle: 60
     animation: WeaponArcClaw
+    wideAnimation: WeaponArcClaw
     damage:
       types:
         Slash: 15
@@ -526,6 +568,7 @@
     tags:
     - Deathclaw
 
+#MARK: Albino Deathclaw
 - type: entity
   name: albino deathclaw
   id: N14MobDeathclawAlbino
@@ -539,11 +582,13 @@
       state: deathclawalbino
       sprite: _Nuclear14/Mobs/Animals/deathclawalbino.rsi
   - type: MeleeWeapon
+    altDisarm: false
     hidden: true
     soundHit:
       collection: AlienClaw
-    angle: 0
+    angle: 60
     animation: WeaponArcClaw
+    wideAnimation: WeaponArcClaw
     damage:
       types:
         Slash: 22
@@ -585,6 +630,7 @@
       Dead:
         Base: dead
 
+#MARK: Metal Deathclaw
 - type: entity
   name: metal deathclaw
   id: N14MobDeathclawMetal
@@ -598,17 +644,20 @@
       state: deathclawmetal
       sprite: _Nuclear14/Mobs/Animals/deathclawmetal.rsi
   - type: MeleeWeapon
+    altDisarm: false
     hidden: true
     soundHit:
       collection: AlienClaw
-    angle: 0
+    angle: 60
     animation: WeaponArcClaw
+    wideAnimation: WeaponArcClaw
     damage:
       types:
         Slash: 20
         Structural: 10
 
-# Passive Animals
+#MARK: Passive Animals
+#MARK: Brahmin
 - type: entity
   name: brahmin
   parent: MobCow
@@ -673,6 +722,7 @@
       maxAmount: 1
   - type: ReproductivePartner
 
+#MARK: Bighorner
 - type: entity
   name: bighorner
   parent: N14MobBrahmin
@@ -698,6 +748,19 @@
     spawned:
     - id: N14FoodMeatBighorner
       amount: 4
+  - type: MeleeWeapon
+    altDisarm: false
+    hidden: true
+    soundHit:
+      collection: MetalThud
+    angle: 60
+    animation: WeaponArcClaw
+    wideAnimation: WeaponArcClaw
+    damage:
+      types:
+        Blunt: 8
+        Slash: 2
+        Structural: 8
   - type: SolutionContainerManager
     solutions:
       udder:
@@ -722,6 +785,7 @@
       maxAmount: 1
   - type: ReproductivePartner
 
+#MARK: Radstag
 - type: entity
   name: radstag
   parent: N14MobBrahmin
@@ -747,6 +811,19 @@
     spawned:
     - id: N14FoodMeatRadstag
       amount: 4
+  - type: MeleeWeapon
+    altDisarm: false
+    hidden: true
+    soundHit:
+      collection: MetalThud
+    angle: 60
+    animation: WeaponArcClaw
+    wideAnimation: WeaponArcClaw
+    damage:
+      types:
+        Blunt: 6
+        Slash: 2
+        Structural: 8
   - type: SolutionContainerManager
     solutions:
       udder:
@@ -771,6 +848,7 @@
       maxAmount: 1
   - type: ReproductivePartner
 
+#MARK: Chicken
 - type: entity
   parent: MobChicken
   id: N14MobChicken
@@ -812,6 +890,7 @@
     eggSpawn:
     - id: N14FoodEggChicken
 
+#MARK: Iguana
 - type: entity
   parent: N14MobBaseSimple
   id: N14MobIguana

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
@@ -267,15 +267,15 @@
       melee:
         maxVol: 2.5
         reagents:
-        - ReagentId: Toxin
+        - ReagentId: NightstalkerVenom
           Quantity: 2.5
       udder:
         maxVol: 5
         reagents:
-        - ReagentId: Toxin
+        - ReagentId: NightstalkerVenom
           Quantity: 5
   - type: Udder
-    reagentId: Toxin
+    reagentId: NightstalkerVenom
     quantityPerUpdate: 1
     growthDelay: 30
     hungerUsage: 2
@@ -283,7 +283,7 @@
     solution: melee
     generated:
       reagents:
-      - ReagentId: Toxin
+      - ReagentId: NightstalkerVenom
         Quantity: 0.1
 
 #MARK: Nightstalker
@@ -354,17 +354,17 @@
   - type: SolutionContainerManager
     solutions:
       melee:
-        maxVol: 5
+        maxVol: 10
         reagents:
-        - ReagentId: Toxin
-          Quantity: 5
+        - ReagentId: NightstalkerVenom
+          Quantity: 10
       udder:
         maxVol: 10
         reagents:
-        - ReagentId: Toxin
+        - ReagentId: NightstalkerVenom
           Quantity: 10
   - type: Udder
-    reagentId: Toxin
+    reagentId: NightstalkerVenom
     quantityPerUpdate: 1
     growthDelay: 30
     hungerUsage: 2
@@ -372,8 +372,11 @@
     solution: melee
     generated:
       reagents:
-      - ReagentId: Toxin
-        Quantity: 0.1
+      - ReagentId: NightstalkerVenom
+        Quantity: 0.25
+  - type: MeleeChemicalInjector
+    solution: melee
+    transferAmount: 1.5
   - type: Reproductive
     breedChance: 0.05
     birthPopup: reproductive-laid-egg-popup

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/basemob.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/basemob.yml
@@ -1,4 +1,5 @@
 # Consider making our own base mob in future so we're resilient to upstream changes.
+#MARK: Base Simple
 - type: entity
   name: wasteland animal
   abstract: true
@@ -67,7 +68,7 @@
   - type: Speech
     speechSounds: Squeak
 
-# Base Hostile
+#MARK: Base Hostile
 - type: entity
   abstract: true
   id: N14MobBaseHostile
@@ -116,8 +117,9 @@
     range: 1
     soundHit:
         path: /Audio/Effects/bite.ogg
-    angle: 0
+    angle: 60
     animation: WeaponArcBite
+    wideAnimation: WeaponArcBite
     damage:
       groups:
         Brute: 2
@@ -132,7 +134,7 @@
   - type: ReplacementAccent
     accent: genericAggressive
 
-
+#MARK: Base Scaley
 - type: entity
   name: scaley wasteland animal
   abstract: true
@@ -143,6 +145,7 @@
     damageContainer: Biological
     damageModifierSet: N14Scale
 
+#MARK: Base Insect
 - type: entity
   name: wasteland insect
   abstract: true
@@ -158,6 +161,7 @@
     - WastelandInsect
 
 # Wave Defence Base Hostile
+#MARK: WAVE
 - type: entity
   name: wave attacker
   abstract: true
@@ -205,7 +209,7 @@
   - type: WaveMob
     group: Insects
 
-# Base Tameable
+#MARK: Base Tameable
 - type: entity
   abstract: true
   id: N14TameableMobBase

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/insects.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/insects.yml
@@ -1,5 +1,6 @@
 # See basemob.yml for parent entities
 
+#MARK: Bloatfly
 - type: entity
   name: bloatfly
   parent: N14MobBaseHostileInsect
@@ -41,6 +42,8 @@
   - type: BallisticAmmoProvider
     proto: N14BulletAcid
     capacity: 100
+  - type: RechargeBasicEntityAmmo
+    rechargeCooldown: 1
   - type: Gun
     fireRate: 0.5
     selectedMode: FullAuto
@@ -56,7 +59,7 @@
       amount: 1
       prob: 0.75
 
-
+#MARK: Giant Ant
 - type: entity
   name: giant ant
   parent: N14MobBaseHostileInsect
@@ -106,15 +109,18 @@
     heatDamageThreshold: 500
     coldDamageThreshold: 0
   - type: MeleeWeapon
+    altDisarm: false
     hidden: true
     soundHit:
         path: /Audio/Weapons/Xeno/alien_claw_flesh3.ogg
-    angle: 0
+    angle: 60
     animation: WeaponArcClaw
+    wideAnimation: WeaponArcClaw
     damage:
       groups:
         Brute: 5
 
+#MARK: Giant Fire Ant
 - type: entity
   name: giant fire ant
   parent: N14MobGiantAnt
@@ -141,6 +147,12 @@
         reagents:
         - ReagentId: FireToxin
           Quantity: 10
+  - type: SolutionRegeneration
+    solution: melee
+    generated:
+      reagents:
+      - ReagentId: FireToxin
+        Quantity: 0.1
   - type: Butcherable
     spawned:
     - id: N14MaterialAntChitin
@@ -151,6 +163,7 @@
       amount: 1
       prob: 0.75
 
+#MARK: Radroach
 - type: entity
   name: radroach
   id: N14MobRadroach
@@ -191,11 +204,13 @@
       Dead:
         Base: dead
   - type: MeleeWeapon
+    altDisarm: false
     hidden: true
     soundHit:
         path: /Audio/Effects/bite.ogg
-    angle: 0
+    angle: 60
     animation: WeaponArcBite
+    wideAnimation: WeaponArcBite
     damage:
       groups:
         Brute: 2
@@ -204,6 +219,7 @@
     - id: N14FoodMeatRadroachFillet
       amount: 1
 
+#MARK: Radscorpion
 - type: entity
   name: radscorpion
   parent: N14MobBaseHostileInsect
@@ -259,21 +275,36 @@
     heatDamageThreshold: 500
     coldDamageThreshold: 0
   - type: MeleeWeapon
+    altDisarm: false
     hidden: true
     soundHit:
         path: /Audio/Weapons/Xeno/alien_claw_flesh3.ogg
-    angle: 0
+    angle: 60
     animation: WeaponArcClaw
+    wideAnimation: WeaponArcClaw
     damage:
       types:
-        Piercing: 5
+        Slash: 2
+        Piercing: 8
   - type: SolutionContainerManager
     solutions:
       melee:
+        maxVol: 10
         reagents:
         - ReagentId: Toxin
-          Quantity: 3
+          Quantity: 5
+        - ReagentId: Radium
+          Quantity: 5
+  - type: SolutionRegeneration
+    solution: melee
+    generated:
+      reagents:
+      - ReagentId: Toxin
+        Quantity: 0.1
+      - ReagentId: Radium
+        Quantity: 0.1
 
+#MARK: Barkscorpion
 - type: entity
   name: barkscorpion
   parent: N14MobRadscorpion
@@ -286,7 +317,21 @@
     - map: [ "enum.DamageStateVisualLayers.Base" ]
       state: radscorpion
       sprite: _Nuclear14/Mobs/Insects/radscorpionbark.rsi
+  - type: SolutionContainerManager
+    solutions:
+      melee:
+        maxVol: 10
+        reagents:
+        - ReagentId: Toxin
+          Quantity: 10
+  - type: SolutionRegeneration
+    solution: melee
+    generated:
+      reagents:
+      - ReagentId: Toxin
+        Quantity: 0.2
 
+#MARK: Cazador
 - type: entity
   name: cazador
   parent: N14MobBaseHostileInsect
@@ -324,20 +369,33 @@
   - type: Bloodstream
     bloodMaxVolume: 50
   - type: MeleeWeapon
+    altDisarm: false
     hidden: true
     soundHit:
         path: /Audio/Effects/bite.ogg
-    angle: 0
+    angle: 60
     animation: WeaponArcBite
+    wideAnimation: WeaponArcBite
     damage:
       types:
         Piercing: 5
   - type: SolutionContainerManager
     solutions:
       melee:
+        maxVol: 10
         reagents:
         - ReagentId: Toxin
           Quantity: 5
+        - ReagentId: ChloralHydrate
+          Quantity: 5
+  - type: SolutionRegeneration
+    solution: melee
+    generated:
+      reagents:
+      - ReagentId: Toxin
+        Quantity: 0.25
+      - ReagentId: ChloralHydrate
+        Quantity: 0.25
   - type: Butcherable
     spawned:
     - id: N14FoodMeatRadRaw

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/insects.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/insects.yml
@@ -332,6 +332,7 @@
         Quantity: 0.2
 
 #MARK: Cazador
+#SCARY FUCKERS, RUUUN!!
 - type: entity
   name: cazador
   parent: N14MobBaseHostileInsect
@@ -373,29 +374,28 @@
     hidden: true
     soundHit:
         path: /Audio/Effects/bite.ogg
-    angle: 60
-    animation: WeaponArcBite
-    wideAnimation: WeaponArcBite
+    angle: 30
+    animation: WeaponArcThrust
+    wideAnimation: WeaponArcThrust
     damage:
       types:
-        Piercing: 5
+        Piercing: 3
   - type: SolutionContainerManager
     solutions:
       melee:
         maxVol: 10
         reagents:
-        - ReagentId: Toxin
-          Quantity: 5
-        - ReagentId: ChloralHydrate
-          Quantity: 5
+        - ReagentId: CazadorVenom
+          Quantity: 10
   - type: SolutionRegeneration
     solution: melee
     generated:
       reagents:
-      - ReagentId: Toxin
+      - ReagentId: CazadorVenom
         Quantity: 0.25
-      - ReagentId: ChloralHydrate
-        Quantity: 0.25
+  - type: MeleeChemicalInjector
+    solution: melee
+    transferAmount: 1.5
   - type: Butcherable
     spawned:
     - id: N14FoodMeatRadRaw

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Medical/chemicals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Medical/chemicals.yml
@@ -574,16 +574,14 @@
     emptySpriteName: smellingsalts0
   - type: Hypospray
     solutionName: pen
-    transferAmount: 10
+    transferAmount: 15
   - type: SolutionContainerManager
     solutions:
       pen:
         maxVol: 15
         reagents:
         - ReagentId: SmellingSalts
-          Quantity: 10
-        - ReagentId: Epinephrine
-          Quantity: 5
+          Quantity: 15
 
 - type: entity
   parent: N14HealingPowder

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Furniture/other_furniture.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Furniture/other_furniture.yml
@@ -5,7 +5,7 @@
   - type: Sprite
     sprite: _Nuclear14/Structures/Furniture/np13_misc.rsi
     state: dresser
-    
+
 - type: entity
   parent: BaseStructure
   id: N14GrandfatherClock
@@ -15,7 +15,7 @@
   - type: Sprite
     sprite: _Nuclear14/Structures/Furniture/np13_misc.rsi
     state: grand_clock
-    
+
 # Televisions
 - type: entity
   parent: BaseStructure
@@ -41,7 +41,7 @@
   components:
   - type: Sprite
     state: radking_tv
-    
+
 - type: entity
   parent: N14Television
   id: N14TelevisionRedwood
@@ -57,7 +57,7 @@
   components:
   - type: Sprite
     state: tube_tv
-    
+
 - type: entity
   parent: N14Television
   id: N14TelevisionSmall
@@ -75,7 +75,7 @@
         density: 100
         mask:
           - TabletopMachineMask
-    
+
 - type: entity
   parent: N14TelevisionSmall
   id: N14TelevisionTiny
@@ -83,7 +83,7 @@
   components:
   - type: Sprite
     state: tiny_tv
-    
+
 # Washroom
 - type: entity
   parent: N14DecorFloorBase
@@ -130,7 +130,7 @@
     range: 8
     sound:
       path: /Audio/Ambience/Objects/drain.ogg    
-    
+
 - type: entity
   parent: SeatBase
   id: N14Toilet
@@ -188,7 +188,7 @@
     autoDrain: false
   - type: DumpableSolution
     solution: drainBuffer
-    
+
 - type: entity
   parent: N14Toilet
   id: N14ToiletWater
@@ -200,7 +200,13 @@
         reagents:
         - ReagentId: Water
           Quantity: 200
-    
+  - type: SolutionRegeneration
+    solution: toilet
+    generated:
+      reagents:
+      - ReagentId: Water
+        Quantity: 2
+
 - type: entity
   parent: N14Toilet
   id: N14ToiletDirty
@@ -214,7 +220,15 @@
           Quantity: 180
         - ReagentId: GastroToxin
           Quantity: 20
-          
+  - type: SolutionRegeneration
+    solution: toilet
+    generated:
+      reagents:
+      - ReagentId: WaterDirty
+        Quantity: 3
+      - ReagentId: GastroToxin
+        Quantity: 1
+
 - type: entity
   parent: N14Toilet
   id: N14ToiletIrradiated
@@ -228,7 +242,15 @@
           Quantity: 180
         - ReagentId: GastroToxin
           Quantity: 20
-    
+  - type: SolutionRegeneration
+    solution: toilet
+    generated:
+      reagents:
+      - ReagentId: WaterIrradiated
+        Quantity: 3
+      - ReagentId: GastroToxin
+        Quantity: 1
+
 - type: entity
   parent: N14Shower
   id: N14Sink
@@ -242,7 +264,7 @@
       drainBuffer:
         maxVol: 100
       tank:
-        maxVol: 500
+        maxVol: 200
   - type: DrainableSolution
     solution: tank
   - type: ReagentTank
@@ -250,7 +272,7 @@
     autoDrain: false
   - type: DumpableSolution
     solution: drainBuffer
-    
+
 - type: entity
   parent: N14Sink
   id: N14SinkFilledWater
@@ -263,8 +285,14 @@
       tank:
         reagents:
         - ReagentId: Water
-          Quantity: 500
-          
+          Quantity: 200
+  - type: SolutionRegeneration
+    solution: tank
+    generated:
+      reagents:
+      - ReagentId: Water
+        Quantity: 1
+
 - type: entity
   parent: N14Sink
   id: N14SinkFilledWaterDirty
@@ -277,8 +305,14 @@
       tank:
         reagents:
         - ReagentId: WaterDirty
-          Quantity: 500
-          
+          Quantity: 200
+  - type: SolutionRegeneration
+    solution: tank
+    generated:
+      reagents:
+      - ReagentId: WaterDirty
+        Quantity: 1
+
 - type: entity
   parent: N14Sink
   id: N14SinkFilledWaterIrradiated
@@ -291,4 +325,10 @@
       tank:
         reagents:
         - ReagentId: WaterIrradiated
-          Quantity: 500
+          Quantity: 200
+  - type: SolutionRegeneration
+    solution: tank
+    generated:
+      reagents:
+      - ReagentId: WaterIrradiated
+        Quantity: 1

--- a/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
@@ -270,15 +270,45 @@
   color: "#e1f5f4"
   metabolisms:
     Medicine:
-      metabolismRate: 5 # Effectively 5 ticks per second
+      metabolismRate: 0.2 # Slow Acting
       effects:
       - !type:HealthChange
         damage:
           groups:
-            Airloss: -10 #TODO add detail to wake up a guy if found
+            Airloss: -5
+        conditions:
+          # they gotta be in crit first
+        - !type:MobStateCondition
+          mobstate: Critical
+        - !type:ReagentThreshold
+          min: 0
+          max: 20
+        damage:
+          types:
+            Asphyxiation: -3
+            Poison: -0.5
+          groups:
+            Brute: -0.5
+            Burn: -0.5
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 20
+        damage:
+          types:
+            Asphyxiation: 1
+            Poison: 1
+      - !type:GenericStatusEffect
+        key: Stun
+        time: 0.75
+        type: Remove
+      - !type:GenericStatusEffect
+        key: KnockedDown
+        time: 0.75
+        type: Remove
       - !type:Jitter
       - !type:ChemVomit
-        probability: 0.1
+        probability: 0.05
 
 - type: reagent
   id: HealingPoultice

--- a/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
@@ -272,12 +272,13 @@
     Medicine:
       metabolismRate: 0.2 # Slow Acting
       effects:
-      - !type:HealthChange
+      - !type:HealthChange # Base Airloss fixing
         damage:
-          groups:
-            Airloss: -5
+          types:
+            Asphyxiation: -5
+            Cold: -2
+      - !type:HealthChange # Conditional Epinephrine-like bonus on unconscious
         conditions:
-          # they gotta be in crit first
         - !type:MobStateCondition
           mobstate: Critical
         - !type:ReagentThreshold
@@ -290,13 +291,13 @@
           groups:
             Brute: -0.5
             Burn: -0.5
-      - !type:HealthChange
+      - !type:HealthChange # 20u threshold
         conditions:
         - !type:ReagentThreshold
           min: 20
         damage:
           types:
-            Asphyxiation: 1
+            Asphyxiation: 3
             Poison: 1
       - !type:GenericStatusEffect
         key: Stun

--- a/Resources/Prototypes/_Nuclear14/Reagents/toxins.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/toxins.yml
@@ -1,11 +1,13 @@
-﻿- type: reagent
+﻿#MARK: Firetoxin
+#Liquid found inside of fire ant stingers, it burns quite a lot.
+- type: reagent
   id: FireToxin
   name: reagent-name-firetoxin
   group: Toxins
   desc: reagent-desc-firetoxin
   flavor: tingly
   color: "#cf3600"
-  physicalDesc: reagent-physical-desc-opaque
+  physicalDesc: reagent-physical-desc-burning
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: 10
@@ -19,3 +21,55 @@
           types:
             Heat: 3
             Poison: 2
+
+#MARK: Nightstalker Venom
+#While not nearly as potent as cazador venom and is a lot slower acting, it will still kill in multiple bites
+- type: reagent
+  id: NightstalkerVenom
+  name: reagent-name-nightstalker-venom
+  group: Toxins
+  desc: reagent-desc-nightstalker-venom
+  flavor: terrible
+  color: "#cf3600"
+  physicalDesc: reagent-physical-desc-viscous
+  plantMetabolism:
+  - !type:PlantAdjustToxins
+    amount: 10
+  - !type:PlantAdjustHealth
+    amount: -5
+  metabolisms:
+    Poison:
+      metabolismRate: 0.1 #Very Slow acting, default 0.5
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Poison: 1
+          groups:
+            Airloss: 2
+
+#MARK: Cazador Venom
+#Insanely potent venom which while acts at half speed, can knock down just about anyone in just a few injections
+- type: reagent
+  id: CazadorVenom
+  name: reagent-name-cazador-venom
+  group: Toxins
+  desc: reagent-desc-cazador-venom
+  flavor: terrible
+  color: "#cf3600"
+  physicalDesc: reagent-physical-desc-bubbling
+  plantMetabolism:
+  - !type:PlantAdjustToxins
+    amount: 10
+  - !type:PlantAdjustHealth
+    amount: -5
+  metabolisms:
+    Poison:
+      metabolismRate: 0.2 #Slow acting, default 0.5
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Poison: 3
+          groups:
+            Airloss: 3.5


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Adds water generation to filled iterations of sinks and toilets, offcourse including dirty water and irradiated water.
Toilets regenerate a bit faster, but contain `GastroToxin` if they aren't clean... Please don't drink this.

Nightstalkers now have udders? Just kidding it uses the `Udder` componenet to make them regen their poison without human 
interaction. It would be very funny if you managed to tame one and make use of this huh?

---

:cl:
Adds regeneration to sinks and toilets
Adds regeneration of venoms to mobs
Adds `wideSwing` to mobs
Fixes `wideSwing` animations and angles
Adds option to milk nightstalker poison if you manage to tame one
Fixes nonsensical components with Udder usage
Rebalances some weak mobs by giving them more potent poisons.

---