### PR TITLE
Minor NCR Door Description Fix

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/doors.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/doors.yml
@@ -226,7 +226,7 @@
   id: N14DoorWoodSecureNCR
   name: secure door
   suffix: NCR
-  description: A secure door made from wood and bearing an NCR embled.
+  description: A secure door made from wood and bearing an NCR emblem.
   components:
   - type: Sprite
     netsync: false


### PR DESCRIPTION
There was a typo in the door description and it bothered me enough to fix.
Its a small PR, but someone has to do it I suppose.
