### PR TITLE
better welding fuel generator

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Devices/machine_parts.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Devices/machine_parts.yml
@@ -4,9 +4,6 @@
   name: gas powered generator machine parts
   description: essential parts for making your own gas powered generator.
   components:
-    - type: Sprite
-      sprite: _Nuclear14/Objects/Misc/materials.rsi
-      state: scrap_electronic_2
     - type: MachineBoard
       prototype: N14PortableGeneratorWeldingFuel
       requirements:

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Devices/machine_parts.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Devices/machine_parts.yml
@@ -1,0 +1,22 @@
+- type: entity
+  id: N14PortableGeneratorWeldingFuelMachineParts
+  parent: BaseMachineCircuitboard
+  name: gas powered generator machine parts
+  description: essential parts for making your own gas powered generator.
+  components:
+    - type: Sprite
+      sprite: _Nuclear14/Objects/Misc/materials.rsi
+      state: scrap_electronic_2
+    - type: MachineBoard
+      prototype: N14PortableGeneratorWeldingFuel
+      requirements:
+        Capacitor: 1
+      materialRequirements:
+        Cable: 10
+    - type: PhysicalComposition
+      materialComposition:
+        Glass: 200
+      chemicalComposition:
+        Silicon: 20
+    - type: StaticPrice
+      price: 40

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
@@ -379,6 +379,8 @@
       - N14Matchbox
       # Ammo
       - ArrowRegular
+      # Machine Parts
+      - N14PortableGeneratorWeldingFuelMachineParts
 
 - type: entity
   parent: N14WorkbenchBase

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Power/generators.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Power/generators.yml
@@ -354,3 +354,114 @@
     energy: 4.5
     softness: 0.5
     color: "#f05e1b"
+
+- type: entity
+  name: gas powered generator
+  description: |-
+    A small generator capable of powering individual rooms.
+    Runs off welding fuel and is rated for up to 8 kW.
+    Beware exhaust fumes.
+  parent: PortableGeneratorBase
+  id: N14PortableGeneratorWeldingFuel
+  suffix: Welding Fuel, 8 kW
+  components:
+    - type: AmbientSound
+      range: 4
+      volume: -8
+
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape:
+            !type:PhysShapeAabb
+            bounds: "-0.30,-0.30,0.30,0.30"
+          density: 80
+          mask:
+            - MachineMask
+          layer:
+            - MachineLayer
+
+    - type: Sprite
+      sprite: _Nuclear14/Structures/Power/power.rsi
+      layers:
+      - state: diesel-off
+        map: [ "enum.GeneratorVisualLayers.Body" ]
+    - type: GenericVisualizer
+      visuals:
+        enum.GeneratorVisuals.Running:
+          enum.GeneratorVisualLayers.Body:
+            True: { state: diesel-on }
+            False: { state: diesel-off }
+
+    - type: Machine
+      board: N14PortableGeneratorWeldingFuelMachineParts
+
+    - type: FuelGenerator
+      targetPower: 5000
+      minTargetPower: 1000
+      optimalPower: 8000
+      maxTargetPower: 8000
+      # 15 minutes at full tank.
+      optimalBurnRate: 0.11111111
+      fuelEfficiencyConstant: 0.3
+    - type: ChemicalFuelGeneratorAdapter
+      solution: tank
+      reagents:
+        WeldingFuel: 1
+    - type: SolutionContainerManager
+      solutions:
+        tank:
+          maxVol: 250 #A bucket of welding fuel.
+    - type: RefillableSolution
+      solution: tank
+    - type: PortableGenerator
+      # Unreliable bugger
+      startChance: 0.5
+    - type: NodeContainer
+      examinable: true
+      nodes:
+        output:
+          !type:CableDeviceNode
+          nodeGroupID: Apc
+    - type: PowerMonitoringDevice
+      group: Generator
+      loadNode: output
+      sprite: _Nuclear14/Structures/Power/power.rsi
+      state: diesel-off
+    - type: PowerSupplier
+      voltage: Apc
+      supplyRampTolerance: 2000
+    - type: GeneratorExhaustGas
+      gasType: CarbonDioxide
+      moleRatio: 0.5
+    - type: Explosive
+      explosionType: Default
+      tileBreakScale: 0
+    - type: Destructible
+      thresholds:
+        - trigger:
+            !type:DamageTrigger
+            damage: 200
+          behaviors:
+            - !type:DoActsBehavior
+              acts: [ "Destruction" ]
+        - trigger:
+            !type:DamageTrigger
+            damage: 100
+          behaviors:
+            - !type:SpillBehavior
+              solution: tank
+            - !type:PlaySoundBehavior
+              sound:
+                collection: MetalBreak
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
+            - !type:DoActsBehavior
+              acts: ["Destruction"]
+        - trigger:
+            !type:DamageTypeTrigger
+            damageType: Piercing
+            damage: 75
+          behaviors:
+            - !type:SolutionExplosionBehavior
+              solution: tank

--- a/Resources/Prototypes/_Nuclear14/Recipes/Lathes/machine_parts.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Lathes/machine_parts.yml
@@ -1,0 +1,9 @@
+- type: latheRecipe
+  id: N14PortableGeneratorWeldingFuelMachineParts
+  result: N14PortableGeneratorWeldingFuelMachineParts
+  applyMaterialDiscount: false
+  completetime: 10
+  materials:
+    Glass: 200
+    Steel: 1000
+    Plastic: 500


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

I noticed we had sprites for a diesel generator kicking around and was sick of how awful the JR pacman is, so I decided to make a new portable generator for mappers to use. The gas powered generator uses almost the same stats but tuned to the needs of N14 a bit better. 

Importantly, the fuel capacity has been increased from 50 -> 250 (one bucket of welding fuel) and its minimum load reduced from 4000 -> 1000 to allow greater efficiency. Most builds will never use 4KW so it was just annoyingly wasted.

I also added a machine board for it in case someone felt like deconstructing it. Said board was also added to the workbench, you still have to find some other half made machine to put it into but I figure players would appreciate the option in case someone snags up all the generators laying around. 
</p>
</details>
