### PR TITLE
Let ID's be put in Wallets

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/currency.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/currency.yml
@@ -19,12 +19,13 @@
   - type: Storage
     grid:
     - 0,0,2,1
-    maxItemSize: Tiny
+    maxItemSize: Normal
     quickInsert: true
     areaInsert: true
     whitelist:
       tags:
       - Currency
+      - DoorBumpOpener
   - type: Dumpable
   - type: Construction
     graph: N14Wallet


### PR DESCRIPTION
**Description**
The Wallet can now fit a Singular ID/Keycard

**Why/Balance**
Wallets have very little use. This actually makes them worthwhile to wear if you have an ID.