### PR TITLE
The Zomegerega update

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
@@ -69,13 +69,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 400
-      behaviors:
-        - !type:DoActsBehavior
-          acts: [ "Destruction" ]
-    - trigger:
-        !type:DamageTrigger
-        damage: 50
+        damage: 250
       behaviors:
       - !type:PlaySoundBehavior
         sound:

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
@@ -1,5 +1,5 @@
 # See basemob.yml for parent entities
-#MARK: Molerat
+#MARK: Molerat #Oh hi Mark.
 - type: entity
   name: molerat
   id: N14MobMolerat
@@ -30,6 +30,8 @@
     thresholds:
       0: Alive
       50: Dead
+  - type: Stamina
+    critThreshold: 60
   - type: DamageStateVisuals
     states:
       Alive:
@@ -114,6 +116,9 @@
     damage:
       groups:
         Brute: 5
+  - type: Speech
+    speechVerb: Canine
+    speechSounds: Vulpkanin
   - type: Reproductive
     breedChance: 0.05
     birthPopup: reproductive-birth-popup
@@ -144,7 +149,7 @@
       sprite: _Nuclear14/Mobs/Animals/gecko.rsi
   - type: MovementSpeedModifier
     baseWalkSpeed : 3
-    baseSprintSpeed : 3.6
+    baseSprintSpeed : 4
   - type: Fixtures
     fixtures:
       fix1:
@@ -274,6 +279,9 @@
         reagents:
         - ReagentId: NightstalkerVenom
           Quantity: 5
+  - type: Speech
+    speechVerb: Canine
+    speechSounds: Vulpkanin
   - type: Udder
     reagentId: NightstalkerVenom
     quantityPerUpdate: 1
@@ -377,6 +385,9 @@
   - type: MeleeChemicalInjector
     solution: melee
     transferAmount: 1.5
+  - type: Speech
+    speechVerb: Canine
+    speechSounds: Vulpkanin
   - type: Reproductive
     breedChance: 0.05
     birthPopup: reproductive-laid-egg-popup
@@ -422,7 +433,13 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      500: Dead
+      550: Dead
+  - type: Stamina
+    critThreshold: 250
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      275: 0.7
+      450: 0.5
   - type: Butcherable
     spawned:
     - id: N14MaterialYaoguaiHide
@@ -452,7 +469,7 @@
     range: 1.25
   - type: MovementSpeedModifier
     baseWalkSpeed : 3
-    baseSprintSpeed : 3.6
+    baseSprintSpeed : 4.75
   - type: NoSlip
   - type: Reproductive
     breedChance: 0.05
@@ -504,6 +521,8 @@
       0: Alive
       500: Critical
       600: Dead
+  - type: Stamina
+    critThreshold: 250
   - type: SlowOnDamage
     speedModifierThresholds:
       250: 0.7
@@ -528,7 +547,7 @@
       types:
         Slash: 15
         Structural: 5
-    range: 1.5
+    range: 1.75
   - type: MovementSpeedModifier
     baseWalkSpeed : 4
     baseSprintSpeed : 5
@@ -550,8 +569,7 @@
     prob: 0.5
     makeSentient: true
     name: deathclaw
-    description: |
-      You're a smart killer. Use tactics to kill everyone.
+    description: You're a smart killer. Use tactics to hunt and stalk.
   - type: NoSlip
   - type: Reproductive
     breedChance: 0.05
@@ -601,6 +619,8 @@
       0: Alive
       750: Critical
       900: Dead
+  - type: Stamina
+    critThreshold: 350
   - type: DamageStateVisuals
     states:
       Alive:
@@ -680,6 +700,8 @@
         Base: brahmin-2
       Dead:
         Base: dead
+  - type: Stamina
+    critThreshold: 200
   - type: Tag
     tags:
     - Brahmin
@@ -744,6 +766,8 @@
         Base: bighorner
       Dead:
         Base: dead
+  - type: Stamina
+    critThreshold: 200
   - type: Tag
     tags:
     - Bighorner
@@ -807,6 +831,8 @@
         Base: radstag
       Dead:
         Base: dead
+  - type: Stamina
+    critThreshold: 200
   - type: Tag
     tags:
     - Radstag
@@ -912,6 +938,8 @@
         Base: iguana
       Dead:
         Base: dead
+  - type: Stamina
+    critThreshold: 20
   # - type: Butcherable
     # spawned:
     # - id: N14FoodMeatRadchicken

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/basemob.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/basemob.yml
@@ -41,8 +41,6 @@
     thresholds:
       0: Alive
       15: Dead
-  - type: Stamina
-    critThreshold: 15
   - type: MovementAlwaysTouching
   - type: Appearance
   - type: DamageStateVisuals
@@ -95,8 +93,6 @@
     thresholds:
       0: Alive
       15: Dead
-  - type: Stamina
-    critThreshold: 15
   - type: DamageStateVisuals
     states:
       Alive:

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/insects.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/insects.yml
@@ -35,6 +35,8 @@
         Base: dead
       Dead:
         Base: dead
+  - type: Stamina
+    critThreshold: 20
   - type: Bloodstream
     bloodMaxVolume: 50
   - type: ReplacementAccent
@@ -88,8 +90,6 @@
     thresholds:
       0: Alive
       100: Dead
-  - type: Stamina
-    critThreshold: 10
   - type: DamageStateVisuals
     states:
       Alive:
@@ -196,6 +196,8 @@
     thresholds:
       0: Alive
       15: Dead
+  - type: Stamina
+    critThreshold: 20
   - type: DamageStateVisuals
     states:
       Alive:
@@ -248,8 +250,6 @@
     thresholds:
       0: Alive
       150: Dead
-  - type: Stamina
-    critThreshold: 10
   - type: DamageStateVisuals
     states:
       Alive:
@@ -368,6 +368,8 @@
         Base: cazador
       Dead:
         Base: dead
+  - type: Stamina
+    critThreshold: 20
   - type: Bloodstream
     bloodMaxVolume: 50
   - type: MeleeWeapon

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/Species/ghouls.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/Species/ghouls.yml
@@ -79,7 +79,6 @@
       0: Alive
       100: Critical
       150: Dead
-  # - type: Special
   - type: Special
 
 - type: entity
@@ -158,6 +157,29 @@
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: GhoulGlowing
+  - type: PassiveDamage #Little more regen, +25% more.
+    allowedStates:
+    - Alive
+    damageCap: 100
+    damage:
+      types:
+        Heat: -1.25
+        Radiation: 0.08
+      groups:
+        Brute: -1.25
+        Toxin: -0.125
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      100: Critical
+      150: Dead
+  - type: PointLight
+    radius: 2
+    energy: 2
+    color: "#4CBB17FF"
+  - type: RadiationSource
+    intensity: 0.5
+    slope: 0.25
   - type: Special
 
 - type: entity

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/turrets.yml
@@ -29,7 +29,7 @@
                 SheetSteel1:
                   min: 2
                   max: 4
-        
+
 - type: entity
   parent: N14WeaponTurretBroken
   id: N14WeaponTurretMobileBroken
@@ -108,7 +108,7 @@
       useKey: false
     # TODO: Power ammo provider?
     - type: BallisticAmmoProvider
-      proto: CartridgeCaselessRifle
+      proto: N14CartridgePistol10 
       capacity: 500
     - type: HTN
       rootTask:
@@ -120,7 +120,7 @@
           path: /Audio/Effects/double_beep.ogg
     - type: MouseRotator
       angleTolerance: 5
-      rotationSpeed: 180
+      rotationSpeed: 90
       simple4DirMode: false
     - type: NoRotateOnInteract
     - type: NoRotateOnMove
@@ -265,7 +265,7 @@
   - type: NpcFactionMember
     factions:
     - BrotherhoodMidwestSecureArea
-    
+
 - type: entity
   parent: N14BaseWeaponTurretMeta
   id: N14WeaponTurretBrotherhoodWashingtonSpawnpoint
@@ -274,7 +274,7 @@
   - type: NpcFactionMember
     factions:
     - BrotherhoodWashingtonSecureArea
-    
+
 - type: entity
   parent: N14BaseWeaponTurretMeta
   id: N14WeaponTurretVaultSpawnpoint
@@ -283,7 +283,7 @@
   - type: NpcFactionMember
     factions:
     - VaultSecureArea
-    
+
 - type: entity
   parent: N14BaseWeaponTurretMeta
   id: N14WeaponTurretNCRSpawnpoint

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/axes.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/axes.yml
@@ -134,3 +134,5 @@
     slots:
     - Back
     - suitStorage
+  - type: Item
+    size: Ginormous

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/doors.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/doors.yml
@@ -48,8 +48,16 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 200
+        damage: 500
       behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 1
+            max: 1
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: Occluder
@@ -74,8 +82,16 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
+        damage: 250
       behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: WoodDestroy
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          MaterialWoodPlank:
+            min: 1
+            max: 1
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: Construction
@@ -94,7 +110,7 @@
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]
-      
+
 - type: entity
   parent: N14DoorMakeshift
   id: N14DoorWoodHousePainted
@@ -140,7 +156,7 @@
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]
-      
+
 - type: entity
   parent: N14DoorMakeshift
   id: N14DoorWoodInterior
@@ -167,7 +183,7 @@
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]
-      
+
 - type: entity
   parent: BaseMaterialDoor
   id: N14DoorRoomRepaired
@@ -181,7 +197,7 @@
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]
-      
+
 - type: entity
   parent: N14DoorMakeshift
   id: N14DoorWoodSecure
@@ -201,7 +217,7 @@
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
-      
+
 - type: entity
   parent: N14DoorWoodSecure
   id: N14DoorWoodSecureNCR
@@ -262,7 +278,7 @@
     enabled: false
   - type: Damageable
     damageContainer: StructuralInorganic
-    damageModifierSet: PerforatedMetallic
+    damageModifierSet: Metallic
 
 - type: entity
   parent: N14DoorCellMetal
@@ -287,7 +303,7 @@
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]
-      
+
 - type: entity
   parent: N14DoorMetalReinforced
   id: N14DoorMetalSecure
@@ -299,7 +315,7 @@
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]
-      
+
 - type: entity
   parent: N14DoorCellMetal
   id: N14DoorSpikedGate
@@ -442,7 +458,7 @@
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]
-      
+
 - type: entity
   parent: N14DoorGlassBroken
   id: N14DoorGlassStoreBroken
@@ -454,7 +470,7 @@
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]
-      
+
 # Other
 - type: entity
   parent: BaseMaterialDoor
@@ -499,7 +515,7 @@
           MaterialCloth1:
             min: 0
             max: 2
-      
+
 - type: entity
   parent: N14DoorTentflap
   id: N14DoorTentLeatherflap
@@ -512,7 +528,7 @@
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]
-      
+
 - type: entity
   parent: N14DoorTentflap
   id: N14DoorTentClothflap

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Storage/barrels.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Storage/barrels.yml
@@ -45,7 +45,7 @@
         solution: barrel
     - trigger:
         !type:DamageTrigger
-        damage: 10
+        damage: 50
       behaviors:
       - !type:SpillBehavior
         solution: barrel
@@ -80,7 +80,7 @@
   - type: Sprite
     sprite: _Nuclear14/Structures/Storage/barrels.rsi
     state: black-closed
-    
+
 - type: entity
   parent: N14BaseBarrel
   id: N14BlueBarrel
@@ -90,7 +90,7 @@
   - type: Sprite
     sprite: _Nuclear14/Structures/Storage/barrels.rsi
     state: blue-closed
-    
+
 - type: entity
   parent: N14BaseBarrel
   id: N14RedBarrel
@@ -103,7 +103,7 @@
   - type: Explosive
     explosionType: Default
     totalIntensity: 120 # ~ 5 tile radius
-    
+
 - type: entity
   parent: N14BaseBarrel
   id: N14YellowBarrel
@@ -128,7 +128,7 @@
   - type: Sprite
     sprite: _Nuclear14/Structures/Storage/barrels.rsi
     state: black-open
-    
+
 - type: entity
   parent: N14BaseBarrelOpen
   id: N14BlueBarrelOpen
@@ -139,7 +139,7 @@
   - type: Sprite
     sprite: _Nuclear14/Structures/Storage/barrels.rsi
     state: blue-open
-    
+
 - type: entity
   parent: N14BaseBarrelOpen
   id: N14RedBarrelOpen
@@ -150,7 +150,7 @@
   - type: Sprite
     sprite: _Nuclear14/Structures/Storage/barrels.rsi
     state: red-open
-    
+
 - type: entity
   parent: N14BaseBarrelOpen
   id: N14YellowBarrelOpen
@@ -164,7 +164,7 @@
   - type: RadiationSource
     intensity: 1
     slope: 1
-    
+
 # Full barrels
 - type: entity
   parent: N14BlackBarrelOpen
@@ -176,7 +176,7 @@
     sprite: _Nuclear14/Structures/Storage/barrels.rsi
     state: black-full
     # TODO - fill with some sort of waste product? Maybe just dirty water.
-    
+
 - type: entity
   parent: N14RedBarrelOpen
   id: N14RedBarrelFull
@@ -201,7 +201,7 @@
   - type: Explosive
     explosionType: Default
     totalIntensity: 120 # ~ 5 tile radius
-    
+
 - type: entity
   parent: N14YellowBarrelOpen
   id: N14YellowBarrelFull
@@ -220,6 +220,19 @@
     energy: 1.6
     color: "#3db83b"
     castShadows: false
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 1000
+      behaviors:
+      - !type:SpillBehavior
+        solution: barrel
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
     # TODO - fill with some sort of radioactive waste reagent.
 
 # Burning Barrels
@@ -246,7 +259,7 @@
         layer:
         - MidImpassable
         - LowImpassable
-    
+
 - type: entity
   parent: N14BurningBarrel
   id: N14BurningBarrelLit

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_nco.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_nco.yml
@@ -15,6 +15,7 @@
   access:
   - NCR
   - NCRNCO
+  - NCRMP
   special:
   - !type:AddComponentSpecial
     components:
@@ -33,7 +34,7 @@
     belt: ClothingBeltNCR
     outerClothing: N14ClothingOuterNCRVest
     pocket1: NCRNCOloadoutkits
-    pocket2: RadioHandheld 
+    pocket2: RadioHandheld
     id: N14IDNCRDogtagNCO
   innerClothingSkirt: N14ClothingOfficerUniformNCR #placeholder
   satchel: N14ClothingBackpackSatchelNCRFilled

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/republic_ranger.yml
@@ -9,7 +9,6 @@
       department: NCR
       time: 36000 # 10 hours as NCR
     - !type:WhitelistRequirement
-  weight: 5
   startingGear: NCRRangerGear
   icon: JobIconSecurityOfficer
   requireAdminNotify: true
@@ -17,6 +16,7 @@
   access:
   - NCR
   - NCRNCO
+  - NCRMP
   - NCRRanger
   special:
   - !type:AddComponentSpecial

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/republic_ranger_veteran.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/republic_ranger_veteran.yml
@@ -9,7 +9,6 @@
       role: NCRRanger
       time: 216000 # 60 hours as NCR
     - !type:WhitelistRequirement
-  weight: 10
   startingGear: NCRRangerVeteranGear
   icon: "JobIconHeadOfSecurity"
   requireAdminNotify: true


### PR DESCRIPTION
MOBS:

All mobs have recieved stamina values according too their general size, with the highest being the Albino Deathclaw, and the lowest being Bloatflies, Cazadors, and Radroaches. 

Deathclaws have aswell recieved a .25 increase in attack range

Yao guai are now much more dangers, having a few more hitpoints, and a major increase too speed, aswell as being slowed down at damage thresholds like deathclaws.

Geckos have also recieved a minor speed increase

STRUCTURES:

Barrels: now have 50 HP

Radiation barrels are now immortal, this will be replaced with the ability too break once more, but with the release of toxic waste, (perfect for glowing ghoul trolling)

Wooden doors now have 300 HP, while metal doors have 500

Aswell they now have breaking sounds and drop materials

Trees now are much hardier, now standing at 250 health, they can be easily chopped with chopping obejcts such as axes and knives, while itll take a bit with a club or gun.

GLOWING GHOULS:

MEGA GLOWING GHOUL UPDATE.

Glowing ghouls now need radaway and have regeneration abilities like normal ghouls, though they gain rad damage 25% faster than other ghouls, and heal 25% faster. 

Glowing ghouls now GLOW bright lucious green

Glowing ghouls now emmit a small amount of rads within a small radius around them (Roughly their glow radius) Be sure too stay away from them, being speciesist against glowing ones is now NON OPTIONAL. KEEP THEM AWAY.

Misc fixes:

Axes now are not pocket sized. and cannot be stored in a bag. 

NCR NCO and Ranger now have MP access

Turrets now shoot 10mm rounds, and the casings fly. 
