### PR TITLE
Update NCR Ranger Badge Desc

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/identification.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/identification.yml
@@ -422,14 +422,14 @@
 - type: entity
   parent: N14IDBadgeNCRDesertRanger
   id: N14IDBadgeNCRRanger
-  description: An ID badge worn by Republic Rangers. Inscribed on it reads: "Quieter than a shadow and more ferocious than a deathclaw."
+  description: An ID badge worn by Republic Rangers. Inscribed on it reads; "Quieter than a shadow and more ferocious than a deathclaw."
   suffix: NCR
 
 
 - type: entity
   parent: N14IDBadgeNCRDesertRangerElite
   id: N14IDBadgeNCRRangerElite
-  description: An ID badge worn by Elite Republic Rangers. Inscribed on it reads: "Quieter than a shadow and more ferocious than a deathclaw."
+  description: An ID badge worn by Elite Republic Rangers. Inscribed on it reads; "Quieter than a shadow and more ferocious than a deathclaw."
   suffix: NCR
 
 #MARK: Townsfolk

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/identification.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/identification.yml
@@ -422,14 +422,14 @@
 - type: entity
   parent: N14IDBadgeNCRDesertRanger
   id: N14IDBadgeNCRRanger
-  description: An ID badge worn by Republic Rangers.
+  description: An ID badge worn by Republic Rangers. Inscribed on it reads: "Quieter than a shadow and more ferocious than a deathclaw."
   suffix: NCR
 
 
 - type: entity
   parent: N14IDBadgeNCRDesertRangerElite
   id: N14IDBadgeNCRRangerElite
-  description: An ID badge worn by Elite Republic Rangers.
+  description: An ID badge worn by Elite Republic Rangers. Inscribed on it reads: "Quieter than a shadow and more ferocious than a deathclaw."
   suffix: NCR
 
 #MARK: Townsfolk


### PR DESCRIPTION
About:
Changes both the NCR Ranger Badge and the NCR Elite Ranger Badge to have a extended description that comes from a lore snippet.

The grammar isn't exactly proper because a : would break the YML, but its fairly close.
