### PR TITLE
Fix Mood (Revert PR#564)

### DIFF
--- a/Content.Server/Mood/MoodSystem.cs
+++ b/Content.Server/Mood/MoodSystem.cs
@@ -250,7 +250,8 @@ public sealed class MoodSystem : EntitySystem
         if (_debugMode)
             return;
 
-        if (TryComp<MobThresholdsComponent>(uid, out var mobThresholdsComponent)
+        if (_config.GetCVar(CCVars.MoodModifiesThresholds)
+            && TryComp<MobThresholdsComponent>(uid, out var mobThresholdsComponent)
             && _mobThreshold.TryGetThresholdForState(uid, MobState.Critical, out var critThreshold, mobThresholdsComponent))
             component.CritThresholdBeforeModify = critThreshold.Value;
 
@@ -343,7 +344,8 @@ public sealed class MoodSystem : EntitySystem
 
     private void SetCritThreshold(EntityUid uid, MoodComponent component, int modifier)
     {
-        if (!TryComp<MobThresholdsComponent>(uid, out var mobThresholds)
+        if (!_config.GetCVar(CCVars.MoodModifiesThresholds)
+            || !TryComp<MobThresholdsComponent>(uid, out var mobThresholds)
             || !_mobThreshold.TryGetThresholdForState(uid, MobState.Critical, out var key))
             return;
 

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2446,13 +2446,16 @@ namespace Content.Shared.CCVar
         #region Mood System
 
         public static readonly CVarDef<bool> MoodEnabled =
-            CVarDef.Create("mood.enabled", false, CVar.SERVER);
+            CVarDef.Create("mood.enabled", true, CVar.SERVER);
 
         public static readonly CVarDef<bool> MoodIncreasesSpeed =
             CVarDef.Create("mood.increases_speed", true, CVar.SERVER);
 
         public static readonly CVarDef<bool> MoodDecreasesSpeed =
             CVarDef.Create("mood.decreases_speed", true, CVar.SERVER);
+
+        public static readonly CVarDef<bool> MoodModifiesThresholds =
+            CVarDef.Create("mood.modify_thresholds", false, CVar.SERVER);
 
         #endregion
 


### PR DESCRIPTION
# Description

Thanks for not reporting the fact that there wasn't a CVar for disabling Crit Threshold modification in the MoodSystem. This PR fixes that by adding a CVar to optionally disable that feature of the MoodSystem. 

I'm going to do this upstream as well.