### PR TITLE
Town and vault Spawn item fixed. Character creation Loadout updates. Various mechanical fixes. 

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Catalog/Fills/Backpacks/StarterGear/backpack.yml
+++ b/Resources/Prototypes/_Nuclear14/Catalog/Fills/Backpacks/StarterGear/backpack.yml
@@ -65,6 +65,15 @@
         - id: Magazine45SubMachineGun
         - id: N14Weapon45SMG
 
+- type: entity
+  noSpawn: true
+  parent: N14ClothingBackpackHiking
+  id: N14ClothingBackpackShopkeeperFilled
+  components:
+    - type: StorageFill
+      contents:
+        - id: N14BoxPlasticFilledWastelander
+
 # Military
 - type: entity
   noSpawn: true
@@ -94,7 +103,6 @@
     - type: StorageFill
       contents:
         - id: N14BoxPlasticFilledWastelander
-        - id: MagazineBox9mm
 
 - type: entity
   noSpawn: true
@@ -105,8 +113,6 @@
       contents:
         - id: N14BoxPlasticFilledWastelander
         - id: N14CombatKnife
-        - id: MagazineBox44
-        - id: MagazineBox308
 
 - type: entity
   noSpawn: true
@@ -117,8 +123,6 @@
       contents:
         - id: N14BoxPlasticFilledWastelander
         - id: N14CombatKnife
-        - id: MagazineBox10mm
-        - id: MagazineBox44
 
 # Tribal
 - type: entity
@@ -148,8 +152,6 @@
     - type: StorageFill
       contents:
         - id: N14BoxPlasticFilledWastelander
-        - id: N14MagazinePistol10mm
-        - id: N14MagazinePistol10mm
 
 - type: entity
   noSpawn: true

--- a/Resources/Prototypes/_Nuclear14/Catalog/Fills/Backpacks/StarterGear/backpack.yml
+++ b/Resources/Prototypes/_Nuclear14/Catalog/Fills/Backpacks/StarterGear/backpack.yml
@@ -112,6 +112,7 @@
     - type: StorageFill
       contents:
         - id: N14BoxPlasticFilledWastelander
+        - id: N14PoliceBaton 
         - id: N14CombatKnife
 
 - type: entity
@@ -122,6 +123,7 @@
     - type: StorageFill
       contents:
         - id: N14BoxPlasticFilledWastelander
+        - id: N14PoliceBaton 
         - id: N14CombatKnife
 
 # Tribal

--- a/Resources/Prototypes/_Nuclear14/Catalog/Fills/Belts/belt.yml
+++ b/Resources/Prototypes/_Nuclear14/Catalog/Fills/Belts/belt.yml
@@ -25,6 +25,18 @@
 - type: entity
   noSpawn: true
   parent: ClothingBeltRevolver
+  id: ClothingBelt10mmfilled
+  components:
+    - type: StorageFill
+      contents:
+        - id: N14WeaponRevolver10mm 
+        - id: SpeedLoader10
+        - id: SpeedLoader10
+        - id: SpeedLoader10
+
+- type: entity
+  noSpawn: true
+  parent: ClothingBeltRevolver
   id: ClothingBeltRevolvervetfilled
   components:
     - type: StorageFill

--- a/Resources/Prototypes/_Nuclear14/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/_Nuclear14/Catalog/Fills/Items/belt.yml
@@ -55,7 +55,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: Stunbaton # TODO: Replace with fallout friendly baton
+      - id: N14PoliceBaton 
       - id: Handcuffs
       - id: Handcuffs
 
@@ -66,8 +66,8 @@
   components:
   - type: StorageFill
     contents:
+      - id: N14PoliceBaton 
       - id: GrenadeFlashBang
-      - id: Stunbaton
 
 - type: entity
   id: N14ClothingBeltWebbingFilled

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Eyes/glasses.yml
@@ -45,6 +45,9 @@
   - type: Clothing
     sprite: _Nuclear14/Clothing/Eyes/glasses.rsi
   - type: VisionCorrection
+  - type: Tag
+    tags: 
+    - GlassesNearsight 
 
 - type: entity
   parent: ClothingEyesBase
@@ -59,3 +62,4 @@
   - type: VisionCorrection
   - type: ClothingSpecialModifier
     charismaModifier: 1 
+  

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/hats.yml
@@ -47,6 +47,45 @@
 
 - type: entity
   parent: ClothingHeadBase
+  id: N14ClothingHeadHatCowboyGrey
+  name: grey cowboy hat
+  description: A rustic grey cowboy hat. A trusted companion for any gunslinger. 
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatgrey.rsi
+  - type: Clothing
+    sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatgrey.rsi
+  - type: ClothingSpecialModifier
+    charismaModifier: 1
+
+- type: entity
+  parent: ClothingHeadBase
+  id: N14ClothingHeadHatCowboyGreyBanded
+  name: banded cowboy hat
+  description: A rugged grey cowboy hat with some brass casings banded around itself.
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatgreybanded.rsi
+  - type: Clothing
+    sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatgreybanded.rsi
+  - type: ClothingSpecialModifier
+    charismaModifier: 1
+
+- type: entity
+  parent: ClothingHeadBase
+  id: N14ClothingHeadHatCowboyBrown 
+  name: brown cowboy hat
+  description: A rustic brown cowboy hat, A trusted companion for any gunslinger. 
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatcowboy.rsi
+  - type: Clothing
+    sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatcowboy.rsi
+  - type: ClothingSpecialModifier
+    charismaModifier: 1 
+
+- type: entity
+  parent: ClothingHeadBase
   id: N14ClothingHeadHatHeadscarf
   name: cloth headscarf
   description: A headscarf made from scraps of cloth
@@ -320,45 +359,6 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatB.rsi
   - type: ClothingSpecialModifier
     charismaModifier: 1
-
-- type: entity
-  parent: ClothingHeadBase
-  id: N14ClothingHeadHatRangerGrey
-  name: grey ranger hat
-  description: A simple grey cowboy hat.
-  components:
-  - type: Sprite
-    sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatgrey.rsi
-  - type: Clothing
-    sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatgrey.rsi
-  - type: ClothingSpecialModifier
-    charismaModifier: 1
-
-- type: entity
-  parent: ClothingHeadBase
-  id: N14ClothingHeadHatRangerGreyBanded
-  name: banded grey ranger hat
-  description: A simple grey cowboy hat with some brass casings banded around itself.
-  components:
-  - type: Sprite
-    sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatgreybanded.rsi
-  - type: Clothing
-    sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatgreybanded.rsi
-  - type: ClothingSpecialModifier
-    charismaModifier: 1
-
-- type: entity
-  parent: ClothingHeadBase
-  id: N14ClothingHeadHatCowboyRang
-  name: trail ranger hat
-  description: A rustic, homely style cowboy hat worn by trail rangers. Yeehaw!
-  components:
-  - type: Sprite
-    sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatcowboy.rsi
-  - type: Clothing
-    sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatcowboy.rsi
-  - type: ClothingSpecialModifier
-    charismaModifier: 1 
 
 # Tribal
 - type: entity

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/coats_and_outer.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/coats_and_outer.yml
@@ -96,6 +96,11 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/falloutduster.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/falloutduster.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.95
+        Heat: 0.9
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -107,28 +112,43 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/falloutleatherduster.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/falloutleatherduster.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.95
+        Heat: 0.9
 
 - type: entity
   parent: ClothingOuterStorageBase
   id: N14ClothingOuterCoatLeatherJacket
   name: leather jacket
-  description: Why, yes, I do own a brahmin farm. How did you know?
+  description: A slick and smooth leather jacket. Perfect for any greaser. 
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/leather_jacket.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/leather_jacket.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.95
+        Heat: 0.9
 
 - type: entity
   parent: ClothingOuterStorageBase
   id: N14ClothingOuterCoatLeatherCoat
   name: leather coat
-  description: Why, yes, I do own a brahmin farm. How did you know?
+  description: A slick and smooth long black leather coat. 
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/coat_leather.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/coat_leather.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.95
+        Heat: 0.9
 
 - type: entity
   parent: ClothingOuterStorageBase

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/baton-club.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/baton-club.yml
@@ -11,14 +11,14 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Blunt: 16
+        Blunt: 8
     soundSwing:
       collection: N14BaseballBatSwing
   - type: Sprite
     sprite: _Nuclear14/Objects/Weapons/Melee/policebaton.rsi
     state: icon
   - type: Item
-    size: Large
+    size: Normal 
   - type: Clothing
     sprite: _Nuclear14/Objects/Weapons/Melee/policebaton.rsi
     quickEquip: false

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/knife.yml
@@ -41,8 +41,16 @@
     sprite: _Nuclear14/Objects/Weapons/Melee/kitchen_knife.rsi
     size: Small
     state: icon
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 16
   - type: Item
     sprite: _Nuclear14/Objects/Weapons/Melee/kitchen_knife.rsi
+  - type: DisarmMalus
+    malus: 0.225
 
 - type: entity
   name: butcher's cleaver
@@ -62,8 +70,16 @@
     damage:
       types:
         Slash: 16
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 20
   - type: Item
     sprite: _Nuclear14/Objects/Weapons/Melee/cleaver.rsi
+  - type: DisarmMalus
+    malus: 0.225
 
 - type: entity
   name: combat knife

--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
@@ -152,7 +152,7 @@
         - NCRRanger
         - NCRRangerVeteran
   items:
-    - N14ClothingHeadHatRangerGrey
+    - N14ClothingHeadHatCowboyGrey
 
 - type: loadout
   id: LoadoutNCRhatGreyBanded
@@ -165,7 +165,7 @@
         - NCRRanger
         - NCRRangerVeteran
   items:
-    - N14ClothingHeadHatRangerGreyBanded
+    - N14ClothingHeadHatCowboyGreyBanded
 
 - type: loadout
   id: LoadoutNCRhatBeret

--- a/Resources/Prototypes/_Nuclear14/Loadouts/eyes.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/eyes.yml
@@ -1,13 +1,27 @@
 - type: loadout
+  id: N14ClothingEyesGlassesWelding
+  category: Accessories
+  cost: 4
+  items:
+    - N14ClothingEyesGlassesWelding
+
+- type: loadout
+  id: N14ClothingEyesSunGlasses
+  category: Accessories
+  cost: 2
+  items:
+    - N14ClothingEyesSunGlasses
+
+- type: loadout
+  id: N14ClothingEyesGlasses 
+  category: Accessories
+  cost: 2
+  items:
+    - N14ClothingEyesGlasses
+
+- type: loadout
   id: N14LoadoutEyesEyepatch
   category: Accessories
   cost: 1
   items:
     - ClothingEyesEyepatch
-
-- type: loadout
-  id: N14LoadoutEyesBlindfold
-  category: Accessories
-  cost: 2
-  items:
-    - ClothingEyesBlindfold

--- a/Resources/Prototypes/_Nuclear14/Loadouts/head.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/head.yml
@@ -39,3 +39,24 @@
   cost: 2
   items:
     - N14ClothingHeadHatArmyCap
+
+- type: loadout
+  id: N14ClothingHeadHatCowboyGrey
+  category: Head
+  cost: 2
+  items:
+    - N14ClothingHeadHatCowboyGrey
+
+- type: loadout
+  id: N14ClothingHeadHatCowboyGreyBanded
+  category: Head
+  cost: 2
+  items:
+    - N14ClothingHeadHatCowboyGreyBanded
+
+- type: loadout
+  id: N14ClothingHeadHatCowboyBrown
+  category: Head
+  cost: 2
+  items:
+    - N14ClothingHeadHatCowboyBrown 

--- a/Resources/Prototypes/_Nuclear14/Loadouts/items.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/items.yml
@@ -1,9 +1,58 @@
 - type: loadout
-  id: N14LoadoutItemCig
+  id: N14WeaponRevolver9mm
   category: Items
-  cost: 1
+  cost: 5
   items:
-    - N14Cigarette
+    - N14WeaponRevolver9mm
+
+- type: loadout
+  id: N14KitchenKnife
+  category: Items
+  cost: 5
+  items:
+    - N14KitchenKnife 
+
+- type: loadout
+  id: ClothingMaskBat 
+  category: Items
+  cost: 4
+  items:
+    - ClothingMaskBat
+
+- type: loadout
+  id: ClothingMaskBear
+  category: Items
+  cost: 4
+  items:
+    - ClothingMaskBear
+
+- type: loadout
+  id: ClothingMaskBee
+  category: Items
+  cost: 4
+  items:
+    - ClothingMaskFox
+
+- type: loadout
+  id: ClothingMaskJackal
+  category: Items
+  cost: 4
+  items:
+    - ClothingMaskJackal
+
+- type: loadout
+  id: ClothingMaskRat
+  category: Items
+  cost: 4
+  items:
+    - ClothingMaskRat 
+
+- type: loadout
+  id: ClothingMaskRaven
+  category: Items
+  cost: 4
+  items:
+    - ClothingMaskRaven
 
 - type: loadout
   id: N14LoadoutItemCigsSalem
@@ -81,3 +130,10 @@
   cost: 1
   items:
     - N14JunkVaultCanteen
+
+- type: loadout
+  id: N14LoadoutItemCig
+  category: Items
+  cost: 1
+  items:
+    - N14Cigarette

--- a/Resources/Prototypes/_Nuclear14/Loadouts/outerClothing.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/outerClothing.yml
@@ -81,7 +81,36 @@
   cost: 3
   items:
     - N14ClothingOuterCoatLeatherDuster
-    
+
+- type: loadout
+  id: N14ClothingOuterCoatLeatherJacket
+  category: Outer
+  cost: 3
+  items:
+    - N14ClothingOuterCoatLeatherJacket 
+
+- type: loadout
+  id: N14ClothingOuterCoatLeatherCoat
+  category: Outer
+  cost: 3
+  items:
+    - N14ClothingOuterCoatLeatherCoat
+
+- type: loadout
+  id: N14ClothingOuterTownCoat
+  category: Outer
+  cost: 3
+  items:
+    - N14ClothingOuterTownCoat 
+
+- type: loadout
+  id: N14ClothingOuterTownMediumCoat
+  category: Outer
+  cost: 5
+  items:
+    - N14ClothingOuterTownMediumCoat
+
+
 - type: loadout
   id: N14LoadoutOuterLeatherArmor
   category: Outer

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Rangers/ranger_recruit.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Rangers/ranger_recruit.yml
@@ -21,7 +21,7 @@
 - type: startingGear
   id: RangerRecruitGear
   equipment:
-    head: N14ClothingHeadHatCowboyRang
+    head: N14ClothingHeadHatCowboyBrown
     back: N14ClothingBackpackMilitaryFilled
     jumpsuit: N14ClothingUniformRangerV1
     ears: N14ClothingHeadsetNCR

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/Townmechanic.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/Townmechanic.yml
@@ -22,7 +22,7 @@
     shoes: N14ClothingShoesBlack
     id: N14IDPassportTownsfolk
     belt: N14ClothingBeltUtilityFilled
-    head: ClothingHeadHatWeldingMaskFlame
+    eyes: N14ClothingEyesGlassesWelding
   innerClothingSkirt: N14ClothingUniformJumpskirtFalloutBlack
   satchel: N14ClothingBackpackSatchelWastelanderFilled
   duffelbag: N14ClothingBackpackDuffelFilled

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/Townshopkeeper.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/Townshopkeeper.yml
@@ -18,9 +18,10 @@
   id: TownShopkeeperGear
   equipment:
     jumpsuit: N14ClothingUniformJumpsuitMerchant
-    back: N14ClothingBackpackWastelanderFilled # N14TODO: Trader bag
+    back: N14ClothingBackpackShopkeeperFilled
     shoes: N14ClothingShoesBlack
     id: N14IDPassportTownsfolk
+    pocket1: N14CurrencyCap50 
   innerClothingSkirt: N14ClothingUniformJumpskirtFalloutBlack
   satchel: N14ClothingBackpackSatchelWastelanderFilled
   duffelbag: N14ClothingBackpackDuffelFilled  # N14TODO: Trader bag

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/towndeputy.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/towndeputy.yml
@@ -23,14 +23,13 @@
   equipment:
     jumpsuit: N14ClothingUniformJumpsuitCowboyBrown
     head: N14ClothingHeadHatDeputy
+    eyes: N14ClothingEyesSunGlasses 
     back: N14ClothingBackpackDeputyFilled
     shoes: N14ClothingShoesBlack
     id: N14IDBadgeTownDeputy
     outerClothing: N14ClothingOuterPoliceVest
-    belt: ClothingBelt9mmfilled
+    belt: ClothingBeltRevolverfilled
     pocket1: RadioHandheld
-    pocket2: N14WeaponRevolver10mm
-    suitstorage: N14WeaponLeverCarbine
   satchel: N14ClothingBackpackSatchelDeputyFilled
   duffelbag: N14ClothingBackpackDuffelDeputyFilled
 

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/townmayor.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/townmayor.yml
@@ -22,7 +22,6 @@
     jumpsuit: N14ClothingUniformJumpsuitCheckered
     back: N14ClothingBackpackMayorFilled
     shoes: N14ClothingShoesBrown
-    belt: N14WeaponPistolChinese
     id: N14IDBadgeTownMayor
     pocket1: RadioHandheld
   innerClothingSkirt: N14ClothingUniformJumpskirtFalloutBlack

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/townsheriff.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/townsheriff.yml
@@ -27,12 +27,11 @@
     back: N14ClothingBackpackSheriffFilled
     shoes: N14ClothingBootsCowboy
     head: N14ClothingHeadHatSheriff
+    eyes: N14ClothingEyesSunGlasses 
     id: N14IDBadgeTownSheriff
     outerClothing: N14ClothingOuterSheriffVest
     belt: ClothingBeltRevolverfilled
     pocket1: RadioHandheld
-    pocket2: N14WeaponHunterRevolver
-    suitstorage: N14WeaponLeverRifle
   satchel: N14ClothingBackpackSatchelSheriffFilled
   duffelbag: N14ClothingBackpackDuffelSheriffFilled
 

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/VaultDwellers/vaultsecurity.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/VaultDwellers/vaultsecurity.yml
@@ -32,10 +32,9 @@
     jumpsuit: N14ClothingUniformJumpsuitVault14
     back: N14ClothingBackpackVaultSecurityFilled
     shoes: N14ClothingBootsBlack
-    eyes: ClothingEyesGlassesSunglasses
-    head: ClothingHeadHelmetRiot
+    eyes: N14ClothingEyesSunGlasses
+    head: N14ClothingHeadHatVaultRiot
     outerClothing: N14ClothingOuterVaultSecVest
-    id: N14VaultSecurityPDA
     pocket1: N14WeaponPistol10mm
     ears: N14ClothingHeadsetVaultSecurity
     belt: N14ClothingBeltPoliceFilled


### PR DESCRIPTION
SPAWN LOADOUTS:
Sheriff and deputy now spawn with Magnum revolvers, this allows them too be able to use revolvers in a viable form of PVP combat. as the 9mm and 10mm revolvers were much too underpowered.  (They also now have awesome shades)

Shopkeeper now spawns with a hiking backpack as its more tradery, aswell as 50 caps

Mechanic now has welding goggles

Mayor now does not have a gun, he will have a gun mapped in his safe. 

CHARACTER CREATION LOADOUTS:
Three varities of the "Ranger" Cowboy hats were renamed and re-descripted as they were simply normal cowboy hats and the players wished too wear them. They were also added too Loadouts

Prescription glasses were fixed and added too loadouts

Animal masks were added too items

Various leather jackets and towncoats were added too outerwear

The 9mm Revolver and Kitchen knife were added too Items. Each is 5 points. This will allow players too be able too survive the begining of the round.

MECHANICAL FIXES:
All knives are now throwable, with the butcher cleaver doing more damage as its slower.

Prescription glasses now work

Leather coats and armors were given 5 blunt and 10 heat protection. 

A few item descriptions updated. 