### PR TITLE
Add Essentials to NCR MP Starting Kit

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
@@ -254,6 +254,28 @@
     sound:
       path: /Audio/Effects/unwrap.ogg
 
+#MARK: MP Kits
+
+- type: entity
+  name: military police kit
+  parent: KitBase
+  id: KitMilitaryPolice
+  description: A crate containing basic equipment for NCR Military Police Officers
+  components:
+  - type: Sprite
+    state: rifleman
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+      - id: N14WeaponPistol9mm
+      - id: N14MagazinePistol9mm
+        amount: 3 #One more than the standard rifleman kit.
+      - id: N14CombatKnife
+      - id: N14BoxCardboardMREBoxCFilled
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
 #MARK: Ranger Kits
 
 - type: entity

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_mp.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_mp.yml
@@ -32,6 +32,7 @@
     belt: N14PoliceBaton
     outerClothing: N14ClothingOuterNCRLightPouchedVest
     pocket1: Handcuffs
+    pocket2: KitMilitaryPolice
     id: N14IDNCRDogtagMP
   innerClothingSkirt: N14ClothingMPUniformNCRSnow #placeholder
   satchel: N14ClothingBackpackSatchelNCRFilled


### PR DESCRIPTION
# Description
Adds a kit to the NCR MP starting gear, like the rifleman kit, to their second pocket.
The kit contains a standard NCR C Ration Pack, A 9mm Pistol (with three magazines), and a combat knife.

The MPs lack equipment and essential living tools at roundstart. MPs should still be armed as they are soldiers. MPs shouldn't have to go to the storeroom and hope a QM or NCO will give them the equipment they need. If you wish for more justification, feel free to post a comment and I'll provide some more.

I don't love using the rifleman state for the item, but I don't think there is a better alternative at present.

As an alternate they can be given a standard rifleman kit roundstart, but I deemed that to be to excessive.

Image:
![image](https://github.com/user-attachments/assets/89ee6e52-f8c5-446c-aee1-89201b6ad224)

:cl:
- add: Added NCR MP Starting Kit.