### PR TITLE
Workaround for minor bug that generates too many tracebacks which causes lag

### DIFF
--- a/Content.Server/Temperature/Systems/EntityHeaterSystem.cs
+++ b/Content.Server/Temperature/Systems/EntityHeaterSystem.cs
@@ -42,7 +42,10 @@ public sealed class EntityHeaterSystem : EntitySystem
             var energy = power.PowerReceived * deltaTime;
             foreach (var ent in placer.PlacedEntities)
             {
-                _temperature.ChangeHeat(ent, energy);
+                // Mitigates error for missing component
+                if (HasComp<TemperatureComponent>(ent)){
+                        _temperature.ChangeHeat(ent, energy);
+                }
             }
         }
     }


### PR DESCRIPTION
So, it's not a very insightful commit at all, it's just made out of necessity. Something started to hang the game *very hard* when there were 39 players - no clue how/if those Update calls correlates with population - and I noticed it's a traceback I've been noticing since I started running Nuclear.
The issue still remains and some objects which don't have the TemperatureComponent will be silently ignored and won't get heated. But since the traceback wasn't really such a big help at debugging the issue, plus logging it may still cause the same issue, I decided to just silently ignored.
My server is running this commit already and it seems to work fine with it.
Sorry for disregarding template, it's only due to being such a minor change
Cheers
  