### PR TITLE
Updates NCRRangerVeteran RoleTimeRequirement

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/republic_ranger_veteran.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/republic_ranger_veteran.yml
@@ -5,9 +5,9 @@
   description: job-description-ncr-ranger-veteran
   playTimeTracker: NCRRangerVeteran
   requirements:
-    - !type:DepartmentTimeRequirement
-      department: NCR
-      time: 72000 # 20 hours as NCR
+    - !type:RoleTimeRequirement
+      role: NCRRanger
+      time: 216000 # 60 hours as NCR
     - !type:WhitelistRequirement
   weight: 10
   startingGear: NCRRangerVeteranGear


### PR DESCRIPTION
# Description

I have previously put placeholders in place because I believed that the people I would whitelist would stick to ranger to learn the ropes of the role and then slowly get to the veteran once they are good what they do.
Instead just about every each person ignored normal ranger and just fought over the veteran role... So I am more or less forced to put a proper RoleTimeRequirement for the vetie to make sure the veterans are actually veteran.

This will also make the role feel more earned as you actually need to be pretty veteran to be the veteran :).
(Times are based off of Sec Senior times)

---