### PR TITLE
replaces HashSet with List for WelderRefinable

### DIFF
--- a/Content.Server/Construction/Components/WelderRefinableComponent.cs
+++ b/Content.Server/Construction/Components/WelderRefinableComponent.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Tools;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Content.Shared.Storage;
 
 namespace Content.Server.Construction.Components
 {
@@ -11,12 +12,12 @@ namespace Content.Server.Construction.Components
     public sealed partial class WelderRefinableComponent : Component
     {
         [DataField("refineResult")]
-        public HashSet<string>? RefineResult = new();
+        public List<EntitySpawnEntry>? RefineResult = new();
 
         [DataField("refineTime")]
         public float RefineTime = 2f;
 
-        [DataField("qualityNeeded", customTypeSerializer:typeof(PrototypeIdSerializer<ToolQualityPrototype>))]
+        [DataField("qualityNeeded", customTypeSerializer: typeof(PrototypeIdSerializer<ToolQualityPrototype>))]
         public string QualityNeeded = "Welding";
     }
 }

--- a/Content.Server/Construction/Components/WelderRefinableComponent.cs
+++ b/Content.Server/Construction/Components/WelderRefinableComponent.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Tools;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Content.Shared.Storage;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.Construction.Components
 {
@@ -11,13 +12,13 @@ namespace Content.Server.Construction.Components
     [RegisterComponent]
     public sealed partial class WelderRefinableComponent : Component
     {
-        [DataField("refineResult")]
-        public List<EntitySpawnEntry>? RefineResult = new();
+        [DataField]
+        public List<EntitySpawnEntry> RefineResult = new();
 
-        [DataField("refineTime")]
+        [DataField]
         public float RefineTime = 2f;
 
-        [DataField("qualityNeeded", customTypeSerializer: typeof(PrototypeIdSerializer<ToolQualityPrototype>))]
-        public string QualityNeeded = "Welding";
+        [DataField]
+        public ProtoId<ToolQualityPrototype> QualityNeeded = "Welding";
     }
 }

--- a/Content.Server/Construction/RefiningSystem.cs
+++ b/Content.Server/Construction/RefiningSystem.cs
@@ -40,14 +40,9 @@ namespace Content.Server.Construction
             EntityManager.DeleteEntity(uid);
 
             // spawn each result after refine
-            foreach (var result in component.RefineResult!)
+            foreach (var ent in EntitySpawnCollection.GetSpawns(component.RefineResult!))
             {
-                var droppedEnt = EntityManager.SpawnEntity(result, resultPosition);
-
-                // TODO: If something has a stack... Just use a prototype with a single thing in the stack.
-                // This is not a good way to do it.
-                if (TryComp<StackComponent>(droppedEnt, out var stack))
-                    _stackSystem.SetCount(droppedEnt, 1, stack);
+                Spawn(ent, resultPosition);
             }
         }
     }

--- a/Content.Server/Construction/RefiningSystem.cs
+++ b/Content.Server/Construction/RefiningSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Stacks;
 using Content.Shared.Tools;
 using Robust.Shared.Serialization;
+using Content.Shared.Storage;
 using SharedToolSystem = Content.Shared.Tools.Systems.SharedToolSystem;
 
 namespace Content.Server.Construction

--- a/Content.Server/Construction/RefiningSystem.cs
+++ b/Content.Server/Construction/RefiningSystem.cs
@@ -14,7 +14,6 @@ namespace Content.Server.Construction
     public sealed class RefiningSystem : EntitySystem
     {
         [Dependency] private readonly SharedToolSystem _toolSystem = default!;
-        [Dependency] private readonly StackSystem _stackSystem = default!;
         public override void Initialize()
         {
             base.Initialize();
@@ -40,7 +39,7 @@ namespace Content.Server.Construction
             EntityManager.DeleteEntity(uid);
 
             // spawn each result after refine
-            foreach (var ent in EntitySpawnCollection.GetSpawns(component.RefineResult!))
+            foreach (var ent in EntitySpawnCollection.GetSpawns(component.RefineResult))
             {
                 Spawn(ent, resultPosition);
             }

--- a/Resources/Prototypes/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/shards.yml
@@ -89,7 +89,7 @@
     color: "#bbeeff"
   - type: WelderRefinable
     refineResult:
-    - SheetGlass1
+    - id: SheetGlass1
   - type: DamageUserOnTrigger
     damage:
       types:
@@ -120,8 +120,8 @@
     color: "#96cdef"
   - type: WelderRefinable
     refineResult:
-    - SheetGlass1
-    - PartRodMetal1
+    - id: SheetGlass1
+    - id: PartRodMetal1
   - type: DamageUserOnTrigger
     damage:
       types:
@@ -152,8 +152,8 @@
     color: "#FF72E7"
   - type: WelderRefinable
     refineResult:
-    - SheetGlass1
-    - SheetPlasma1
+    - id: SheetGlass1
+    - id: SheetPlasma1
   - type: DamageUserOnTrigger
     damage:
       types:
@@ -186,8 +186,8 @@
     color: "#8eff7a"
   - type: WelderRefinable
     refineResult:
-    - SheetGlass1
-    - SheetUranium1
+    - id: SheetGlass1
+    - id: SheetUranium1
   - type: DamageUserOnTrigger
     damage:
       types:
@@ -221,8 +221,8 @@
     color: "#e0aa36"
   - type: WelderRefinable
     refineResult:
-    - SheetGlass1
-    - SheetBrass1
+    - id: SheetGlass1
+    - id: SheetBrass1
   - type: DamageUserOnTrigger
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Misc/broken_bottle.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/broken_bottle.yml
@@ -28,4 +28,4 @@
   - type: SpaceGarbage
   - type: WelderRefinable
     refineResult:
-    - SheetGlass1
+    - id: SheetGlass1

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -68,7 +68,7 @@
   - type: SpaceGarbage
   - type: WelderRefinable
     refineResult:
-    - SheetGlass1
+    - id: SheetGlass1
 
 - type: entity
   parent: BaseLightbulb
@@ -276,8 +276,8 @@
     node: icon
   - type: WelderRefinable
     refineResult:
-    - SheetGlass1
-    - ShardCrystalCyan
+    - id: SheetGlass1
+    - id: ShardCrystalCyan1
 
 - type: entity
   parent: LightTubeCrystalCyan
@@ -296,8 +296,8 @@
     node: icon
   - type: WelderRefinable
     refineResult:
-    - SheetGlass1
-    - ShardCrystalBlue
+    - id: SheetGlass1
+    - id: ShardCrystalBlue1
 
 - type: entity
   parent: LightTubeCrystalCyan
@@ -316,8 +316,8 @@
     node: icon
   - type: WelderRefinable
     refineResult:
-    - SheetGlass1
-    - ShardCrystalPink
+    - id: SheetGlass1
+    - id: ShardCrystalPink1
 
 - type: entity
   parent: LightTubeCrystalCyan
@@ -336,8 +336,8 @@
     node: icon
   - type: WelderRefinable
     refineResult:
-    - SheetGlass1
-    - ShardCrystalOrange
+    - id: SheetGlass1
+    - id: ShardCrystalOrange1
 
 - type: entity
   parent: LightTubeCrystalCyan
@@ -356,8 +356,8 @@
     node: icon
   - type: WelderRefinable
     refineResult:
-    - SheetGlass1
-    - ShardCrystalRed
+    - id: SheetGlass1
+    - id: ShardCrystalRed1
 
 - type: entity
   parent: LightTubeCrystalCyan
@@ -376,5 +376,5 @@
     node: icon
   - type: WelderRefinable
     refineResult:
-    - SheetGlass1
-    - ShardCrystalGreen
+    - id: SheetGlass1
+    - id: ShardCrystalGreen1

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -277,7 +277,7 @@
   - type: WelderRefinable
     refineResult:
     - id: SheetGlass1
-    - id: ShardCrystalCyan1
+    - id: ShardCrystalCyan
 
 - type: entity
   parent: LightTubeCrystalCyan
@@ -297,7 +297,7 @@
   - type: WelderRefinable
     refineResult:
     - id: SheetGlass1
-    - id: ShardCrystalBlue1
+    - id: ShardCrystalBlue
 
 - type: entity
   parent: LightTubeCrystalCyan
@@ -317,7 +317,7 @@
   - type: WelderRefinable
     refineResult:
     - id: SheetGlass1
-    - id: ShardCrystalPink1
+    - id: ShardCrystalPink
 
 - type: entity
   parent: LightTubeCrystalCyan
@@ -337,7 +337,7 @@
   - type: WelderRefinable
     refineResult:
     - id: SheetGlass1
-    - id: ShardCrystalOrange1
+    - id: ShardCrystalOrange
 
 - type: entity
   parent: LightTubeCrystalCyan
@@ -357,7 +357,7 @@
   - type: WelderRefinable
     refineResult:
     - id: SheetGlass1
-    - id: ShardCrystalRed1
+    - id: ShardCrystalRed
 
 - type: entity
   parent: LightTubeCrystalCyan
@@ -377,4 +377,4 @@
   - type: WelderRefinable
     refineResult:
     - id: SheetGlass1
-    - id: ShardCrystalGreen1
+    - id: ShardCrystalGreen

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Consumable/Food/pre-warfood.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Consumable/Food/pre-warfood.yml
@@ -294,7 +294,7 @@
     state: trash
   - type: WelderRefinable
     refineResult:
-    - SheetSteel1
+    - id: SheetSteel1
   - type: PhysicalComposition
     materialComposition:
       Steel: 100

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/junk.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/junk.yml
@@ -63,7 +63,7 @@
     - Trash
   - type: WelderRefinable
     refineResult:
-    - SheetGlass1
+    - id: SheetGlass1
   - type: PhysicalComposition
   materialComposition:
       Glass: 50
@@ -75,7 +75,7 @@
   components:
   - type: WelderRefinable
     refineResult:
-    - SheetGlass1
+    - id: SheetGlass1
   - type: PhysicalComposition
   materialComposition:
       Glass: 50
@@ -87,7 +87,7 @@
   components:
   - type: WelderRefinable
     refineResult:
-    - MaterialWoodPlank1
+    - id: MaterialWoodPlank1
   - type: PhysicalComposition
     materialComposition:
       Wood: 50
@@ -99,7 +99,7 @@
   components:
   - type: WelderRefinable
     refineResult:
-    - SheetPlastic1
+    - id: SheetPlastic1
   - type: PhysicalComposition
     materialComposition:
       Plastic: 50
@@ -111,7 +111,7 @@
   components:
   - type: WelderRefinable
     refineResult:
-    - SheetSteel1
+    - id: SheetSteel1
   - type: PhysicalComposition
     materialComposition:
       Steel: 50
@@ -123,7 +123,7 @@
   components:
   - type: WelderRefinable
     refineResult:
-    - IngotAluminum1
+    - id: IngotAluminum1
   - type: PhysicalComposition
     materialComposition:
       Aluminum: 50
@@ -135,7 +135,7 @@
   components:
   - type: WelderRefinable
     refineResult:
-    - IngotLead1
+    - id: IngotLead1
   - type: PhysicalComposition
     materialComposition:
       Lead: 50
@@ -147,7 +147,7 @@
   components:
   - type: WelderRefinable
     refineResult:
-    - SheetPlastic1
+    - id: SheetPlastic1
   - type: PhysicalComposition
     materialComposition:
       Plastic: 50
@@ -170,7 +170,7 @@
           Quantity: 50
   - type: WelderRefinable
     refineResult:
-    - SheetPlastic1
+    - id: SheetPlastic1
   - type: PhysicalComposition
     materialComposition:
       Plastic: 100
@@ -250,8 +250,8 @@
     state: iron
   - type: WelderRefinable
     refineResult:
-    - id: SheetSteel
-      amount: 2
+    - id: SheetSteel1
+      amount: 1
       maxAmount: 3
       prob: 0.5
       orGroup: Metal

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/junk.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/junk.yml
@@ -250,7 +250,11 @@
     state: iron
   - type: WelderRefinable
     refineResult:
-    - SheetSteel1
+    - id: SheetSteel
+      amount: 2
+      maxAmount: 3
+      prob: 0.5
+      orGroup: Metal
 
 - type: entity
   parent: [ N14JunkItemBaseAluminum , BoxCardboard ]

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Medical/chemicals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Medical/chemicals.yml
@@ -31,7 +31,7 @@
     emptySpriteName: stimpak0
   - type: WelderRefinable
     refineResult:
-    - SheetPlastic1
+    - id: SheetPlastic1
   - type: Tag
     tags:
     - Syringe
@@ -69,7 +69,7 @@
     emptySpriteName: stimpak0
   - type: WelderRefinable
     refineResult:
-    - SheetPlastic1
+    - id: SheetPlastic1
   - type: Tag
     tags:
     - Syringe
@@ -427,7 +427,7 @@
     fillBaseName: radawayphial
   - type: WelderRefinable
     refineResult:
-    - MaterialGlass
+    - id: SheetGlass1
   - type: PhysicalComposition
     materialComposition:
       Glass: 50
@@ -472,7 +472,7 @@
     emptySpriteName: radawayphial
   - type: WelderRefinable
     refineResult:
-    - MaterialGlass
+    - id: SheetGlass1
   - type: PhysicalComposition
     materialComposition:
       Glass: 50


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR aims to turn a HashSet string? into List EntitySpawnEntry? for better and more detailed entry for junk system.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Update RefiningSystem.cs to spawn items properly via EntitiySpawnEntry
- [x] Replace all instances of `WelderRefinableComponent` to match it's new format

---