### PR TITLE
Gave Medical Roles CPR Training

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/BrotherhoodMidwest/scribe.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/BrotherhoodMidwest/scribe.yml
@@ -20,6 +20,7 @@
       - type: NpcFactionMember
         factions:
           - BrotherhoodMidwest
+      - type: CPRTraining
   jobBlockForSpecies:
   - !type:JobBlockForSpecie
     nameSpecie: Ghoul

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/BrotherhoodWashington/scribe.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/BrotherhoodWashington/scribe.yml
@@ -21,6 +21,7 @@
       - type: NpcFactionMember
         factions:
           - BrotherhoodWashington
+      - type: CPRTraining
   jobBlockForSpecies:
   - !type:JobBlockForSpecie
     nameSpecie: Ghoul

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/CaravanCompany/caravan_leader.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/CaravanCompany/caravan_leader.yml
@@ -21,6 +21,7 @@
       - type: NpcFactionMember
         factions:
           - CaravanCompany
+      - type: CPRTraining
 
 - type: startingGear
   id: CaravanLeaderGear

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_doctor.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NCR/ncr_doctor.yml
@@ -21,6 +21,7 @@
       - type: NpcFactionMember
         factions:
           - NCR
+      - type: CPRTraining
 
 - type: startingGear
   id: NCRDoctorGear

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/Towndoctor.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/Towndoctor.yml
@@ -15,6 +15,7 @@
       - type: NpcFactionMember
         factions:
           - Townsfolk
+      - type: CPRTraining
 
 - type: startingGear
   id: TownDoctorGear

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Tribal/tribalhealer.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Tribal/tribalhealer.yml
@@ -13,6 +13,7 @@
       - type: NpcFactionMember
         factions:
           - Tribal
+      - type: CPRTraining
 
 - type: startingGear
   id: TribalHealerGear

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/VaultDwellers/vaultdoctor.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/VaultDwellers/vaultdoctor.yml
@@ -16,6 +16,7 @@
       - type: NpcFactionMember
         factions:
           - Vault
+      - type: CPRTraining
   jobBlockForSpecies:
   - !type:JobBlockForSpecie
     nameSpecie: Ghoul


### PR DESCRIPTION
**Description**
ROLES GIVEN CPR TRAINING
Caravan Leader
BOS Scribes
Town Doctor
Vault Doctor
NCR Doctor
Tribe Healer

**Why/Balance**
Medical Roles are intended to have CPR training by default, this also is a major QOL thing considering that currently the only Airloss med is Smelling Salts

Anyone else can take the trait for CPR training if they want it.