### PR TITLE
Farm Equipment Crafting

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
@@ -329,6 +329,11 @@
       - N14Shovel
       - N14SprayPainter
       - N14ClothingEyesGlassesWelding
+      - N14HydroponicsToolHoe
+      - N14HydroponicsToolHatchet
+      - HydroponicsToolSpade
+      - N14HydroponicsToolScythe
+      - N14HydroponicsToolClippers
       # Kitchen
       - N14ButchersCleaver
       - N14KitchenKnife

--- a/Resources/Prototypes/_Nuclear14/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Lathes/tools.yml
@@ -191,3 +191,43 @@
   materials:
     Steel: 100
     Circuitry: 100
+
+- type: latheRecipe
+  id: N14HydroponicsToolClippers
+  result: N14HydroponicsToolClippers
+  category: N14Tools
+  completetime: 3
+  materials:
+    Steel: 100
+
+- type: latheRecipe
+  id: N14HydroponicsToolHatchet
+  result: N14HydroponicsToolHatchet
+  category: N14Tools
+  completetime: 3
+  materials:
+    Steel: 100
+
+- type: latheRecipe
+  id: N14HydroponicsToolScythe
+  result: N14HydroponicsToolScythe
+  category: N14Tools
+  completetime: 5
+  materials:
+    Steel: 200
+
+- type: latheRecipe
+  id: HydroponicsToolSpade
+  result: HydroponicsToolSpade
+  category: N14Tools
+  completetime: 3
+  materials:
+    Steel: 100
+
+- type: latheRecipe
+  id: N14HydroponicsToolHoe
+  result: N14HydroponicsToolHoe
+  category: N14Tools
+  completetime: 3
+  materials:
+    Steel: 100


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

you couldn't craft these. I felt bad stealing them. Now you can craft them, farmers rejoice!

made at the common workbench, uses a bit of steel. I considered plastic for the handle but that seems cruel and unusual. Maybe in the future we can have a wooden handle sprite for hydroponics tools and make the recipe use wood as well buut until then I think this will do fine.

---

