### PR TITLE
the rest of the craftible chems

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
@@ -223,7 +223,7 @@
       sprite: _Nuclear14/Mobs/Animals/nightstalkercub.rsi
   - type: Bloodstream
     bloodMaxVolume: 30
-    bloodReagent: WastelandBlood
+    bloodReagent: NightstalkerBlood
   - type: MovementSpeedModifier
     baseWalkSpeed : 3.5
     baseSprintSpeed : 4.5
@@ -311,7 +311,7 @@
       sprite: _Nuclear14/Mobs/Animals/nightstalker.rsi
   - type: Bloodstream
     bloodMaxVolume: 50
-    bloodReagent: WastelandBlood
+    bloodReagent: NightstalkerBlood
   - type: MovementSpeedModifier
     baseWalkSpeed : 3.5
     baseSprintSpeed : 5

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Medical/chemicals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Medical/chemicals.yml
@@ -155,8 +155,9 @@
 
 - type: entity
   parent: N14ChemicalSyringe
-  id: N14ChemicalSyringeAntidote
-  name: antidote
+  id: N14ChemicalSyringeAntidoteEmpty
+  suffix: empty
+  name: antidote syringe
   description: A syringe filled with an effective antitoxin.
   components:
   - type: Sprite
@@ -174,6 +175,14 @@
     maxFillLevels: 1
     changeColor: false
     emptySpriteName: used
+
+- type: entity
+  parent: N14ChemicalSyringeAntidoteEmpty
+  id: N14ChemicalSyringeAntidote
+  suffix: filled
+  name: antidote
+  description: A syringe filled with an effective antitoxin.
+  components:
   - type: SolutionContainerManager
     solutions:
       pen:
@@ -217,15 +226,16 @@
   - type: SolutionContainerManager
     solutions:
       pen:
-        maxVol: 18
+        maxVol: 15
         reagents:
         - ReagentId: MovespeedMixture
-          Quantity: 18
+          Quantity: 15
 
 - type: entity
   parent: N14ChemicalSyringe
-  id: N14Turbo
-  name: Turbo
+  id: N14TurboInhaler
+  suffix: empty
+  name: Turbo inhaler
   description: A small injector filled with a narcotic reagent, that makes you feel as though the world around you is slowing down. It's stronger, and more dangerous than Jet.
   components:
   - type: Sprite
@@ -239,6 +249,18 @@
   - type: Hypospray
     solutionName: pen
     transferAmount: 10
+  - type: SolutionContainerManager
+    solutions:
+      pen:
+        maxVol: 10
+
+- type: entity
+  parent: N14TurboInhaler
+  id: N14Turbo
+  suffix: filled
+  name: Turbo
+  description: A small injector filled with a narcotic reagent, that makes you feel as though the world around you is slowing down. It's stronger, and more dangerous than Jet.
+  components:
   - type: SolutionContainerManager
     solutions:
       pen:
@@ -274,8 +296,9 @@
 
 - type: entity
   parent: N14ChemicalSyringe
-  id: N14Hydra
-  name: hydra
+  id: N14HydraInhaler
+  suffix: empty
+  name: hydra inhaler
   description: A bottle of Supa Yum soda with several vials attached to it. Contains a mildly potent healing chemical that comes with side effects.
   components:
   - type: Sprite
@@ -289,6 +312,15 @@
   - type: Hypospray
     solutionName: pen
     transferAmount: 15
+
+
+- type: entity
+  parent: N14HydraInhaler
+  id: N14Hydra
+  suffix: filled
+  name: hydra
+  description: A bottle of Supa Yum soda with several vials attached to it. Contains a mildly potent healing chemical that comes with side effects.
+  components:
   - type: SolutionContainerManager
     solutions:
       pen:
@@ -299,8 +331,8 @@
 
 - type: entity
   parent: N14ChemicalSyringe
-  id: N14Psycho
-  name: psycho
+  id: N14PsychoSyringe
+  name: psycho syringe
   description: A syringe filled with a reagent designed to make you more violent. Legend has it that these have a military origin.
   components:
   - type: Sprite
@@ -314,6 +346,17 @@
   - type: Hypospray
     solutionName: pen
     transferAmount: 20
+  - type: SolutionContainerManager
+    solutions:
+      pen:
+        maxVol: 20
+
+- type: entity
+  parent: N14PsychoSyringe
+  id: N14Psycho
+  name: psycho
+  description: A syringe filled with a reagent designed to make you more violent. Legend has it that these have a military origin.
+  components:
   - type: SolutionContainerManager
     solutions:
       pen:

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
@@ -367,6 +367,10 @@
       - N14PillCanisterCateye
       - N14PillCanisterFixer
       - N14JetInhaler
+      - N14TurboInhaler
+      - N14HydraInhaler
+      - N14ChemicalSyringeAntidoteEmpty
+      - N14PsychoSyringe
       - N14RadAwayPhialEmpty
       # Misc
       - N14LightTube

--- a/Resources/Prototypes/_Nuclear14/Reagents/chems.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/chems.yml
@@ -141,7 +141,7 @@
 - type: reagent
   id: Cateye
   name: reagent-name-cateye
-  group: Medicine
+  group: Chems
   desc: reagent-desc-cateye
   physicalDesc: reagent-physical-desc-sticky
   color: "#00e5ff"
@@ -155,7 +155,7 @@
 - type: reagent
   id: Buffout
   name: reagent-name-buffout
-  group: Medicine
+  group: Chems
   desc: reagent-desc-buffout
   physicalDesc: reagent-physical-desc-robust
   color: "#00e5ff"
@@ -174,7 +174,7 @@
 - type: reagent
   id: Buffjet
   name: reagent-name-buffjet
-  group: Medicine
+  group: Chems
   desc: reagent-desc-buffjet
   physicalDesc: reagent-physical-desc-robust
   color: "#00e5ff"
@@ -196,7 +196,7 @@
 - type: reagent
   id: Bufftats
   name: reagent-name-bufftats
-  group: Medicine
+  group: Chems
   desc: reagent-desc-bufftats
   physicalDesc: reagent-physical-desc-robust
   color: "#00e5ff"
@@ -217,7 +217,7 @@
 - type: reagent
   id: Mentats
   name: reagent-name-mentats
-  group: Medicine
+  group: Chems
   desc: reagent-desc-mentats
   physicalDesc: reagent-physical-desc-tangy
   color: "#00e5ff"
@@ -233,7 +233,7 @@
 - type: reagent
   id: MentatsBerry
   name: reagent-name-mentats-berry
-  group: Medicine
+  group: Chems
   desc: reagent-desc-mentats-berry
   physicalDesc: reagent-physical-desc-tangy
   color: "#2E0071"
@@ -247,7 +247,7 @@
 - type: reagent
   id: MentatsGrape
   name: reagent-name-mentats-grape
-  group: Medicine
+  group: Chems
   desc: reagent-desc-mentats-grape
   physicalDesc: reagent-physical-desc-tangy
   color: "#9932a4"
@@ -261,7 +261,7 @@
 - type: reagent
   id: MentatsOrange
   name: reagent-name-mentats-orange
-  group: Medicine
+  group: Chems
   desc: reagent-desc-mentats-orange
   physicalDesc: reagent-physical-desc-tangy
   color: "#ffb82e"
@@ -290,7 +290,7 @@
 - type: reagent
   id: Hydra
   name : reagent-name-hydra
-  group: Medicine
+  group: Chems
   desc: reagent-desc-hydra
   physicalDesc: reagent-physical-desc-volatile
   color: "#990099"

--- a/Resources/Prototypes/_Nuclear14/Recipes/Lathes/chemistry.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Lathes/chemistry.yml
@@ -98,6 +98,38 @@
     Plastic: 100
 
 - type: latheRecipe
+  id: N14TurboInhaler
+  result: N14TurboInhaler
+  completetime: 2
+  category: N14Chemistry
+  materials:
+    Plastic: 100
+
+- type: latheRecipe
+  id: N14PsychoSyringe
+  result: N14PsychoSyringe
+  completetime: 2
+  category: N14Chemistry
+  materials:
+    Glass: 100
+
+- type: latheRecipe
+  id: N14ChemicalSyringeAntidoteEmpty
+  result: N14ChemicalSyringeAntidoteEmpty
+  completetime: 2
+  category: N14Chemistry
+  materials:
+    Glass: 100
+
+- type: latheRecipe
+  id: N14HydraInhaler
+  result: N14HydraInhaler
+  completetime: 2
+  category: N14Chemistry
+  materials:
+    Glass: 100
+
+- type: latheRecipe
   id: N14RadAwayPhialEmpty
   result: N14RadAwayPhialEmpty
   completetime: 2

--- a/Resources/Prototypes/_Nuclear14/Recipes/Reactions/chems.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Reactions/chems.yml
@@ -77,3 +77,51 @@
   effects:
     - !type:CreateEntityReactionEffect
       entity: N14Hydra
+
+- type: reaction
+  id: Psycho
+  reactants:
+    N14BloatflyAcid:
+      amount: 1
+    ExtractBroc: #N14:TODO: Add hubflower
+      amount: 2
+    Blood:
+      amount : 1
+    Antiseptic:
+      amount: 2
+  products:
+    DamageModifyingMixture: 3
+
+- type: reaction
+  id: Turbo
+  reactants:
+    N14CazadorAcid:
+      amount: 1
+    ExtractBroc:
+      amount: 1
+    MovespeedMixture:
+      amount : 1
+    Turpentine:
+      amount: 1
+  products:
+    RobustMovespeedMixture: 3
+
+- type: reaction
+  id: Buffjet
+  reactants:
+    MovespeedMixture:
+      amount: 1
+    Buffout:
+      amount: 1
+  products:
+    Buffjet : 1
+
+- type: reaction
+  id: Bufftats
+  reactants:
+    Mentats:
+      amount: 1
+    Buffout:
+      amount: 1
+  products:
+    Bufftats : 1


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->
So this was originally just gonna be hydra but it was an easy fix and all the chems are in the same folder so what the hell. I tried to keep it as close to the recipes as I could find.

Psycho, hydra, turbo, bufftats, and buffjet are now craftable.

The drug containers for psycho, hydra, antidote, and turbo have also been added to the workbench.

Mapped jet was also 18u and crafted containers were 15u. This drove me NUTS so I normalized it all to 15u.

Sadly, we have no hubflower so psycho uses broc flower for now, said recipe I saw also called for acid so I decided to use the oft slept on bloatfly acid, fairly common but still must be fetched. 
 
Other than that the chems that were missing from the guidebook have also been added.

Let me know if you think any of the ratios are funky we can change those easy-peasy.

