### PR TITLE
Five Hours Playtime Requirement for Mayor

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/townmayor.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/townmayor.yml
@@ -4,6 +4,10 @@
   name: job-name-townmayor
   description: job-description-townmayor
   playTimeTracker: TownMayor
+  requirements:
+    - !type:CharacterDepartmentTimeRequirement
+      department: Townsfolk
+      min: 18000 # 5 hours
   startingGear: TownMayorGear
   icon: "JobIconPassenger"
   supervisors: job-supervisors-townsfolk


### PR DESCRIPTION
# Description

Its weird that the elected mayor of Oasis didn't have a playtime requirement, when roles (that could be considered more important), like deputy and sheriff, do have one.

Apparently its been a frequent issue where first time players (Both to ss14 and the server) are jumping into the mayor role. I think five hours is sufficient to know how things usually go on a round to round basis. Thats asking for two, maybe three rounds, from a player before entering the mayor role.