### PR TITLE
Loadout expansion

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Loadouts/items.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/items.yml
@@ -1,14 +1,28 @@
 - type: loadout
   id: N14WeaponRevolver9mm
   category: Items
-  cost: 5
+  cost: 3
   items:
     - N14WeaponRevolver9mm
 
 - type: loadout
+  id: N14BaseSpeedLoader9
+  category: Items
+  cost: 3
+  items:
+    - N14BaseSpeedLoader9
+
+- type: loadout
+  id: N14WeaponPistol22lr
+  category: Items
+  cost: 6
+  items:
+    - N14WeaponPistol22lr
+
+- type: loadout
   id: N14WeaponDoubleBarrelShotgun 
   category: Items
-  cost: 5
+  cost: 4
   items:
     - N14WeaponDoubleBarrelShotgun 
 
@@ -205,7 +219,7 @@
 - type: loadout
   id: d6Dice 
   category: Items
-  cost: 2
+  cost: 0
   items:
     - d6Dice 
 
@@ -220,7 +234,7 @@
 - type: loadout
   id: N14LoadoutItemCig
   category: Items
-  cost: 1
+  cost: 0
   items:
     - N14Cigarette
 

--- a/Resources/Prototypes/_Nuclear14/Loadouts/shoes.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/shoes.yml
@@ -33,3 +33,9 @@
   items:
     - N14ClothingBootsBlack
 
+- type: loadout
+  id: N14ClothingBootsCombat
+  category: Shoes
+  cost: 4
+  items:
+    - N14ClothingBootsCombat


### PR DESCRIPTION
# Description

Made some tweaks in basic loadout and added few items to make character creation little bit more varied.

Tweaks:
- Changed cost of 9mm revolver from 5 to 3 points
- Changed cost of double barrel shotgun from 5 to 4 points
- Changed costs of cigarette and d6 dice to 0

New items added:
- Combat boots with cost of 4 points
- 9mm speedloader for revolver with a cost of 3 points
- 22lr pistol with a cost of 6 points

Hopefully this changes make life little bit more bearable, especially for late joiners, when map is already mostly looted. Also should solve problem with lots of discarded 9mm revolvers, because now you will have easier way to reload them.

---