### PR TITLE
Jet recipe tweak

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
@@ -730,7 +730,7 @@
   - type: Timer
   - type: TimedSpawner
     prototypes:
-      - N14Dung
+      - N14BrahminDung
     chance: 0.5
     intervalSeconds: 300
     minimumEntitiesSpawned: 1

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Materials/materials.yml
@@ -209,6 +209,22 @@
     lifetime: 300
 
 - type: entity
+  parent: N14Dung
+  id: N14BrahminDung
+  name: brahmin dung
+  description: A dung pile more acrid and vile than the rest, rancher's gold.
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      dung:
+        maxVol: 25
+        reagents:
+        - ReagentId: Dung
+          Quantity: 15
+        - ReagentId: Ammonia
+          Quantity: 10
+
+- type: entity
   parent: BaseItem
   id: N14CompostRotted
   name: compost

--- a/Resources/Prototypes/_Nuclear14/Recipes/Reactions/chems.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Reactions/chems.yml
@@ -7,7 +7,7 @@
     Abraxocleaner:
       amount: 1
   products:
-    MovespeedMixture: 2
+    MovespeedMixture: 1
 
 - type: reaction
   id: Mentats

--- a/Resources/Prototypes/_Nuclear14/Recipes/Reactions/chems.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Reactions/chems.yml
@@ -3,11 +3,11 @@
   minTemp: 373.15 # 100 degrees Celcius.
   reactants:
     Ammonia:
-      amount: 5
+      amount: 1
     Abraxocleaner:
-      amount: 5
+      amount: 1
   products:
-    MovespeedMixture: 5
+    MovespeedMixture: 2
 
 - type: reaction
   id: Mentats

--- a/Resources/Prototypes/_Nuclear14/Recipes/Reactions/chems.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Reactions/chems.yml
@@ -5,9 +5,9 @@
     Ammonia:
       amount: 5
     Abraxocleaner:
-      amount: 1
+      amount: 5
   products:
-    MovespeedMixture: 3
+    MovespeedMixture: 5
 
 - type: reaction
   id: Mentats

--- a/Resources/Prototypes/_Nuclear14/Recipes/Reactions/chems.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Reactions/chems.yml
@@ -1,12 +1,13 @@
 - type: reaction
   id: Jet
+  minTemp: 373.15 # 100 degrees Celcius.
   reactants:
     Ammonia:
-      amount: 1
-    ExtractXander: # N14:TODO: This will do for now till we figure out a catalyst...
+      amount: 5
+    Abraxocleaner:
       amount: 1
   products:
-    MovespeedMixture: 2
+    MovespeedMixture: 3
 
 - type: reaction
   id: Mentats


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

So the jet recipe was basically impossible to make as the only source of ammonia was coal, and that sucked.
 So to make it a little more lore friendly but also an interesting chem to make, ammonia now comes from brahmin dung which can be mixed with abraxo and heated to make jet. I threw heating into the recipe to give it a slight complication. Jet is relatively easy to make but it requires one to be at least in proximity to brahmin, electricity, and done some looting. I'm happy with that. 

Let me know if the values seem wonky, that's easy to adjust anyways.