### PR TITLE
MEGA ARMOR REBALANCE 

### DIFF
--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -1,5 +1,8 @@
 ﻿[game]
 role_timers = false
+lobbyenabled = false
+map = "Wave1"
+map_rotation = false
 
 [gateway]
 generator_enabled = false

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/hats.yml
@@ -94,6 +94,7 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/headscarf.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/headscarf.rsi
+  - type: ClothingSpecialModifier
     perceptionModifier: 1
 
 # Army

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/hats.yml
@@ -56,7 +56,7 @@
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatgrey.rsi
   - type: ClothingSpecialModifier
-    charismaModifier: 1
+    perceptionModifier: 1
 
 - type: entity
   parent: ClothingHeadBase
@@ -69,7 +69,7 @@
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatgreybanded.rsi
   - type: ClothingSpecialModifier
-    charismaModifier: 1
+    perceptionModifier: 1
 
 - type: entity
   parent: ClothingHeadBase
@@ -82,7 +82,7 @@
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatcowboy.rsi
   - type: ClothingSpecialModifier
-    charismaModifier: 1
+    perceptionModifier: 1
 
 - type: entity
   parent: ClothingHeadBase
@@ -94,6 +94,7 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/headscarf.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/headscarf.rsi
+    perceptionModifier: 1
 
 # Army
 - type: entity
@@ -345,6 +346,7 @@
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhat.rsi
   - type: ClothingSpecialModifier
+    perceptionModifier: 1
     charismaModifier: 1
 
 - type: entity
@@ -358,6 +360,7 @@
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/rangerhatB.rsi
   - type: ClothingSpecialModifier
+    perceptionModifier: 1
     charismaModifier: 1
 
 # Tribal
@@ -371,6 +374,13 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHats/tribalhoodoutcast.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHats/tribalhoodoutcast.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.95
+        Heat: 0.9
 
 # Vault
 - type: entity
@@ -387,9 +397,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
+        Blunt: 0.9
+        Slash: 0.9
         Piercing: 0.9
+        Heat: 0.9
 
 # Craftable
 - type: entity
@@ -407,7 +418,8 @@
       coefficients:
         Blunt: 0.9
         Slash: 0.9
-        Heat: 0.9
+        Piercing: 0.95
+        Heat: 0.95
   - type: ClothingSpecialModifier
     strengthModifier: 1
 
@@ -425,7 +437,9 @@
     modifiers:
       coefficients:
         Blunt: 0.9
-        Slash: 0.8
-        Heat: 0.8
+        Slash: 0.9
+        Piercing: 0.95
+        Heat: 0.95
+        Poison: 0.8
   - type: ClothingSpecialModifier
-    strengthModifier: 1
+    enduranceModifier: 1

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/helmets.yml
@@ -80,8 +80,8 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
-  - type: ClothingSpecialModifier
-    strengthModifier: 1
+  - type: ExplosionResistance
+    damageCoefficient: 0.95
 
 - type: entity
   parent: ClothingHeadBase
@@ -93,10 +93,12 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
+        Blunt: 0.85
+        Slash: 0.85
         Piercing: 0.85
-        Heat: 0.8
+        Heat: 0.85
+  - type: ExplosionResistance
+    damageCoefficient: 0.9
 
 - type: entity
   parent: N14ClothingHeadHatBaseHelmetMetal
@@ -133,10 +135,12 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.8
-        Heat: 0.7
+        Blunt: 0.75
+        Slash: 0.75
+        Piercing: 0.75
+        Heat: 0.75
+  - type: ExplosionResistance
+    damageCoefficient: 0.85
 
 # Brotherhood of Steel
 - type: entity
@@ -207,7 +211,7 @@
 
 # Enclave
 - type: entity
-  parent: N14ClothingHeadHatBaseHelmetMetal
+  parent: N14ClothingHeadHatBaseHelmetMK2
   id: N14ClothingHeadHatEnclaveHelmet
   name: Enclave helmet
   description: A combat helmet worn by Enclave soldiers.
@@ -218,7 +222,7 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHelmets/enclavehelmet.rsi
 
 - type: entity
-  parent: N14ClothingHeadHatBaseHelmetMetal
+  parent: N14ClothingHeadHatBaseHelmetMK2
   id: N14ClothingHeadHatEnclaveHelmetHood
   name: Enclave hooded helmet
   description: A combat helmet worn by Enclave soldiers. This one has a hood covering it.
@@ -229,7 +233,7 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHelmets/enclavehelmethood.rsi
 
 - type: entity
-  parent: N14ClothingHeadHatBaseHelmetMK2
+  parent: N14ClothingHeadHatBaseHelmetmarine
   id: N14ClothingHeadHatEnclaveHelmetMarine
   name: Enclave marine helmet
   description: A marine helmet worn by elite Enclave soldiers.
@@ -283,7 +287,7 @@
     - HidesHair
 
 - type: entity
-  parent: N14ClothingHeadHatBaseHelmetmarine
+  parent: N14ClothingHeadHatBaseHelmetMK2
   id: N14ClothingHeadHatRangerHelmetOld
   name: old ranger combat helmet
   description: An old combat helmet, out of use around the time of the war.
@@ -297,7 +301,7 @@
     - HidesHair
 
 - type: entity
-  parent: N14ClothingHeadHatBaseHelmetmarine
+  parent: N14ClothingHeadHatBaseHelmetMK2
   id: N14ClothingHeadHatRangerHelmetDesert
   name: desert ranger combat helmet
   description: An U.S Marine Corps helmet, used by the legendary Desert Rangers.
@@ -311,7 +315,7 @@
     - HidesHair
 
 - type: entity
-  parent: N14ClothingHeadHatBaseHelmetmarine
+  parent: N14ClothingHeadHatBaseHelmetMK2
   id: N14ClothingHeadHatRangerHelmetPrice
   name: spider ranger combat helmet
   description: A customised riot helmet reminiscient of the more advanced riot helmets found in the Divide, sporting purple lenses over the traditional red or green and a pair of red fangs painted over the respirator. The back of the helmet has a the face of an albino spider painted over it.
@@ -325,7 +329,7 @@
     - HidesHair
 
 - type: entity
-  parent: N14ClothingHeadHatBaseHelmetmarine
+  parent: N14ClothingHeadHatBaseHelmetMK2
   id: N14ClothingHeadHatRangerHelmetElite
   name: elite ranger combat helmet
   description: An old combat helmet seen in the divide, repurposed for higher ranking Rangers.
@@ -334,19 +338,12 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHelmets/rangerhelmetelite.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHelmets/rangerhelmetelite.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.5
-        Slash: 0.4
-        Piercing: 0.5
-        Heat: 0.4
   - type: Tag
     tags:
     - HidesHair
 
 - type: entity
-  parent: N14ClothingHeadHatBaseHelmetmarine
+  parent: N14ClothingHeadHatBaseHelmetMK2
   id: N14ClothingHeadHatRangerHelmetEliteOld
   name: worn elite ranger combat helmet
   description: An old combat helmet seen in the divide, repurposed for higher ranking Rangers.
@@ -355,19 +352,12 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHelmets/rangerhelmetelite.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHelmets/rangerhelmetelite.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.7
-        Slash: 0.6
-        Piercing: 0.7
-        Heat: 0.6
   - type: Tag
     tags:
     - HidesHair
 
 - type: entity
-  parent: N14ClothingHeadHatBaseHelmetmarine
+  parent: N14ClothingHeadHatBaseHelmetMK2
   id: N14ClothingHeadHatRangerHelmetFox
   name: fox ranger combat helmet
   description: A customized and well-worn helmet of riot gear with parts of the suit reinforced with leather armor and slain Centurion armor pieces by the wearer. A sniper's veil is wrapped around the neck.
@@ -381,7 +371,7 @@
     - HidesHair
 
 - type: entity
-  parent: N14ClothingHeadHatBaseHelmetmarine
+  parent: N14ClothingHeadHatBaseHelmetMK2
   id: N14ClothingHeadHatRangerHelmetModif
   name: modified ranger combat helmet
   description: A thicker than average helmet worn by rangers out in the field.
@@ -390,13 +380,6 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHelmets/rangerhelmetmodif.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Head/FalloutHelmets/rangerhelmetmodif.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.65
-        Slash: 0.65
-        Piercing: 0.75
-        Heat: 0.65
   - type: Tag
     tags:
     - HidesHair

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/hoods.yml
@@ -26,10 +26,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.85
-        Slash: 0.85
-        Piercing: 0.9
-        Heat: 0.85
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.95
+        Heat: 0.9
   - type: Tag
     tags:
     - HidesHair
@@ -48,8 +48,8 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
+        Blunt: 0.95
+        Slash: 0.95
         Piercing: 0.95
         Heat: 0.9
   - type: Tag

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Mask/gasmasks.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Mask/gasmasks.yml
@@ -32,8 +32,9 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
+        Blunt: 0.95
+        Slash: 0.95
+        Radiation: 0.9
 
 # NCR Rangers, Vets
 
@@ -135,10 +136,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.95
+        Heat: 0.95
 
 - type: entity
   parent: ClothingMaskGas
@@ -178,10 +179,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.95
+        Heat: 0.95
 
 - type: entity
   parent: ClothingMaskGas
@@ -201,6 +202,8 @@
       coefficients:
         Blunt: 0.95
         Slash: 0.95
+        Piercing: 0.95
+        Heat: 0.95
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -223,10 +226,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.95
+        Heat: 0.95
 
 - type: entity
   parent: ClothingMaskGasCombat
@@ -245,7 +248,7 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.95
+        Heat: 0.95

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Mask/masks.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Mask/masks.yml
@@ -15,6 +15,7 @@
       coefficients:
         Blunt: 0.95
         Slash: 0.95
+        Piercing: 0.95
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -36,6 +37,7 @@
       coefficients:
         Blunt: 0.9
         Slash: 0.9
+        piercing: 0.95
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -57,6 +59,7 @@
       coefficients:
         Blunt: 0.9
         Slash: 0.9
+        piercing: 0.95
   - type: Tag
     tags:
     - WhitelistChameleon

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Mask/masks.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Mask/masks.yml
@@ -15,7 +15,7 @@
       coefficients:
         Blunt: 0.95
         Slash: 0.95
-        Pierce: 0.95
+        Piercing: 0.95
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -37,7 +37,7 @@
       coefficients:
         Blunt: 0.9
         Slash: 0.9
-        Pierce: 0.95
+        Piercing: 0.95
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -59,7 +59,7 @@
       coefficients:
         Blunt: 0.9
         Slash: 0.9
-        Pierce: 0.95
+        Piercing: 0.95
   - type: Tag
     tags:
     - WhitelistChameleon

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Mask/masks.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Mask/masks.yml
@@ -15,7 +15,7 @@
       coefficients:
         Blunt: 0.95
         Slash: 0.95
-        Piercing: 0.95
+        Pierce: 0.95
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -37,7 +37,7 @@
       coefficients:
         Blunt: 0.9
         Slash: 0.9
-        piercing: 0.95
+        pierce: 0.95
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -59,7 +59,7 @@
       coefficients:
         Blunt: 0.9
         Slash: 0.9
-        piercing: 0.95
+        pierce: 0.95
   - type: Tag
     tags:
     - WhitelistChameleon

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Mask/masks.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Mask/masks.yml
@@ -37,7 +37,7 @@
       coefficients:
         Blunt: 0.9
         Slash: 0.9
-        pierce: 0.95
+        Pierce: 0.95
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -59,7 +59,7 @@
       coefficients:
         Blunt: 0.9
         Slash: 0.9
-        pierce: 0.95
+        Pierce: 0.95
   - type: Tag
     tags:
     - WhitelistChameleon

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/coats_and_outer.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/coats_and_outer.yml
@@ -1,6 +1,6 @@
 #MARK: Plain Coats and Clothing
 - type: entity
-  parent: ClothingOuterBase
+  parent: ClothingOuterStorageBase
   id: N14ClothingOuterJacketLettermanRed
   name: letterman jacket
   description: A red letterman jacket.
@@ -9,9 +9,11 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/letterman_red.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/letterman_red.rsi
+  - type: ClothingSpecialModifier
+    charismaModifier: 1
 
 - type: entity
-  parent: N14ClothingOuterJacketLettermanRed
+  parent: ClothingOuterStorageBase
   id: N14ClothingOuterJacketLettermanBrown
   description: A brown letterman jacket.
   components:
@@ -19,6 +21,8 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/letterman_brown.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/letterman_brown.rsi
+  - type: ClothingSpecialModifier
+    charismaModifier: 1
 
 - type: entity
   parent: ClothingOuterBase
@@ -30,9 +34,11 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/hubologist.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/hubologist.rsi
+  - type: ClothingSpecialModifier
+    intelligenceModifier: 1
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: ClothingOuterStorageBase
   id: N14ClothingOuterFlannelRed
   name: flannel shirt
   description: A red flannel shirt
@@ -41,9 +47,11 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/flannel_red.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/flannel_red.rsi
+  - type: ClothingSpecialModifier
+    charismaModifier: 1
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: ClothingOuterStorageBase
   id: N14ClothingOuterFlannelAqua
   name: flannel shirt
   description: An aqua flannel shirt
@@ -52,9 +60,11 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/flannel_aqua.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/flannel_aqua.rsi
+  - type: ClothingSpecialModifier
+    charismaModifier: 1
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: ClothingOuterStorageBase
   id: N14ClothingOuterFlannelBrown
   name: flannel shirt
   description: A brown flannel shirt
@@ -63,6 +73,8 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/flannel_brown.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/flannel_brown.rsi
+  - type: ClothingSpecialModifier
+    charismaModifier: 1
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -74,6 +86,8 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/falloutfollowerlabcoat.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/falloutfollowerlabcoat.rsi
+  - type: ClothingSpecialModifier
+    intelligenceModifier: 1
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -85,6 +99,8 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/jacket_bomber.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/jacket_bomber.rsi
+  - type: ClothingSpecialModifier
+    strengthModifier: 1
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -99,8 +115,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.95
-        Heat: 0.9
+        Blunt: 0.9
+        Slash: 0.95
+        Piercing: 0.9
+        Heat: 0.85
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -114,12 +132,14 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/falloutleatherduster.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.95
-        Heat: 0.9
+     coefficients:
+        Blunt: 0.9
+        Slash: 0.95
+        Piercing: 0.9
+        Heat: 0.85
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: ClothingOuterBase
   id: N14ClothingOuterCoatLeatherJacket
   name: leather jacket
   description: A slick and smooth leather jacket. Perfect for any greaser.
@@ -131,8 +151,12 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.95
+        Blunt: 0.9
+        Slash: 0.95
+        Piercing: 0.95
         Heat: 0.9
+  - type: ClothingSpecialModifier
+    strengthModifier: 1
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -146,9 +170,11 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/coat_leather.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.95
-        Heat: 0.9
+     coefficients:
+        Blunt: 0.9
+        Slash: 0.95
+        Piercing: 0.9
+        Heat: 0.85
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -160,6 +186,13 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/coat_soldier.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/coat_soldier.rsi
+  - type: Armor
+    modifiers:
+     coefficients:
+        Blunt: 0.85
+        Slash: 0.9
+        Piercing: 0.9
+        Heat: 0.9
 
 - type: entity
   parent: ClothingOuterStorageBase # balance this?
@@ -171,6 +204,13 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/police_officer.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/police_officer.rsi
+  - type: Armor
+    modifiers:
+     coefficients:
+        Blunt: 0.85
+        Slash: 0.85
+        Piercing: 0.9
+        Heat: 0.9
 
 - type: entity
   parent: ClothingOuterStorageBase # balance this?
@@ -182,6 +222,13 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/police_lieutenant.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/police_lieutenant.rsi
+  - type: Armor
+    modifiers:
+     coefficients:
+        Blunt: 0.85
+        Slash: 0.85
+        Piercing: 0.9
+        Heat: 0.9
 
 - type: entity
   parent: ClothingOuterStorageBase # balance this?
@@ -193,6 +240,13 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/police_chief.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/police_chief.rsi
+  - type: Armor
+    modifiers:
+     coefficients:
+        Blunt: 0.85
+        Slash: 0.85
+        Piercing: 0.9
+        Heat: 0.9
 
 #MARK: Armored Coats
 - type: entity
@@ -210,13 +264,13 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.85
-        Slash: 0.85
-        Piercing: 0.9
-        Heat: 0.8
+        Blunt: 0.80
+        Slash: 0.80
+        Piercing: 0.85
+        Heat: 0.85
 
 - type: entity
-  parent: N14ClothingOuterOverseerCoat
+  parent: ClothingOuterStorageBase
   id: N14ClothingOuterBattlecoatCoat
   name: battlecoat
   description: For when you're going into battle.
@@ -225,6 +279,13 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/falloutbattlecoat.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/falloutbattlecoat.rsi
+  - type: Armor
+    modifiers:
+     coefficients:
+        Blunt: 0.85
+        Slash: 0.85
+        Piercing: 0.9
+        Heat: 0.9
 
 - type: entity
   parent: N14ClothingOuterBattlecoatCoat
@@ -246,31 +307,31 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/falloutcombatduster.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/falloutcombatduster.rsi
-  - type: ClothingSpeedModifier
-    walkModifier: 0.95
-    sprintModifier: 0.95
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.80
+        Blunt: 0.7
         Slash: 0.7
-        Piercing: 0.6
-        Heat: 0.7
+        Piercing: 0.65
+        Heat: 0.65
 
 #MARK: Brotherhood
 - type: entity
-  parent: N14ClothingOuterOverseerCoat
+  parent: N14ClothingOuterCoatWinterArmored
   id: N14ClothingOuterBrotherhoodElderCoat
   name: Elder greatcoat
-  description: For when you're going into battle.
+  description: Coat of the biggest brother.
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/brotherhoodeldercoat.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/brotherhoodeldercoat.rsi
+  - type: ClothingSpecialModifier
+    strengthModifier: 1
+    charismaModifier: 1
 
 - type: entity
-  parent: N14ClothingOuterOverseerCoat
+  parent: N14ClothingOuterCoatWinterArmored
   id: N14ClothingOuterBrotherhoodFieldScribeCoat
   name: Brotherhood field Scribe coat
   description: A warm coat worn by Brotherhood field Scribes.
@@ -279,17 +340,10 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/brotherhoodfieldscribe.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/brotherhoodfieldscribe.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.7
-        Slash: 0.8
-        Piercing: 0.75
-        Heat: 0.8
 
 #MARK: Enclave
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: N14ClothingOuterCoatWinterArmored
   id: N14ClothingOuterEnclaverOfficerCoat
   name: enclave officer coat
   description: A coat worn by enclave officers. It has armor underneath.
@@ -298,13 +352,6 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/falloutarmoredofficer.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/falloutarmoredofficer.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.85
-        Slash: 0.85
-        Piercing: 0.85
-        Heat: 0.9
 
 #MARK: NCR
 - type: entity
@@ -317,6 +364,8 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/ncr_cf.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/ncr_cf.rsi
+  - type: ClothingSpecialModifier
+    strengthModifier: 1
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -328,6 +377,8 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/ncr_dressjacket.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/ncr_dressjacket.rsi
+  - type: ClothingSpecialModifier
+    charismaModifier: 1
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -339,9 +390,11 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/ncr_codressjacket.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/ncr_codressjacket.rsi
+  - type: ClothingSpecialModifier
+    charismaModifier: 1
 
 - type: entity
-  parent: N14ClothingOuterOverseerCoat
+  parent: ClothingOuterStorageBase
   id: N14ClothingOuterNCRQuartermaster
   name: NCR QM uniform
   description: The uniform of an NCR Quartermaster.
@@ -350,10 +403,12 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/ncr_qm.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/ncr_qm.rsi
+  - type: ClothingSpecialModifier
+    charismaModifier: 1
 
 #MARK: Vault
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: N14ClothingOuterBattlecoatCoat
   id: N14ClothingOuterOverseerCoat
   name: "overseer's coat"
   description: A coat worn by someone important. It has the number 14 on the back.
@@ -364,11 +419,8 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/falloutoverseercoat.rsi
   - type: TemperatureProtection
     coefficient: 0.1
-  - type: Armor
-    modifiers:
-      coefficients:
-        Slash: 0.95
-        Heat: 0.75
+  - type: ClothingSpecialModifier
+    charismaModifier: 1
 
 #MARK: Midwest BoS
 - type: entity
@@ -391,7 +443,7 @@
 
 #MARK: Washington BoS
 - type: entity
-  parent: ClothingOuterStorageBase # balance this.
+  parent: N14ClothingOuterBattlecoatCoat
   id: N14ClothingOuterBrotherhoodWashingtonScribe
   name: scribe clothes
   description: An outfit traditionally worn by Brotherhood scribes.
@@ -402,7 +454,7 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/washington_bos_scribe.rsi
 
 - type: entity
-  parent: ClothingOuterStorageBase # balance this.
+  parent: N14ClothingOuterBrotherhoodElderCoat
   id: N14ClothingOuterBrotherhoodWashingtonElder
   name: elder clothes
   description: An outfit traditionally worn by Brotherhood elders.
@@ -428,7 +480,7 @@
       coefficients:
         Blunt: 0.65
         Slash: 0.6
-        Piercing: 0.8
+        Piercing: 0.7
         Heat: 0.8
 
 #MARK: Town
@@ -445,8 +497,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.95
-        Heat: 0.9
+        Blunt: 0.9
+        Slash: 0.95
+        Piercing: 0.9
+        Heat: 0.85
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -461,10 +515,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.8
+        Blunt: 0.85
+        Slash: 0.9
         Piercing: 0.85
-        Heat: 0.9
+        Heat: 0.8
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -479,13 +533,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
+        Blunt: 0.65
+        Slash: 0.65
         Piercing: 0.7
-        Heat: 0.8
-  - type: ClothingSpeedModifier
-    walkModifier: 0.95
-    sprintModifier: 0.95
+        Heat: 0.7
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -500,7 +551,7 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.6
-        Heat: 0.7
+        Blunt: 0.6
+        Slash: 0.6
+        Piercing: 0.65
+        Heat: 0.65

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
@@ -11,10 +11,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.7
-        Piercing: 0.9
-        Heat: 0.8
+        Blunt: 0.75
+        Slash: 0.85
+        Piercing: 0.85
+        Heat: 0.75
 
 - type: entity
   parent: ClothingOuterBase
@@ -26,16 +26,21 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutmetal.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutmetal.rsi
-  - type: ClothingSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.75
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
+        Blunt: 0.75
         Slash: 0.6
-        Piercing: 0.7
+        Piercing: 0.65
         Heat: 0.8
+  - type: ExplosionResistance
+    damageCoefficient: 0.7
+  - type: Reflect
+    reflectProb: 0.05
+    reflectSpread: 150
+  - type: ClothingSpeedModifier
+    walkModifier: 0.90
+    sprintModifier: 0.90
 
 - type: entity
   parent: ClothingOuterBase
@@ -53,7 +58,9 @@
         Blunt: 0.65
         Slash: 0.65
         Piercing: 0.6
-        Heat: 0.7
+        Heat: 0.6
+  - type: ExplosionResistance
+    damageCoefficient: 0.7
 
 - type: entity
   parent: ClothingOuterBase
@@ -70,8 +77,10 @@
       coefficients:
         Blunt: 0.6
         Slash: 0.6
-        Piercing: 0.5
-        Heat: 0.6
+        Piercing: 0.55
+        Heat: 0.55
+  - type: ExplosionResistance
+    damageCoefficient: 0.65
 
 - type: entity
   parent: ClothingOuterBase
@@ -86,10 +95,12 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.45
+        Blunt: 0.55
+        Slash: 0.55
+        Piercing: 0.5
         Heat: 0.5
+  - type: ExplosionResistance
+    damageCoefficient: 0.6
 
 - type: entity
   parent: N14ClothingOuterCombatArmorMK2
@@ -152,9 +163,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
+        Blunt: 0.75
+        Slash: 0.75
         Piercing: 0.75
+        Heat: 0.9
 
 - type: entity
   parent: ClothingOuterBase
@@ -167,15 +179,17 @@
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/fallouttribalheavy.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 0.95
+    sprintModifier: 0.95
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.65
-        Slash: 0.6
-        Piercing: 0.6
+        Slash: 0.65
+        Piercing: 0.65
         Heat: 0.8
+  - type: ExplosionResistance
+    damageCoefficient: 0.85
 
 - type: entity
   parent: ClothingOuterBase
@@ -190,14 +204,16 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.55
-        Slash: 0.5
-        Piercing: 0.75
-        Heat: 0.7
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.65
+        Heat: 0.65
+  - type: ExplosionResistance
+    damageCoefficient: 0.75
 
 #MARK: Raiders
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: ClothingOuterBase
   id: N14ClothingOuterRaiderBadlands
   name: raider badlands armor
   description: A suit of raider armor. It provides barely any protection... but it DOES look cool.
@@ -209,12 +225,15 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.75
-        Slash: 0.75
-        Heat: 0.8
+        Blunt: 0.85
+        Slash: 0.85
+        Heat: 0.85
+        Piercing: 0.85
+  - type: ClothingSpecialModifier
+    strengthModifier: 1
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: ClothingOuterBase
   id: N14ClothingOuterRaiderBlastmaster
   name: raider blastmaster armor
   description: A suit of raider armor. It provides barely any protection... but it DOES look cool.
@@ -226,11 +245,15 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-
+        Blunt: 0.85
+        Slash: 0.85
+        Heat: 0.85
+        Piercing: 0.85
+  - type: ClothingSpecialModifier
+    strengthModifier: 1
+    
 - type: entity
-  parent: ClothingOuterBase
+  parent: N14ClothingOuterCombatArmor
   id: N14ClothingOuterRaiderCombat1
   name: raider combat armor
   description: An armor piece infamously used by Raiders of all kinds in combat.
@@ -239,16 +262,9 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutcombatraider1.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutcombatraider1.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.75
-        Slash: 0.75
-        Piercing: 0.7
-        Heat: 0.7
 
 - type: entity
-  parent: N14ClothingOuterRaiderCombat1
+  parent: ClothingOuterBase
   id: N14ClothingOuterRaiderCombat2
   name: raider combat armor mk2
   description: An armor piece infamously used by Raiders of all kinds in combat, this one seems to hold some pieces of a salvaged mk2 combat armor.
@@ -260,10 +276,12 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.65
-        Heat: 0.7
+        Blunt: 0.6
+        Slash: 0.6
+        Piercing: 0.5
+        Heat: 0.5
+  - type: ExplosionResistance
+    damageCoefficient: 0.75
 
 - type: entity
   parent: ClothingOuterBase
@@ -278,10 +296,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.6
-        Heat: 0.8
+        Blunt: 0.75
+        Slash: 0.75
+        Piercing: 0.7
+        Heat: 0.7
 
 - type: entity
   parent: ClothingOuterBase
@@ -296,13 +314,15 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.75
-        Slash: 0.75
+        Blunt: 0.7
+        Slash: 0.7
         Piercing: 0.65
-        Heat: 0.75
+        Heat: 0.65
+  - type: ExplosionResistance
+    damageCoefficient: 0.75
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: N14ClothingOuterCombatRusted
   id: N14ClothingOuterCombatRaider
   name: raider combat armor
   description: A suit of combat armor. This one is quite salvaged and broken down.
@@ -311,16 +331,9 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutcombatraider.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutcombatraider.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.7
-        Heat: 0.8
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: N14ClothingOuterCombatArmor
   id: N14ClothingOuterCombatPainspike
   name: painspike combat armor
   description: A suit of combat armor. This one seems to be dyed black and modified with spikes around it's entirety.
@@ -329,13 +342,6 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutcombatpainspike.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutcombatpainspike.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.75
-        Slash: 0.75
-        Piercing: 0.65
-        Heat: 0.7
 
 - type: entity
   parent: ClothingOuterBase
@@ -365,9 +371,6 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutsupafly.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutsupafly.rsi
-  - type: ClothingSpeedModifier
-    walkModifier: 1.2
-    sprintModifier: 1.2
   - type: Armor
     modifiers:
       coefficients:
@@ -375,6 +378,12 @@
         Slash: 1.1
         Piercing: 1.2
         Heat: 1.2
+  - type: ClothingSpeedModifier
+    walkModifier: 1.2
+    sprintModifier: 1.2
+  - type: Reflect
+    reflectProb: 0.5
+    reflectSpread: 150
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -389,9 +398,9 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.8
+        Blunt: 0.85
+        Slash: 0.85
+        Piercing: 0.7
         Heat: 0.7
 
 - type: entity
@@ -409,8 +418,8 @@
       coefficients:
         Blunt: 0.8
         Slash: 0.8
-        Piercing: 0.6
-        Heat: 0.8
+        Piercing: 0.65
+        Heat: 0.65
 
 #MARK: NCR
 
@@ -431,6 +440,8 @@
         Slash: 0.8
         Piercing: 0.65
         Heat: 0.7
+  - type: ExplosionResistance
+    damageCoefficient: 0.9
 
 - type: entity
   parent: ClothingOuterBase
@@ -445,10 +456,18 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
+        Blunt: 0.75
         Slash: 0.6
-        Piercing: 0.8
+        Piercing: 0.6
         Heat: 0.7
+  - type: ExplosionResistance
+    damageCoefficient: 0.65
+  - type: Reflect
+    reflectProb: 0.05
+    reflectSpread: 150
+  - type: ClothingSpeedModifier
+    walkModifier: 0.90
+    sprintModifier: 0.90
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -460,9 +479,6 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutNCRwebvest.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutNCRwebvest.rsi
-  - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
   - type: Armor
     modifiers:
       coefficients:
@@ -470,6 +486,8 @@
         Slash: 0.8
         Piercing: 0.65
         Heat: 0.7
+  - type: ExplosionResistance
+    damageCoefficient: 0.9
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -488,9 +506,11 @@
         Slash: 0.8
         Piercing: 0.7
         Heat: 0.75
+  - type: ExplosionResistance
+    damageCoefficient: 0.9
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: N14ClothingOuterCombatArmor
   id: N14ClothingOuterNCRCombatArmor
   name: NCR combat armor
   description: An old military grade pre-war combat armor, repainted to the colour scheme of the New California Republic.
@@ -499,16 +519,9 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutcombatNCR.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutcombatNCR.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.65
-        Slash: 0.65
-        Piercing: 0.6
-        Heat: 0.6
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: N14ClothingOuterCombatArmorMK2
   id: N14ClothingOuterNCRCombatArmorMK2
   name: NCR combat armor mk2
   description: A reinforced set of bracers, greaves, and torso plating of pre-war design. This one is kitted with additional plates, repainted to the colour scheme of the New California Republic.
@@ -517,13 +530,6 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutcombatNCRmk2.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutcombatNCRmk2.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.5
-        Heat: 0.5
 
 #MARK: NCR Rangers
 
@@ -540,13 +546,15 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.65
-        Slash: 0.65
+        Blunt: 0.75
+        Slash: 0.75
         Piercing: 0.6
         Heat: 0.6
+  - type: ExplosionResistance
+    damageCoefficient: 0.8
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: N14ClothingOuterNCRCombatArmor
   id: N14ClothingOuterRangerArmor
   name: ranger patrol armor
   description: A complete piece of combat armor created by the NCR itself, used by the NCR rangers during their most dangerous patrols.
@@ -555,16 +563,9 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutrangersuit.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutrangersuit.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.65
-        Slash: 0.65
-        Piercing: 0.6
-        Heat: 0.6
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: N14ClothingOuterNCRCombatArmor
   id: N14ClothingOuterRangerArmorB
   name: customized ranger patrol armor
   description: A customized and moderately-worn suit of patrol ranger armor. A sun-worn thick olive duster is worn over the armor.
@@ -573,13 +574,6 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutrangersuitb.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutrangersuitb.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.55
-        Heat: 0.6
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -594,10 +588,12 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.5
-        Heat: 0.6
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.55
+  - type: ExplosionResistance
+    damageCoefficient: 0.8
 
 #MARK: Veteran
 
@@ -614,10 +610,12 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.45
-        Heat: 0.45
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.55
+  - type: ExplosionResistance
+    damageCoefficient: 0.8
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -634,11 +632,13 @@
       coefficients:
         Blunt: 0.6
         Slash: 0.6
-        Piercing: 0.45
-        Heat: 0.45
+        Piercing: 0.55
+        Heat: 0.55
+  - type: ExplosionResistance
+    damageCoefficient: 0.65
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: N14ClothingOuterRangerCombat
   id: N14ClothingOuterRangerCombatDesert
   name: desert ranger combat armor
   description: This is the original armor the NCR Ranger Combat armor was based off of. An awe inspiring suit of armor used by the legendary Desert Rangers.
@@ -647,16 +647,9 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutrangerdesertcombat.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutrangerdesertcombat.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.4
-        Heat: 0.45
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: N14ClothingOuterRangerCombat
   id: N14ClothingOuterRangerFox
   name: fox ranger combat armor
   description: A customized and well-worn suit of riot gear with parts of the suit reinforced with leather armor and slain Centurion armor pieces by the wearer. A sniper's veil is wrapped around the neck.
@@ -665,16 +658,9 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutrangerfox.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutrangerfox.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.6
-        Slash: 0.5
-        Piercing: 0.45
-        Heat: 0.5
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: N14ClothingOuterRangerCombat
   id: N14ClothingOuterRangerWeathered
   name: weathered ranger combat armor
   description: A set of pre-unification desert ranger armor, made using parts of what was once USMC riot armor. It looks as if it has been worn for decades; the coat has become discoloured from years under the Mojave sun and has multiple tears and bullet holes in its leather. The armor plating itself seems to be in relatively good shape, though it could do with some maintenance.
@@ -683,16 +669,9 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutrangerweathered.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutrangerweathered.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.7
-        Heat: 0.7
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: N14ClothingOuterRangerCombat
   id: N14ClothingOuterRangerElite # Admin event gear (OP)
   name: elite ranger combat armor
   description: A customized and well-worn suit of riot gear with parts of the suit reinforced with leather armor and slain Centurion armor pieces by the wearer. A sniper's veil is wrapped around the neck.
@@ -710,7 +689,7 @@
         Heat: 0.3
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: N14ClothingOuterRangerCombat
   id: N14ClothingOuterRangerEliteOld
   name: worn elite ranger combat armor
   description: A customized and well-worn suit of riot gear with parts of the suit reinforced with leather armor and slain Centurion armor pieces by the wearer. A sniper's veil is wrapped around the neck. This one has seen some wear.
@@ -728,7 +707,7 @@
         Heat: 0.4
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: N14ClothingOuterRangerCombat
   id: N14ClothingOuterRangerPrice
   name: spider ranger combat armor
   description: A customised and faded suit of riot gear, reminiscient of that found near Hopeville in the Divide, with a pair of wrist mounted ammo pouches for easy access to spare munitions with a pair of stripes down the back made from a fire-proof material.
@@ -830,7 +809,7 @@
 #MARK: midwest BoS
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: N14ClothingOuterCombatArmor
   id: N14ClothingOuterMidwestArmor
   name: midwest BoS combat armor
   description: A suit of combat armor modified with multiple well polished metal plates.
@@ -839,16 +818,9 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutmidbosarmor.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutmidbosarmor.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.65
-        Slash: 0.65
-        Piercing: 0.6
-        Heat: 0.6
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: N14ClothingOuterCombatArmorMK2
   id: N14ClothingOuterMidwestArmorMK2
   name: veteran midwest BoS combat armor
   description: A suit of combat armor modified with multiple well polished metal plates and orange lines, a more robust version.
@@ -857,13 +829,6 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutmidbosarmorV2.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutmidbosarmorV2.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.5
-        Heat: 0.5
 
 #MARK: craftable armors
 
@@ -934,7 +899,9 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.8
-        Heat: 0.9
+        Blunt: 0.85
+        Slash: 0.75
+        Piercing: 0.75
+        Heat: 0.85
+  - type: ExplosionResistance
+    damageCoefficient: 0.85

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
@@ -37,7 +37,7 @@
     damageCoefficient: 0.7
   - type: Reflect
     reflectProb: 0.05
-    reflectSpread: 150
+    spread: 150
   - type: ClothingSpeedModifier
     walkModifier: 0.90
     sprintModifier: 0.90
@@ -251,7 +251,7 @@
         Piercing: 0.85
   - type: ClothingSpecialModifier
     strengthModifier: 1
-    
+
 - type: entity
   parent: N14ClothingOuterCombatArmor
   id: N14ClothingOuterRaiderCombat1
@@ -383,7 +383,7 @@
     sprintModifier: 1.2
   - type: Reflect
     reflectProb: 0.5
-    reflectSpread: 150
+    spread: 150
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -464,7 +464,7 @@
     damageCoefficient: 0.65
   - type: Reflect
     reflectProb: 0.05
-    reflectSpread: 150
+    spread: 150
   - type: ClothingSpeedModifier
     walkModifier: 0.90
     sprintModifier: 0.90

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
@@ -29,7 +29,7 @@
     strengthModifier: 10
   - type: Reflect
     reflectProb: 0.15
-    reflectSpread: 150
+    spread: 150
 # Maybe someday...
 #  - type: FootstepModifier
 #    footstepSoundCollection:
@@ -64,7 +64,7 @@
     clothingPrototype: N14ClothingHeadHelmetPowerArmorT51
   - type: Reflect
     reflectProb: 0.2
-    reflectSpread: 150
+    spread: 150
 
 - type: entity
   parent: N14ClothingOuterPowerArmorT45
@@ -95,7 +95,7 @@
     clothingPrototype: N14ClothingHeadHelmetPowerArmorT60
   - type: Reflect
     reflectProb: 0.2
-    reflectSpread: 150
+    spread: 150
 
 - type: entity
   parent: N14ClothingOuterPowerArmorT60
@@ -115,7 +115,7 @@
     clothingPrototype: N14ClothingHeadHelmetPowerArmorT60
   - type: Reflect
     reflectProb: 0.2
-    reflectSpread: 150
+    spread: 150
 
 - type: entity
   parent: N14ClothingOuterPowerArmorT45
@@ -146,7 +146,7 @@
     clothingPrototype: N14ClothingHeadHelmetPowerArmorX01
   - type: Reflect
     reflectProb: 0.2
-    reflectSpread: 150
+    spread: 150
 
 - type: entity
   parent: N14ClothingOuterPowerArmorAdvanced1
@@ -177,7 +177,7 @@
     clothingPrototype: N14ClothingHeadHelmetPowerArmorX02
   - type: Reflect
     reflectProb: 0.2
-    reflectSpread: 150
+    spread: 150
 
 - type: entity
   parent: N14ClothingOuterPowerArmorAdvanced1
@@ -205,7 +205,7 @@
     clothingPrototype: N14ClothingHeadHelmetPowerArmorHellfire
   - type: Reflect
     reflectProb: 0.2
-    reflectSpread: 150
+    spread: 150
 
 - type: entity
   parent: N14ClothingOuterPowerArmorT45
@@ -237,7 +237,7 @@
       collection: N14FootstepPowerArmor
   - type: Reflect
     reflectProb: 0.10
-    reflectSpread: 150
+    spread: 150
 
 - type: entity
   parent: N14ClothingOuterPowerArmorT45
@@ -268,7 +268,7 @@
     clothingPrototype: N14ClothingHeadHelmetPowerArmorT51BC
   - type: Reflect
     reflectProb: 0.2
-    reflectSpread: 150
+    spread: 150
 
 - type: entity
   parent: N14ClothingOuterPowerArmorT45
@@ -287,4 +287,4 @@
     sprintModifier: 0.75
   - type: Reflect
     reflectProb: 0.10
-    reflectSpread: 150
+    spread: 150

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
@@ -9,8 +9,8 @@
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/t45.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 0.85
+    sprintModifier: 0.85
   - type: TemperatureProtection
     coefficient: 0.6
   - type: Armor
@@ -18,15 +18,18 @@
       coefficients:
         Blunt: 0.4
         Slash: 0.4
-        Piercing: 0.45
-        Heat: 0.5
-        Radiation: 0.7
+        Piercing: 0.5
+        Heat: 0.55
+        Radiation: 0.4
   - type: ExplosionResistance
     damageCoefficient: 0.5
   - type: ToggleableClothing
     clothingPrototype: N14ClothingHeadHelmetPowerArmorT45
   - type: ClothingSpecialModifier
-    strengthModifier: 10 
+    strengthModifier: 10
+  - type: Reflect
+    reflectProb: 0.15
+    reflectSpread: 150
 # Maybe someday...
 #  - type: FootstepModifier
 #    footstepSoundCollection:
@@ -50,15 +53,18 @@
       coefficients:
         Blunt: 0.4
         Slash: 0.3
-        Piercing: 0.4
-        Heat: 0.4
-        Radiation: 0.5
+        Piercing: 0.45
+        Heat: 0.45
+        Radiation: 0.3
   - type: TemperatureProtection
     coefficient: 0.55
   - type: ExplosionResistance
     damageCoefficient: 0.4
   - type: ToggleableClothing
     clothingPrototype: N14ClothingHeadHelmetPowerArmorT51
+  - type: Reflect
+    reflectProb: 0.2
+    reflectSpread: 150
 
 - type: entity
   parent: N14ClothingOuterPowerArmorT45
@@ -71,22 +77,25 @@
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/t60.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.95
-    sprintModifier: 0.95
+    walkModifier: 0.90
+    sprintModifier: 0.90
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.35
         Slash: 0.3
-        Piercing: 0.45
-        Heat: 0.35
-        Radiation: 0.6
+        Piercing: 0.5
+        Heat: 0.4
+        Radiation: 0.3
   - type: TemperatureProtection
     coefficient: 0.5
   - type: ExplosionResistance
     damageCoefficient: 0.35
   - type: ToggleableClothing
     clothingPrototype: N14ClothingHeadHelmetPowerArmorT60
+  - type: Reflect
+    reflectProb: 0.2
+    reflectSpread: 150
 
 - type: entity
   parent: N14ClothingOuterPowerArmorT60
@@ -104,6 +113,9 @@
     damageCoefficient: 0.35
   - type: ToggleableClothing
     clothingPrototype: N14ClothingHeadHelmetPowerArmorT60
+  - type: Reflect
+    reflectProb: 0.2
+    reflectSpread: 150
 
 - type: entity
   parent: N14ClothingOuterPowerArmorT45
@@ -123,15 +135,18 @@
       coefficients:
         Blunt: 0.3
         Slash: 0.25
-        Piercing: 0.4
-        Heat: 0.35
-        Radiation: 0.4
+        Piercing: 0.45
+        Heat: 0.4
+        Radiation: 0.1
   - type: TemperatureProtection
     coefficient: 0.2
   - type: ExplosionResistance
     damageCoefficient: 0.2
   - type: ToggleableClothing
     clothingPrototype: N14ClothingHeadHelmetPowerArmorX01
+  - type: Reflect
+    reflectProb: 0.2
+    reflectSpread: 150
 
 - type: entity
   parent: N14ClothingOuterPowerArmorAdvanced1
@@ -151,15 +166,18 @@
       coefficients:
         Blunt: 0.5
         Slash: 0.30
-        Piercing: 0.3
-        Heat: 0.40
-        Radiation: 0.4
+        Piercing: 0.35
+        Heat: 0.45
+        Radiation: 0.1
   - type: TemperatureProtection
     coefficient: 0.25
   - type: ExplosionResistance
     damageCoefficient: 0.25
   - type: ToggleableClothing
     clothingPrototype: N14ClothingHeadHelmetPowerArmorX02
+  - type: Reflect
+    reflectProb: 0.2
+    reflectSpread: 150
 
 - type: entity
   parent: N14ClothingOuterPowerArmorAdvanced1
@@ -176,18 +194,21 @@
       coefficients:
         Blunt: 0.2
         Slash: 0.2
-        Piercing: 0.3
-        Heat: 0.2
-        Radiation: 0.3
+        Piercing: 0.35
+        Heat: 0.25
+        Radiation: 0.1
   - type: TemperatureProtection
     coefficient: 0.1
   - type: ExplosionResistance
     damageCoefficient: 0.15
   - type: ToggleableClothing
     clothingPrototype: N14ClothingHeadHelmetPowerArmorHellfire
+  - type: Reflect
+    reflectProb: 0.2
+    reflectSpread: 150
 
 - type: entity
-  parent: ClothingOuterEVASuitBase
+  parent: N14ClothingOuterPowerArmorT45
   id: N14ClothingOuterPowerArmorRaider
   name: raider power armor
   description: Terrifying, AND robust. Everything a Raider needs in a power armor suit.
@@ -197,23 +218,26 @@
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/raider.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+    walkModifier: 0.85
+    sprintModifier: 0.85
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.6
         Slash: 0.5
-        Piercing: 0.5
-        Heat: 0.6
-        Radiation: 0.9
+        Piercing: 0.55
+        Heat: 0.65
+        Radiation: 0.6
   - type: ExplosionResistance
     damageCoefficient: 0.65
   - type: ClothingSpecialModifier
-    strengthModifier: 10 
+    strengthModifier: 10
   - type: FootstepModifier
     footstepSoundCollection:
       collection: N14FootstepPowerArmor
+  - type: Reflect
+    reflectProb: 0.10
+    reflectSpread: 150
 
 - type: entity
   parent: N14ClothingOuterPowerArmorT45
@@ -233,15 +257,18 @@
       coefficients:
         Blunt: 0.35
         Slash: 0.25
-        Piercing: 0.3
-        Heat: 0.35
-        Radiation: 0.5
+        Piercing: 0.35
+        Heat: 0.4
+        Radiation: 0.3
   - type: TemperatureProtection
     coefficient: 0.5
   - type: ExplosionResistance
     damageCoefficient: 0.3
   - type: ToggleableClothing
     clothingPrototype: N14ClothingHeadHelmetPowerArmorT51BC
+  - type: Reflect
+    reflectProb: 0.2
+    reflectSpread: 150
 
 - type: entity
   parent: N14ClothingOuterPowerArmorT45
@@ -256,5 +283,8 @@
   - type: ToggleableClothing
     clothingPrototype: N14ClothingHeadHelmetPowerArmorT45NCR
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+    walkModifier: 0.75
+    sprintModifier: 0.75
+  - type: Reflect
+    reflectProb: 0.10
+    reflectSpread: 150

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/longblades.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/longblades.yml
@@ -96,14 +96,24 @@
   - type: Sprite
     sprite: _Nuclear14/Objects/Weapons/Melee/ripper.rsi
     state: icon
+  - type: EmbeddableProjectile
+    sound: /Audio/_Nuclear14/Weapons/Melee/Swing/ripper.ogg
   - type: DamageOtherOnHit
     damage:
       types:
-        Slash: 30
+        Slash: 15
+        Pierce: 15
+  - type: Sharp
   - type: MeleeWeapon
+    autoAttack: true
+    angle: 0
+    wideAnimationRotation: -135
+    attackRate: 4
     damage:
       types:
-        Slash: 25
+        Slash: 3
+        Piercing: 3
+        Structural: 4
     soundHit:
       path: /Audio/Weapons/chainsaw.ogg
     soundSwing:
@@ -111,3 +121,19 @@
   - type: Item
     size: Huge
     sprite: _Nuclear14/Objects/Weapons/Melee/ripper.rsi
+  - type: DisarmMalus
+  - type: RefillableSolution
+    solution: Welder
+  - type: SolutionContainerManager
+    solutions:
+      Welder:
+        reagents:
+        - ReagentId: WeldingFuel
+          Quantity: 300
+        maxVol: 300
+  - type: UseDelay
+    delay: 1
+  - type: Tool
+    qualities:
+      - Sawing
+    speed: 3.0


### PR DESCRIPTION

ARMOR REBALANCES AND CHANGES

Armor and outerware has been in a lukewarm state for quite some time, this PR attempts too address some of the issues and provide more balance and fairness too the game.

VETERAN RANGERS: 

too start veteran rangers have recieved a decent nerf too their armor their total resistances pre-nerf were

Blunt 75%
Slashing 75%
Piercing 80%
Heat 90%

while a suit of T-45 power armor is.
Blunt 80%
Slash 80%
Piercing 70% 
Heat 70% 

For referance, the stats reduce the incoming damage by that amount, so say for example, a veteran ranger was hit with a 10 damage laser, it would then deal 1 damage. That is a bit absurd.

with the following nerfs their resistances are now reduced too, from combined, helmet/gasmask/armor

Blunt 60
Slash 60
Piercing 55
Heat 55

These new numbers are subject too change, but i feel this gives other factions a much more fair time when fighting rangers, Rangers in the lore are elite warriors yes. but most of their prowess comes from skill, not their armor. Its a little silly too give them absurdly high armor values too emmulate their skill in combat. Veteran Rangers in Nuclear14 will still have an advantage yes, still quite a big one, i expect vets should still be able too pretty easily win 1v2s. But most of their skill will now have too come from the player. 

For concerns about Veteran ranger balance against fighting Paladins, The NCR has over twice as many troops as the BOS, aswell NCR pretty standardly has a high player count, so even though Veteran ranger is weaker now, the BOS is probably still at a disadvantage. Aswell the Vets have better weaponry. and armor piercing weaponry. 

POWER ARMOR:

Bullets and lasers will now occasionally bounce off power armor. 

All power armors now have a base 15% reflection chance, with T-51 and up armors having a 20% chance. In exchange all piercing and heat resistances of all power armors has been lowered by 5%.. 

Metal and NCR plate (and a secret armor) now also have a 5% chance too reflect, just for fun. 

RAIDER AND WASTERS:

Coats, dusters, armors, coats, have all recieved more resistances, they are still quite a bit weaker then the armors of advanced factions such as the NCR, and BOS. but on average expect your average wastelander/Townie too be 10-15% more difficult too kill. aswell alot of hats and clothes have recieved special bonuses and gained pockets, such as the flannels.

Alot of armors, and coats have been standardized aswell, too use the same stats, this allows for an easier time futher balancing things, and lets the player pick whatever one they think is coolest without sacrificing in game resistances :P. Rusted armor, salvaged armor, and tribal armor will still  be slightly worse because of the nature of them. 

CHANGELOG:

-Veteran rangers lost their plot armor
-Power armor gives reflects, and has increased rad resist
-Metal and NCR plate has smaller chance too reflect
-Ranger hoods nerfed
-Tribal hood now gives slight resistances.
-Cowboy hats now give perception instead of charisma
-Mining masks give some more rad resist
-Raider armor lost pockets, gained some minor resistances 
-Combat and metal based armors have gained explosive resistances
-Metal armor and NCR plate now decrease speed by 10%
-Various other changes...

Future PRs will be released too further balance armor and weaponry. feedback is appreciated, but educated feedback. 

BONUS:

Ripper now works like a proper chainsaw RRRRRRrrrrRRRRRRRRRrrr 
