### PR TITLE
fixed plant display names

### DIFF
--- a/Resources/Locale/en-US/_Nuclear14/seeds.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/seeds.ftl
@@ -1,11 +1,11 @@
 # Seeds
 clipping-wild-agave-name = wild agave clipping
 clipping-wild-agave-noun = wild agaves clippings
-clipping-wild-agave-display-name = wild agave clipping
+clipping-wild-agave-display-name = wild agave
 
 clipping-wild-banana-yucca-name = wild banana yucca clipping
 clipping-wild-banana-yucca-noun = wild banana yucca clippings
-clipping-wild-banana-yucca-display-name = wild banana yucca clipping
+clipping-wild-banana-yucca-display-name = wild banana yucca
 
 clipping-wild-barrel-cactus-name = wild barrel cactus clipping
 clipping-wild-barrel-cactus-noun = wild barrel cactus clippings
@@ -13,85 +13,80 @@ clipping-wild-barrel-cactus-display-name = wild barrel cactus
 
 clipping-wild-blackberry-name = wild blackberry clipping
 clipping-wild-blackberry-noun = wild blackberry clippings
-clipping-wild-blackberry-display-name = wild blackberry clipping
+clipping-wild-blackberry-display-name = wild blackberry
 
 clipping-wild-broc-name = wild broc clipping
 clipping-wild-broc-noun = wild broc clippings
-clipping-wild-broc-display-name = wild broc clipping
+clipping-wild-broc-display-name = wild broc
 
 clipping-wild-buffalo-gourd-name = wild buffalo bgourd clipping
 clipping-wild-buffalo-gourd-noun = wild buffalo ngourd clippings
-clipping-wild-buffalo-gourd-display-name = wild buffalo gourd clipping
+clipping-wild-buffalo-gourd-display-name = wild buffalo gourd
 
 clipping-wild-cabbage-name = wild cabbage clipping
 clipping-wild-cabbage-noun = wild cabbage clippings
-clipping-wild-cabbage-display-name = wild cabbage clipping
+clipping-wild-cabbage-display-name = wild cabbage
 
 clipping-wild-carrot-name = wild carrot clipping
 clipping-wild-carrot-noun = wild carrot clippings
-clipping-wild-carrot-display-name = wild carrot clipping
+clipping-wild-carrot-display-name = wild carrot
 
 clipping-coyote-tobacco-name = coyote tobacco clipping
 clipping-coyote-tobacco-noun = coyote tobacco clippings
-clipping-coyote-tobacco-display-name = coyote tobacco clipping
+clipping-coyote-tobacco-display-name = coyote tobacco
 
 clipping-datura-name = datura clipping
 clipping-datura-noun = datura clippings
-clipping-datura-display-name = datura clipping
+clipping-datura-display-name = datura
 
 clipping-jalapeno-name = jalapeno clipping
 clipping-jalapeno-noun = jalapeno clippings
-clipping-jalapeno-display-name = jalapeno clipping
+clipping-jalapeno-display-name = jalapeno
 
 clipping-maize-name = maize clipping
 clipping-maize-noun = maize clippings
-clipping-maize-display-name = maize clipping
+clipping-maize-display-name = maize
 
 clipping-mesquite-name = mesquite clipping
 clipping-mesquite-noun = mesquite clippings
-clipping-mesquite-display-name = mesquite clipping
+clipping-mesquite-display-name = mesquite
 
 clipping-mutfruit-name = mutfruit clipping
 clipping-mutfruit-noun = mutfruit clippings
-clipping-mutfruit-display-name = mutfruit clipping
+clipping-mutfruit-display-name = mutfruit
 
 clipping-wild-onion-name = wild onion clipping
 clipping-wild-onion-noun = wild onion clippings
-clipping-wild-onion-display-name = wild onion clipping
+clipping-wild-onion-display-name = wild onion
 
 clipping-pinyon-name = pinyon clipping
 clipping-pinyon-noun = pinyon clippings
-clipping-pinyon-display-name = pinyon clipping
+clipping-pinyon-display-name = pinyon
 
 clipping-pricky-pear-name = pricky pear clipping
 clipping-pricky-pear-noun = pricky pear clippings
-clipping-pricky-pear-display-name = pricky pear clipping
+clipping-pricky-pear-display-name = pricky pear
 
 clipping-wild-razorgrain-name = wild razorgrain clipping
 clipping-wild-razorgrain-noun = wild razorgrain clippings
-clipping-wild-razorgrain-display-name = wild razorgrain clipping
+clipping-wild-razorgrain-display-name = wild razorgrain
 
 clipping-starlight-name = starlight berry clipping
 clipping-starlight-seeds = starlight berry clipping
-clipping-starlight-display-name = starlight berry clipping
-
-
-clipping-starlight-name = starlight berry clipping
-clipping-starlight-seeds = starlight berry clipping
-clipping-starlight-display-name = starlight berries clipping
+clipping-starlight-display-name = starlight berries
 
 clipping-tarberry-name = tarberry clipping
 clipping-tarberry-seeds = tarberry clipping
-clipping-tarberry-display-name = tarberries clipping
+clipping-tarberry-display-name = tarberries
 
 clipping-wild-tato-name = wild tato clipping
 clipping-wild-tato-noun = wild tato clippings
-clipping-wild-tato-display-name = wild tato clipping
+clipping-wild-tato-display-name = wild tato
 
 clipping-wild-white-horsenettle-name = wild white horsenettle clipping
 clipping-wild-white-horsenettle-noun = wild white horsenettle clippings
-clipping-wild-white-horsenettle-display-name = wild white horsenettle clipping
+clipping-wild-white-horsenettle-display-name = wild white horsenettle
 
 clipping-wild-xander-name = wild xander clipping
 clipping-wild-xander-noun = wild xander clippings
-clipping-wild-xander-display-name = wild xander clipping
+clipping-wild-xander-display-name = wild xander

--- a/Resources/Prototypes/_Nuclear14/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/_Nuclear14/Hydroponics/seeds.yml
@@ -523,7 +523,7 @@
   id: N14WildWhiteHorsenettle
   name: clipping-wild-white-horsenettle-name
   noun: clipping-wild-white-horsenettle-noun
-  displayName: clipping-white-horsenettle-display-name
+  displayName: clipping-wild-white-horsenettle-display-name
   plantRsi: _Nuclear14/Objects/Specific/Hydroponics/whitehorsenettle.rsi
   packetPrototype: N14FloraWildWhiteHorsenettleClippingSeed
   productPrototypes:


### PR DESCRIPTION
Revised the display names for plant clippings so that the descriptions now read:

> It looks like you can grow **plant** from these.

As opposed to:

> It looks like you can grow **plant** clippings from these.

Also:

- Corrects one typo in the prototype for white horsenettle which prevented it from showing the correct display name.
- Removes a duplicate seed entry for starlight berries.
