### PR TITLE
brahmin dung fix

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
@@ -800,6 +800,10 @@
     quantityperUpdate: 25
     growthDelay: 90
     hungerUsage: 7.5
+  - type: TimedSpawner
+    prototypes:
+      - N14Dung
+    chance: 0.5
   - type: Reproductive
     breedChance: 0.05
     birthPopup: reproductive-birth-popup
@@ -865,6 +869,10 @@
     quantityperUpdate: 10
     growthDelay: 40
     hungerUsage: 5
+  - type: TimedSpawner
+    prototypes:
+      - N14Dung
+    chance: 0.5
   - type: Reproductive
     breedChance: 0.05
     birthPopup: reproductive-birth-popup


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

While testing the new jet recipe again, I noticed that both bighorners and radstags had the brahmin as a parent and were thus making brahmin dung. This PR rectifies that, making them use normal dung instead.
