### PR TITLE
Jobs Tab Cleanup

### DIFF
--- a/Resources/Locale/en-US/_Nuclear14/department.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/department.ftl
@@ -3,6 +3,7 @@ department-BrotherhoodMidwest = Midwest Brotherhood of Steel
 department-BrotherhoodWashington = Washington Brotherhood of Steel
 department-CaravanCompany = Caravan Company
 department-NCR = New California Republic
+department-Ranger = Desert Rangers
 department-Tribe = Tribal
 department-Vault = Vault Dwellers
 department-Wastelander = Wastelander

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -1,122 +1,122 @@
 - type: department
- id: Logistics # DeltaV - Logistics Department replacing Cargo
- description: department-Cargo-description
- color: "#A46106"
- roles:
- - CargoTechnician
- - Quartermaster
- - SalvageSpecialist
- - MailCarrier # Nyanotrasen - MailCarrier, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Cargo/mail-carrier.yml
+  id: Logistics # DeltaV - Logistics Department replacing Cargo
+  description: department-Cargo-description
+  color: "#A46106"
+  roles:
+  - CargoTechnician
+  - Quartermaster
+  - SalvageSpecialist
+  - MailCarrier # Nyanotrasen - MailCarrier, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Cargo/mail-carrier.yml
 
 - type: department
- id: Civilian
-description: department-Civilian-description
- color: "#9FED58"
- weight: -10
- roles:
- - Bartender
- - Borg
- - Botanist
- - Boxer
- # - Chaplain # DeltaV - Move Chaplain into Epistemics
- - Chef
- - Clown
- - HeadOfPersonnel
- - Janitor
- # - Lawyer # DeltaV - Move Lawyer into Justice
- - Mime
- - Musician
- - Passenger
- - Reporter
- - Visitor
- - Zookeeper
- - ServiceWorker
- - MartialArtist # Nyanotrasen - MartialArtist, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/martialartist.yml
- - Prisoner # Nyanotrasen - Prisoner, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
- - Gladiator # Nyanotrasen - Gladiator, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
+  id: Civilian
+  description: department-Civilian-description
+  color: "#9FED58"
+  weight: -10
+  roles:
+  - Bartender
+  - Borg
+  - Botanist
+  - Boxer
+  # - Chaplain # DeltaV - Move Chaplain into Epistemics
+  - Chef
+  - Clown
+  - HeadOfPersonnel
+  - Janitor
+  # - Lawyer # DeltaV - Move Lawyer into Justice
+  - Mime
+  - Musician
+  - Passenger
+  - Reporter
+  - Visitor
+  - Zookeeper
+  - ServiceWorker
+  - MartialArtist # Nyanotrasen - MartialArtist, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/martialartist.yml
+  - Prisoner # Nyanotrasen - Prisoner, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
+  - Gladiator # Nyanotrasen - Gladiator, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
 
 - type: department
- id: Command
- description: department-Command-description
- color: "#334E6D"
- roles:
- - Captain
-- CentralCommandOfficial
- - ChiefEngineer
- - ChiefMedicalOfficer
- - HeadOfPersonnel
- - HeadOfSecurity
- - ResearchDirector
- - Quartermaster
- primary: false
- weight: 100
+  id: Command
+  description: department-Command-description
+  color: "#334E6D"
+  roles:
+  - Captain
+  - CentralCommandOfficial
+  - ChiefEngineer
+  - ChiefMedicalOfficer
+  - HeadOfPersonnel
+  - HeadOfSecurity
+  - ResearchDirector
+  - Quartermaster
+  primary: false
+  weight: 100
 
 - type: department
- id: Engineering
- description: department-Engineering-description
- color: "#EFB341"
- roles:
- - AtmosphericTechnician
- - ChiefEngineer
-- SeniorEngineer
- - StationEngineer
- - TechnicalAssistant
+  id: Engineering
+  description: department-Engineering-description
+  color: "#EFB341"
+  roles:
+  - AtmosphericTechnician
+  - ChiefEngineer
+  - SeniorEngineer
+  - StationEngineer
+  - TechnicalAssistant
 
 - type: department
- id: Medical
- description: department-Medical-description
- color: "#52B4E9"
- roles:
- - Chemist
- - ChiefMedicalOfficer
- - MedicalDoctor
- - MedicalIntern
- - Psychologist
- - Paramedic
- - SeniorPhysician
- - MedicalBorg  # Delta V - Medical Borg, see Resources/Prototypes/DeltaV/Roles/Jobs/Medical/medicalborg.yml
+  id: Medical
+  description: department-Medical-description
+  color: "#52B4E9"
+  roles:
+  - Chemist
+  - ChiefMedicalOfficer
+  - MedicalDoctor
+  - MedicalIntern
+  - Psychologist
+  - Paramedic
+  - SeniorPhysician
+  - MedicalBorg  # Delta V - Medical Borg, see Resources/Prototypes/DeltaV/Roles/Jobs/Medical/medicalborg.yml
 
 - type: department
- id: Security
- description: department-Security-description
- color: "#DE3A3A"
- weight: 20
- roles:
- - HeadOfSecurity
- - SecurityCadet
- - SecurityOfficer
- - SeniorOfficer
- - Detective
- - Warden
- - PrisonGuard # Nyanotrasen - PrisonGuard, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
- - Brigmedic # DeltaV - Brigmedic, see Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
-
-- type: department # N14 - All standard departments disabled.
- id: Epistemics # DeltaV - Epistemics Department replacing Science
- description: department-Science-description
- color: "#D381C9"
- roles:
- - ResearchDirector
- - SeniorResearcher
- - Scientist
- - ResearchAssistant
- - Chaplain # DeltaV - Move Chaplain into Epistemics
-- ForensicMantis # Nyanotrasen - ForensicMantis, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
-- Librarian
-- Roboticist
+  id: Security
+  description: department-Security-description
+  color: "#DE3A3A"
+  weight: 20
+  roles:
+  - HeadOfSecurity
+  - SecurityCadet
+  - SecurityOfficer
+  - SeniorOfficer
+  - Detective
+  - Warden
+  - PrisonGuard # Nyanotrasen - PrisonGuard, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
+  - Brigmedic # DeltaV - Brigmedic, see Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
 
 - type: department
- id: Specific
- description: department-Specific-description
- color: "#9FED58"
- weight: 10
- roles:
- - Boxer
- - Reporter
- - Zookeeper
- - Psychologist
- - MartialArtist # Nyanotrasen - MartialArtist, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/martialartist.yml
- - Gladiator # Nyanotrasen - Gladiator, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
- - Prisoner # Nyanotrasen - Prisoner, see Resrouces/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
- - Brigmedic # DeltaV - Corpsman, see Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
- primary: false
+  id: Epistemics # DeltaV - Epistemics Department replacing Science
+  description: department-Science-description
+  color: "#D381C9"
+  roles:
+  - ResearchDirector
+  - SeniorResearcher
+  - Scientist
+  - ResearchAssistant
+  - Chaplain # DeltaV - Move Chaplain into Epistemics
+  - ForensicMantis # Nyanotrasen - ForensicMantis, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+  - Librarian
+  - Roboticist
+
+- type: department
+  id: Specific
+  description: department-Specific-description
+  color: "#9FED58"
+  weight: 10
+  roles:
+  - Boxer
+  - Reporter
+  - Zookeeper
+  - Psychologist
+  - MartialArtist # Nyanotrasen - MartialArtist, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/martialartist.yml
+  - Gladiator # Nyanotrasen - Gladiator, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
+  - Prisoner # Nyanotrasen - Prisoner, see Resrouces/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
+  - Brigmedic # DeltaV - Corpsman, see Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
+  primary: false

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -1,124 +1,122 @@
-# N14 - All standard departments disabled.
+- type: department
+ id: Logistics # DeltaV - Logistics Department replacing Cargo
+ description: department-Cargo-description
+ color: "#A46106"
+ roles:
+ - CargoTechnician
+ - Quartermaster
+ - SalvageSpecialist
+ - MailCarrier # Nyanotrasen - MailCarrier, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Cargo/mail-carrier.yml
 
-# - type: department # N14 - All standard departments disabled.
-#  id: Logistics # DeltaV - Logistics Department replacing Cargo
-#  description: department-Cargo-description
-#  color: "#A46106"
-#  roles:
-#  - CargoTechnician
-#  - Quartermaster
-#  - SalvageSpecialist
-#  - MailCarrier # Nyanotrasen - MailCarrier, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Cargo/mail-carrier.yml
+- type: department
+ id: Civilian
+description: department-Civilian-description
+ color: "#9FED58"
+ weight: -10
+ roles:
+ - Bartender
+ - Borg
+ - Botanist
+ - Boxer
+ # - Chaplain # DeltaV - Move Chaplain into Epistemics
+ - Chef
+ - Clown
+ - HeadOfPersonnel
+ - Janitor
+ # - Lawyer # DeltaV - Move Lawyer into Justice
+ - Mime
+ - Musician
+ - Passenger
+ - Reporter
+ - Visitor
+ - Zookeeper
+ - ServiceWorker
+ - MartialArtist # Nyanotrasen - MartialArtist, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/martialartist.yml
+ - Prisoner # Nyanotrasen - Prisoner, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
+ - Gladiator # Nyanotrasen - Gladiator, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
 
-# - type: department # N14 - All standard departments disabled.
-#  id: Civilian
-# description: department-Civilian-description
-#  color: "#9FED58"
-#  weight: -10
-#  roles:
-#  - Bartender
-#  - Borg
-#  - Botanist
-#  - Boxer
-#  # - Chaplain # DeltaV - Move Chaplain into Epistemics
-#  - Chef
-#  - Clown
-#  - HeadOfPersonnel
-#  - Janitor
-#  # - Lawyer # DeltaV - Move Lawyer into Justice
-#  - Mime
-#  - Musician
-#  - Passenger
-#  - Reporter
-#  - Visitor
-#  - Zookeeper
-#  - ServiceWorker
-#  - MartialArtist # Nyanotrasen - MartialArtist, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/martialartist.yml
-#  - Prisoner # Nyanotrasen - Prisoner, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
-#  - Gladiator # Nyanotrasen - Gladiator, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
+- type: department
+ id: Command
+ description: department-Command-description
+ color: "#334E6D"
+ roles:
+ - Captain
+- CentralCommandOfficial
+ - ChiefEngineer
+ - ChiefMedicalOfficer
+ - HeadOfPersonnel
+ - HeadOfSecurity
+ - ResearchDirector
+ - Quartermaster
+ primary: false
+ weight: 100
 
-#- type: department # N14 - All standard departments disabled.
-#  id: Command
-#  description: department-Command-description
-#  color: "#334E6D"
-#  roles:
-#  - Captain
-# - CentralCommandOfficial
-#  - ChiefEngineer
-#  - ChiefMedicalOfficer
-#  - HeadOfPersonnel
-#  - HeadOfSecurity
-#  - ResearchDirector
-#  - Quartermaster
-#  primary: false
-#  weight: 100
+- type: department
+ id: Engineering
+ description: department-Engineering-description
+ color: "#EFB341"
+ roles:
+ - AtmosphericTechnician
+ - ChiefEngineer
+- SeniorEngineer
+ - StationEngineer
+ - TechnicalAssistant
 
-#- type: department # N14 - All standard departments disabled.
-#  id: Engineering
-#  description: department-Engineering-description
-#  color: "#EFB341"
-#  roles:
-#  - AtmosphericTechnician
-#  - ChiefEngineer
-# - SeniorEngineer
-#  - StationEngineer
-#  - TechnicalAssistant
+- type: department
+ id: Medical
+ description: department-Medical-description
+ color: "#52B4E9"
+ roles:
+ - Chemist
+ - ChiefMedicalOfficer
+ - MedicalDoctor
+ - MedicalIntern
+ - Psychologist
+ - Paramedic
+ - SeniorPhysician
+ - MedicalBorg  # Delta V - Medical Borg, see Resources/Prototypes/DeltaV/Roles/Jobs/Medical/medicalborg.yml
 
-#- type: department # N14 - All standard departments disabled.
-#  id: Medical
-#  description: department-Medical-description
-#  color: "#52B4E9"
-#  roles:
-#  - Chemist
-#  - ChiefMedicalOfficer
-#  - MedicalDoctor
-#  - MedicalIntern
-#  - Psychologist
-#  - Paramedic
-#  - SeniorPhysician
-#  - MedicalBorg  # Delta V - Medical Borg, see Resources/Prototypes/DeltaV/Roles/Jobs/Medical/medicalborg.yml
+- type: department
+ id: Security
+ description: department-Security-description
+ color: "#DE3A3A"
+ weight: 20
+ roles:
+ - HeadOfSecurity
+ - SecurityCadet
+ - SecurityOfficer
+ - SeniorOfficer
+ - Detective
+ - Warden
+ - PrisonGuard # Nyanotrasen - PrisonGuard, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
+ - Brigmedic # DeltaV - Brigmedic, see Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
 
-#- type: department # N14 - All standard departments disabled.
-#  id: Security
-#  description: department-Security-description
-#  color: "#DE3A3A"
-#  weight: 20
-#  roles:
-#  - HeadOfSecurity
-#  - SecurityCadet
-#  - SecurityOfficer
-#  - SeniorOfficer
-#  - Detective
-#  - Warden
-#  - PrisonGuard # Nyanotrasen - PrisonGuard, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
-#  - Brigmedic # DeltaV - Brigmedic, see Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
+- type: department # N14 - All standard departments disabled.
+ id: Epistemics # DeltaV - Epistemics Department replacing Science
+ description: department-Science-description
+ color: "#D381C9"
+ roles:
+ - ResearchDirector
+ - SeniorResearcher
+ - Scientist
+ - ResearchAssistant
+ - Chaplain # DeltaV - Move Chaplain into Epistemics
+- ForensicMantis # Nyanotrasen - ForensicMantis, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+- Librarian
+- Roboticist
 
-#- type: department # N14 - All standard departments disabled.
-#  id: Epistemics # DeltaV - Epistemics Department replacing Science
-#  description: department-Science-description
-#  color: "#D381C9"
-#  roles:
-#  - ResearchDirector
-#  - SeniorResearcher
-#  - Scientist
-#  - ResearchAssistant
-#  - Chaplain # DeltaV - Move Chaplain into Epistemics
-# - ForensicMantis # Nyanotrasen - ForensicMantis, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
-# - Librarian
-# - Roboticist
-
-#- type: department # N14 - All standard departments disabled.
-#  id: Specific
-#  description: department-Specific-description
-#  color: "#9FED58"
-#  weight: 10
-#  roles:
-#  - Boxer
-#  - Reporter
-#  - Zookeeper
-#  - Psychologist
-#  - MartialArtist # Nyanotrasen - MartialArtist, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/martialartist.yml
-#  - Gladiator # Nyanotrasen - Gladiator, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
-#  - Prisoner # Nyanotrasen - Prisoner, see Resrouces/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
-#  - Brigmedic # DeltaV - Corpsman, see Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
-#  primary: false
+- type: department
+ id: Specific
+ description: department-Specific-description
+ color: "#9FED58"
+ weight: 10
+ roles:
+ - Boxer
+ - Reporter
+ - Zookeeper
+ - Psychologist
+ - MartialArtist # Nyanotrasen - MartialArtist, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/martialartist.yml
+ - Gladiator # Nyanotrasen - Gladiator, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
+ - Prisoner # Nyanotrasen - Prisoner, see Resrouces/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
+ - Brigmedic # DeltaV - Corpsman, see Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
+ primary: false

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -1,6 +1,6 @@
 # N14 - All standard departments disabled.
 
-# - type: department
+# - type: department # N14 - All standard departments disabled.
 #  id: Logistics # DeltaV - Logistics Department replacing Cargo
 #  description: department-Cargo-description
 #  color: "#A46106"
@@ -10,7 +10,7 @@
 #  - SalvageSpecialist
 #  - MailCarrier # Nyanotrasen - MailCarrier, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Cargo/mail-carrier.yml
 
-# - type: department
+# - type: department # N14 - All standard departments disabled.
 #  id: Civilian
 # description: department-Civilian-description
 #  color: "#9FED58"
@@ -37,7 +37,7 @@
 #  - Prisoner # Nyanotrasen - Prisoner, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
 #  - Gladiator # Nyanotrasen - Gladiator, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
 
-#- type: department
+#- type: department # N14 - All standard departments disabled.
 #  id: Command
 #  description: department-Command-description
 #  color: "#334E6D"
@@ -53,7 +53,7 @@
 #  primary: false
 #  weight: 100
 
-#- type: department
+#- type: department # N14 - All standard departments disabled.
 #  id: Engineering
 #  description: department-Engineering-description
 #  color: "#EFB341"
@@ -64,7 +64,7 @@
 #  - StationEngineer
 #  - TechnicalAssistant
 
-#- type: department
+#- type: department # N14 - All standard departments disabled.
 #  id: Medical
 #  description: department-Medical-description
 #  color: "#52B4E9"
@@ -78,7 +78,7 @@
 #  - SeniorPhysician
 #  - MedicalBorg  # Delta V - Medical Borg, see Resources/Prototypes/DeltaV/Roles/Jobs/Medical/medicalborg.yml
 
-#- type: department
+#- type: department # N14 - All standard departments disabled.
 #  id: Security
 #  description: department-Security-description
 #  color: "#DE3A3A"
@@ -93,7 +93,7 @@
 #  - PrisonGuard # Nyanotrasen - PrisonGuard, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
 #  - Brigmedic # DeltaV - Brigmedic, see Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
 
-#- type: department
+#- type: department # N14 - All standard departments disabled.
 #  id: Epistemics # DeltaV - Epistemics Department replacing Science
 #  description: department-Science-description
 #  color: "#D381C9"
@@ -107,7 +107,7 @@
 # - Librarian
 # - Roboticist
 
-#- type: department
+#- type: department # N14 - All standard departments disabled.
 #  id: Specific
 #  description: department-Specific-description
 #  color: "#9FED58"

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -1,122 +1,124 @@
-- type: department
-  id: Logistics # DeltaV - Logistics Department replacing Cargo
-  description: department-Cargo-description
-  color: "#A46106"
-  roles:
-  - CargoTechnician
-  - Quartermaster
-  - SalvageSpecialist
-  - MailCarrier # Nyanotrasen - MailCarrier, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Cargo/mail-carrier.yml
+# N14 - All standard departments disabled.
 
-- type: department
-  id: Civilian
-  description: department-Civilian-description
-  color: "#9FED58"
-  weight: -10
-  roles:
-  - Bartender
-  - Borg
-  - Botanist
-  - Boxer
-  # - Chaplain # DeltaV - Move Chaplain into Epistemics
-  - Chef
-  - Clown
-  - HeadOfPersonnel
-  - Janitor
-  # - Lawyer # DeltaV - Move Lawyer into Justice
-  - Mime
-  - Musician
-  - Passenger
-  - Reporter
-  - Visitor
-  - Zookeeper
-  - ServiceWorker
-  - MartialArtist # Nyanotrasen - MartialArtist, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/martialartist.yml
-  - Prisoner # Nyanotrasen - Prisoner, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
-  - Gladiator # Nyanotrasen - Gladiator, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
+# - type: department
+#  id: Logistics # DeltaV - Logistics Department replacing Cargo
+#  description: department-Cargo-description
+#  color: "#A46106"
+#  roles:
+#  - CargoTechnician
+#  - Quartermaster
+#  - SalvageSpecialist
+#  - MailCarrier # Nyanotrasen - MailCarrier, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Cargo/mail-carrier.yml
 
-- type: department
-  id: Command
-  description: department-Command-description
-  color: "#334E6D"
-  roles:
-  - Captain
-  - CentralCommandOfficial
-  - ChiefEngineer
-  - ChiefMedicalOfficer
-  - HeadOfPersonnel
-  - HeadOfSecurity
-  - ResearchDirector
-  - Quartermaster
-  primary: false
-  weight: 100
+# - type: department
+#  id: Civilian
+# description: department-Civilian-description
+#  color: "#9FED58"
+#  weight: -10
+#  roles:
+#  - Bartender
+#  - Borg
+#  - Botanist
+#  - Boxer
+#  # - Chaplain # DeltaV - Move Chaplain into Epistemics
+#  - Chef
+#  - Clown
+#  - HeadOfPersonnel
+#  - Janitor
+#  # - Lawyer # DeltaV - Move Lawyer into Justice
+#  - Mime
+#  - Musician
+#  - Passenger
+#  - Reporter
+#  - Visitor
+#  - Zookeeper
+#  - ServiceWorker
+#  - MartialArtist # Nyanotrasen - MartialArtist, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/martialartist.yml
+#  - Prisoner # Nyanotrasen - Prisoner, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
+#  - Gladiator # Nyanotrasen - Gladiator, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
 
-- type: department
-  id: Engineering
-  description: department-Engineering-description
-  color: "#EFB341"
-  roles:
-  - AtmosphericTechnician
-  - ChiefEngineer
-  - SeniorEngineer
-  - StationEngineer
-  - TechnicalAssistant
+#- type: department
+#  id: Command
+#  description: department-Command-description
+#  color: "#334E6D"
+#  roles:
+#  - Captain
+# - CentralCommandOfficial
+#  - ChiefEngineer
+#  - ChiefMedicalOfficer
+#  - HeadOfPersonnel
+#  - HeadOfSecurity
+#  - ResearchDirector
+#  - Quartermaster
+#  primary: false
+#  weight: 100
 
-- type: department
-  id: Medical
-  description: department-Medical-description
-  color: "#52B4E9"
-  roles:
-  - Chemist
-  - ChiefMedicalOfficer
-  - MedicalDoctor
-  - MedicalIntern
-  - Psychologist
-  - Paramedic
-  - SeniorPhysician
-  - MedicalBorg  # Delta V - Medical Borg, see Resources/Prototypes/DeltaV/Roles/Jobs/Medical/medicalborg.yml
+#- type: department
+#  id: Engineering
+#  description: department-Engineering-description
+#  color: "#EFB341"
+#  roles:
+#  - AtmosphericTechnician
+#  - ChiefEngineer
+# - SeniorEngineer
+#  - StationEngineer
+#  - TechnicalAssistant
 
-- type: department
-  id: Security
-  description: department-Security-description
-  color: "#DE3A3A"
-  weight: 20
-  roles:
-  - HeadOfSecurity
-  - SecurityCadet
-  - SecurityOfficer
-  - SeniorOfficer
-  - Detective
-  - Warden
-  - PrisonGuard # Nyanotrasen - PrisonGuard, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
-  - Brigmedic # DeltaV - Brigmedic, see Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
+#- type: department
+#  id: Medical
+#  description: department-Medical-description
+#  color: "#52B4E9"
+#  roles:
+#  - Chemist
+#  - ChiefMedicalOfficer
+#  - MedicalDoctor
+#  - MedicalIntern
+#  - Psychologist
+#  - Paramedic
+#  - SeniorPhysician
+#  - MedicalBorg  # Delta V - Medical Borg, see Resources/Prototypes/DeltaV/Roles/Jobs/Medical/medicalborg.yml
 
-- type: department
-  id: Epistemics # DeltaV - Epistemics Department replacing Science
-  description: department-Science-description
-  color: "#D381C9"
-  roles:
-  - ResearchDirector
-  - SeniorResearcher
-  - Scientist
-  - ResearchAssistant
-  - Chaplain # DeltaV - Move Chaplain into Epistemics
-  - ForensicMantis # Nyanotrasen - ForensicMantis, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
-  - Librarian
-  - Roboticist
+#- type: department
+#  id: Security
+#  description: department-Security-description
+#  color: "#DE3A3A"
+#  weight: 20
+#  roles:
+#  - HeadOfSecurity
+#  - SecurityCadet
+#  - SecurityOfficer
+#  - SeniorOfficer
+#  - Detective
+#  - Warden
+#  - PrisonGuard # Nyanotrasen - PrisonGuard, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
+#  - Brigmedic # DeltaV - Brigmedic, see Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
 
-- type: department
-  id: Specific
-  description: department-Specific-description
-  color: "#9FED58"
-  weight: 10
-  roles:
-  - Boxer
-  - Reporter
-  - Zookeeper
-  - Psychologist
-  - MartialArtist # Nyanotrasen - MartialArtist, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/martialartist.yml
-  - Gladiator # Nyanotrasen - Gladiator, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
-  - Prisoner # Nyanotrasen - Prisoner, see Resrouces/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
-  - Brigmedic # DeltaV - Corpsman, see Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
-  primary: false
+#- type: department
+#  id: Epistemics # DeltaV - Epistemics Department replacing Science
+#  description: department-Science-description
+#  color: "#D381C9"
+#  roles:
+#  - ResearchDirector
+#  - SeniorResearcher
+#  - Scientist
+#  - ResearchAssistant
+#  - Chaplain # DeltaV - Move Chaplain into Epistemics
+# - ForensicMantis # Nyanotrasen - ForensicMantis, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+# - Librarian
+# - Roboticist
+
+#- type: department
+#  id: Specific
+#  description: department-Specific-description
+#  color: "#9FED58"
+#  weight: 10
+#  roles:
+#  - Boxer
+#  - Reporter
+#  - Zookeeper
+#  - Psychologist
+#  - MartialArtist # Nyanotrasen - MartialArtist, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/martialartist.yml
+#  - Gladiator # Nyanotrasen - Gladiator, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
+#  - Prisoner # Nyanotrasen - Prisoner, see Resrouces/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
+#  - Brigmedic # DeltaV - Corpsman, see Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
+#  primary: false

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/factions.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/factions.yml
@@ -109,9 +109,9 @@
 #  roles:
 #  - Zetan
 
-- type: department
-  id: Followers
-  description: department-Followers-description
-  color: "#33a1c1"
-  roles:
-  - Followers
+#- type: department #Disabled until roles are implemented.
+#  id: Followers
+#  description: department-Followers-description
+#  color: "#33a1c1"
+#  roles:
+#  - Followers

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/factions.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/factions.yml
@@ -44,15 +44,15 @@
   - NCRRanger
   - NCRRangerVeteran
 
-- type: department
-  id: Rangers
-  description: department-Ranger-description
-  color: "#3ab700"
-  roles:
-  - RangerRecruit
-  - Ranger
-  - RangerVeteran
-  - RangerChief
+#- type: department # Disabled until roles are implemented
+#  id: Rangers
+#  description: department-Ranger-description
+#  color: "#3ab700"
+#  roles:
+#  - RangerRecruit
+#  - Ranger
+#  - RangerVeteran
+#  - RangerChief
 
 - type: department
   id: Tribe
@@ -102,12 +102,12 @@
   - TownSheriff
   - TownMayor
 
-- type: department
-  id: Zetan
-  description: department-Zetan-description
-  color: "#7ec133"
-  roles:
-  - Zetan
+#- type: department #Disabled until roles are implemented.
+#  id: Zetan
+#  description: department-Zetan-description
+#  color: "#7ec133"
+#  roles:
+#  - Zetan
 
 - type: department
   id: Followers


### PR DESCRIPTION
About:
Disables Zetan, Desert Rangers, and Followers of the Apocalypse from appearing in the jobs menu.
Fixes the locale string for the Desert Rangers.

(Note: This PR was originally to also disable the ss14 jobs from appearing aswell, but apparently there will be a much easier way to do this soon, so I'm going to wait until that exists to even consider it.)
