### PR TITLE
Non Job-Specific Item Groups

### DIFF
--- a/Resources/Locale/en-US/_Nuclear14/Loadouts/itemgroups.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/Loadouts/itemgroups.ftl
@@ -1,0 +1,12 @@
+character-item-group-N14LoadoutEyes = Eyewear
+character-item-group-N14LoadoutHands = Gloves
+character-item-group-N14LoadoutHead = Headgear
+character-item-group-N14LoadoutMask = Masks
+character-item-group-N14LoadoutSmokeables = Smokeables
+character-item-group-N14LoadoutLighters = Lighters
+character-item-group-N14LoadoutGuns = Guns
+character-item-group-N14LoadoutAmmo = Ammo
+character-item-group-N14LoadoutMelee = Melee Weapons
+character-item-group-N14LoadoutNeck = Neckwear
+character-item-group-N14LoadoutOuter = Outerwear
+character-item-group-N14LoadoutShoes = Shoes

--- a/Resources/Prototypes/_Nuclear14/CharacterItemGroups/eyesGroup.yml
+++ b/Resources/Prototypes/_Nuclear14/CharacterItemGroups/eyesGroup.yml
@@ -1,0 +1,11 @@
+- type: characterItemGroup
+  id: N14LoadoutEyes
+  items:
+    - type: loadout
+      id: N14ClothingEyesGlassesWelding
+    - type: loadout
+      id: N14ClothingEyesSunGlasses
+    - type: loadout
+      id: N14ClothingEyesGlasses
+    - type: loadout
+      id: N14LoadoutEyesEyepatch

--- a/Resources/Prototypes/_Nuclear14/CharacterItemGroups/handsGroup.yml
+++ b/Resources/Prototypes/_Nuclear14/CharacterItemGroups/handsGroup.yml
@@ -1,0 +1,11 @@
+- type: characterItemGroup
+  id: N14LoadoutHands
+  items:
+    - type: loadout
+      id: N14LoadoutHandsGlovesCloth
+    - type: loadout
+      id: N14LoadoutHandsGlovesLeather
+    - type: loadout
+      id: N14LoadoutHandsGlovesFur
+    - type: loadout
+      id: N14LoadoutHandsGlovesBlackLeather

--- a/Resources/Prototypes/_Nuclear14/CharacterItemGroups/headGroup.yml
+++ b/Resources/Prototypes/_Nuclear14/CharacterItemGroups/headGroup.yml
@@ -1,0 +1,23 @@
+- type: characterItemGroup
+  id: N14LoadoutHead
+  items:
+    - type: loadout
+      id: N14LoadoutHeadHatBaseball
+    - type: loadout
+      id: N14LoadoutHeadHatTrucker
+    - type: loadout
+      id: N14LoadoutHeadHatBeanie
+    - type: loadout
+      id: N14LoadoutHeadHatHeadscarf
+    - type: loadout
+      id: N14LoadoutHeadHatBandit
+    - type: loadout
+      id: N14LoadoutHeadHatTribalOutcastHood
+    - type: loadout
+      id: N14LoadoutHeadHatArmyCap
+    - type: loadout
+      id: N14ClothingHeadHatCowboyGrey
+    - type: loadout
+      id: N14ClothingHeadHatCowboyGreyBanded
+    - type: loadout
+      id: N14ClothingHeadHatCowboyBrown

--- a/Resources/Prototypes/_Nuclear14/CharacterItemGroups/maskGroup.yml
+++ b/Resources/Prototypes/_Nuclear14/CharacterItemGroups/maskGroup.yml
@@ -1,0 +1,15 @@
+- type: characterItemGroup
+  id: N14LoadoutMask
+  items:
+    - type: loadout
+      id: ClothingMaskBat
+    - type: loadout
+      id: ClothingMaskBear
+    - type: loadout
+      id: ClothingMaskBee
+    - type: loadout
+      id: ClothingMaskJackal
+    - type: loadout
+      id: ClothingMaskRat
+    - type: loadout
+      id: ClothingMaskRaven

--- a/Resources/Prototypes/_Nuclear14/CharacterItemGroups/miscGroups.yml
+++ b/Resources/Prototypes/_Nuclear14/CharacterItemGroups/miscGroups.yml
@@ -1,0 +1,51 @@
+- type: characterItemGroup
+  id: N14LoadoutSmokeables
+  items:
+    - type: loadout
+      id: N14LoadoutItemCigsSalem
+    - type: loadout
+      id: N14LoadoutItemCigsKool
+    - type: loadout
+      id: N14LoadoutItemCigsMarlboro
+    - type: loadout
+      id: N14LoadoutItemCigsWinston
+    - type: loadout
+      id: N14LoadoutItemCigsCustom
+    - type: loadout
+      id: N14LoadoutItemCigsRepublics
+
+- type: characterItemGroup
+  id: N14LoadoutLighters
+  items:
+    - type: loadout
+      id: N14LoadoutItemLighter
+    - type: loadout
+      id: N14LoadoutItemLighterCheap
+    - type: loadout
+      id: N14LoadoutItemMatches
+
+- type: characterItemGroup
+  id: N14LoadoutGuns
+  items:
+    - type: loadout
+      id: N14WeaponRevolver9mm
+    - type: loadout
+      id: N14WeaponPistol10mmPipe
+    - type: loadout
+      id: N14WeaponPistol9mm
+    - type: loadout
+      id: N14WeaponPistol22lr
+    - type: loadout
+      id: N14WeaponShotgunDoubleBarrel
+
+- type: characterItemGroup
+  id: N14LoadoutAmmo
+  items:
+    - type: loadout
+      id: N14SpeedLoader9
+
+- type: characterItemGroup
+  id: N14LoadoutMelee
+  items:
+    - type: loadout
+      id: N14KitchenKnife

--- a/Resources/Prototypes/_Nuclear14/CharacterItemGroups/neckGroup.yml
+++ b/Resources/Prototypes/_Nuclear14/CharacterItemGroups/neckGroup.yml
@@ -1,0 +1,7 @@
+- type: characterItemGroup
+  id: N14LoadoutNeck
+  items:
+    - type: loadout
+      id: N14LoadoutNeckCloakLeather
+    - type: loadout
+      id: N14LoadoutNeckMantleLeather

--- a/Resources/Prototypes/_Nuclear14/CharacterItemGroups/outerwearGroup.yml
+++ b/Resources/Prototypes/_Nuclear14/CharacterItemGroups/outerwearGroup.yml
@@ -1,0 +1,47 @@
+- type: characterItemGroup
+  id: N14LoadoutOuter
+  items:
+    - type: loadout
+      id: N14LoadoutOuterGhostSheet
+    - type: loadout
+      id: N14LoadoutOuterJacketLettermanRed
+    - type: loadout
+      id: N14LoadoutOuterJacketLettermanBrown
+    - type: loadout
+      id: N14LoadoutOuterRobeHubologist
+    - type: loadout
+      id: N14ClothingOuterFlannelRed
+    - type: loadout
+      id: N14ClothingOuterFlannelAqua
+    - type: loadout
+      id: N14ClothingOuterFlannelBrown
+    - type: loadout
+      id: N14LoadoutOuterCoatWinterArmored
+    - type: loadout
+      id: N14LoadoutOuterCoatBattlecoat
+    - type: loadout
+      id: N14LoadoutOuterCoatBattlecoatTan
+    - type: loadout
+      id: N14LoadoutOuterCoatDuster
+    - type: loadout
+      id: N14LoadoutOuterCoatLeatherDuster
+    - type: loadout
+      id: N14ClothingOuterCoatLeatherJacket
+    - type: loadout
+      id: N14ClothingOuterCoatLeatherCoat
+    - type: loadout
+      id: N14ClothingOuterTownCoat
+    - type: loadout
+      id: N14ClothingOuterTownMediumCoat
+    - type: loadout
+      id: N14LoadoutOuterLeatherArmor
+    - type: loadout
+      id: N14LoadoutOuterMetalArmor
+    - type: loadout
+      id: N14LoadoutOuterTribalArmor
+    - type: loadout
+      id: N14LoadoutOuterTribalArmorHeavy
+    - type: loadout
+      id: N14LoadoutOuterRaiderBadlands
+    - type: loadout
+      id: N14LoadoutOuterRaiderBlastmaster

--- a/Resources/Prototypes/_Nuclear14/CharacterItemGroups/shoesGroup.yml
+++ b/Resources/Prototypes/_Nuclear14/CharacterItemGroups/shoesGroup.yml
@@ -1,0 +1,15 @@
+- type: characterItemGroup
+  id: N14LoadoutShoes
+  items:
+    - type: loadout
+      id: N14LoadoutShoesBlack
+    - type: loadout
+      id: N14LoadoutShoesBrown
+    - type: loadout
+      id: N14LoadoutShoesRags
+    - type: loadout
+      id: N14LoadoutBootsCowboy
+    - type: loadout
+      id: N14LoadoutBootsBlack
+    - type: loadout
+      id: N14ClothingBootsCombat

--- a/Resources/Prototypes/_Nuclear14/Loadouts/eyes.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/eyes.yml
@@ -1,27 +1,39 @@
 - type: loadout
   id: N14ClothingEyesGlassesWelding
   category: Accessories
-  cost: 4
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutEyes
   items:
     - N14ClothingEyesGlassesWelding
 
 - type: loadout
   id: N14ClothingEyesSunGlasses
   category: Accessories
-  cost: 2
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutEyes
   items:
     - N14ClothingEyesSunGlasses
 
 - type: loadout
-  id: N14ClothingEyesGlasses 
+  id: N14ClothingEyesGlasses
   category: Accessories
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutEyes
   items:
     - N14ClothingEyesGlasses
 
 - type: loadout
   id: N14LoadoutEyesEyepatch
   category: Accessories
-  cost: 1
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutEyes
   items:
     - ClothingEyesEyepatch

--- a/Resources/Prototypes/_Nuclear14/Loadouts/hands.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/hands.yml
@@ -1,27 +1,39 @@
 - type: loadout
   id: N14LoadoutHandsGlovesCloth
   category: Hands
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHands
   items:
     - N14ClothingHandsGlovesCloth
 
 - type: loadout
   id: N14LoadoutHandsGlovesLeather
   category: Hands
-  cost: 4
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHands
   items:
     - N14ClothingHandsGlovesLeather
 
 - type: loadout
   id: N14LoadoutHandsGlovesFur
   category: Hands
-  cost: 4
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHands
   items:
     - N14ClothingHandsGlovesFur
 
 - type: loadout
   id: N14LoadoutHandsGlovesBlackLeather
   category: Hands
-  cost: 4
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHands
   items:
     - N14ClothingHandsGlovesBlackLeather

--- a/Resources/Prototypes/_Nuclear14/Loadouts/head.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/head.yml
@@ -1,70 +1,99 @@
 - type: loadout
   id: N14LoadoutHeadHatBaseball
   category: Head
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHead
   items:
     - N14ClothingHeadHatBaseball
-    
+
 - type: loadout
   id: N14LoadoutHeadHatTrucker
   category: Head
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHead
   items:
     - N14ClothingHeadHatTrucker
 
-    
 - type: loadout
   id: N14LoadoutHeadHatBeanie
   category: Head
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHead
   items:
     - N14ClothingHeadHatBeanie
 
 - type: loadout
   id: N14LoadoutHeadHatHeadscarf
   category: Head
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHead
   items:
     - N14ClothingHeadHatHeadscarf
-    
+
 - type: loadout
   id: N14LoadoutHeadHatBandit
   category: Head
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHead
   items:
     - N14ClothingHeadHatBandit
-    
+
 - type: loadout
   id: N14LoadoutHeadHatTribalOutcastHood
   category: Head
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHead
   items:
     - N14ClothingHeadHatTribalOutcastHood
 
 - type: loadout
   id: N14LoadoutHeadHatArmyCap
   category: Head
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHead
   items:
     - N14ClothingHeadHatArmyCap
 
 - type: loadout
   id: N14ClothingHeadHatCowboyGrey
   category: Head
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHead
   items:
     - N14ClothingHeadHatCowboyGrey
 
 - type: loadout
   id: N14ClothingHeadHatCowboyGreyBanded
   category: Head
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHead
   items:
     - N14ClothingHeadHatCowboyGreyBanded
 
 - type: loadout
   id: N14ClothingHeadHatCowboyBrown
   category: Head
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHead
   items:
-    - N14ClothingHeadHatCowboyBrown 
+    - N14ClothingHeadHatCowboyBrown

--- a/Resources/Prototypes/_Nuclear14/Loadouts/items.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/items.yml
@@ -1,81 +1,4 @@
 - type: loadout
-  id: N14WeaponRevolver9mm
-  category: Items
-  cost: 3
-  items:
-    - N14WeaponRevolver9mm
-
-- type: loadout
-  id: N14SpeedLoader9
-  category: Items
-  cost: 3
-  items:
-    - SpeedLoader9
-
-- type: loadout
-  id: N14WeaponPistol22lr
-  category: Items
-  cost: 6
-  items:
-    - N14WeaponPistol22lr
-
-- type: loadout
-  id: N14WeaponShotgunDoubleBarrel 
-  category: Items
-  cost: 4
-  items:
-    - N14WeaponShotgunDoubleBarrel 
-
-- type: loadout
-  id: N14KitchenKnife
-  category: Items
-  cost: 5
-  items:
-    - N14KitchenKnife 
-
-- type: loadout
-  id: ClothingMaskBat 
-  category: Items
-  cost: 4
-  items:
-    - ClothingMaskBat
-
-- type: loadout
-  id: ClothingMaskBear
-  category: Items
-  cost: 4
-  items:
-    - ClothingMaskBear
-
-- type: loadout
-  id: ClothingMaskBee
-  category: Items
-  cost: 4
-  items:
-    - ClothingMaskFox
-
-- type: loadout
-  id: ClothingMaskJackal
-  category: Items
-  cost: 4
-  items:
-    - ClothingMaskJackal
-
-- type: loadout
-  id: ClothingMaskRat
-  category: Items
-  cost: 4
-  items:
-    - ClothingMaskRat 
-
-- type: loadout
-  id: ClothingMaskRaven
-  category: Items
-  cost: 4
-  items:
-    - ClothingMaskRaven
-
-- type: loadout
   id: N14InstrumentBanjo
   category: Items
   cost: 5
@@ -87,7 +10,7 @@
   category: Items
   cost: 5
   items:
-    - N14InstrumentClarinet 
+    - N14InstrumentClarinet
 
 - type: loadout
   id: N14InstrumentFlute
@@ -97,39 +20,39 @@
     - N14InstrumentFlute
 
 - type: loadout
-  id: N14InstrumentGuitar 
+  id: N14InstrumentGuitar
   category: Items
   cost: 5
   items:
-    - N14InstrumentGuitar 
+    - N14InstrumentGuitar
 
 - type: loadout
-  id: N14InstrumentHarmonica 
+  id: N14InstrumentHarmonica
   category: Items
   cost: 5
   items:
-    - N14InstrumentHarmonica 
+    - N14InstrumentHarmonica
 
 - type: loadout
   id: N14InstrumentPanflute
   category: Items
   cost: 5
   items:
-    - N14InstrumentPanflute 
+    - N14InstrumentPanflute
 
 - type: loadout
-  id: N14InstrumentSaxaphone  
+  id: N14InstrumentSaxaphone
   category: Items
   cost: 5
   items:
-    - N14InstrumentSaxaphone 
+    - N14InstrumentSaxaphone
 
 - type: loadout
-  id: N14InstrumentTrombone 
+  id: N14InstrumentTrombone
   category: Items
   cost: 5
   items:
-    - N14InstrumentTrombone 
+    - N14InstrumentTrombone
 
 - type: loadout
   id: N14InstrumentTrumpet
@@ -139,75 +62,104 @@
     - N14InstrumentTrumpet
 
 - type: loadout
-  id: N14InstrumentViolin 
+  id: N14InstrumentViolin
   category: Items
   cost: 5
   items:
     - N14InstrumentViolin
 
+# Smokeables
 - type: loadout
   id: N14LoadoutItemCigsSalem
   category: Items
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutSmokeables
   items:
     - N14CigarettePackSalem
-    
+
 - type: loadout
   id: N14LoadoutItemCigsKool
   category: Items
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutSmokeables
   items:
     - N14CigarettePackKool
-    
+
 - type: loadout
   id: N14LoadoutItemCigsMarlboro
   category: Items
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutSmokeables
   items:
     - N14CigarettePackMarlboro
-    
+
 - type: loadout
   id: N14LoadoutItemCigsWinston
   category: Items
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutSmokeables
   items:
     - N14CigarettePackWinston
-    
+
 - type: loadout
   id: N14LoadoutItemCigsCustom
   category: Items
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutSmokeables
   items:
     - N14CigarettePackCustom
-    
+
 - type: loadout
   id: N14LoadoutItemCigsRepublics
   category: Items
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutSmokeables
   items:
     - N14CigarettePackRepublics
 
+# Lighters
 - type: loadout
   id: N14LoadoutItemLighter
   category: Items
-  cost: 2
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutLighters
   items:
     - Lighter
 
 - type: loadout
   id: N14LoadoutItemLighterCheap
   category: Items
-  cost: 1
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutLighters
   items:
     - CheapLighter
 
 - type: loadout
   id: N14LoadoutItemMatches
   category: Items
-  cost: 1
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutLighters
   items:
     - Matchbox
-    
+
 - type: loadout
   id: N14LoadoutItemWallet
   category: Items
@@ -215,15 +167,13 @@
   items:
     - N14Wallet
 
-
 - type: loadout
-  id: d6Dice 
+  id: d6Dice
   category: Items
   cost: 0
   items:
-    - d6Dice 
+    - d6Dice
 
-    
 - type: loadout
   id: N14LoadoutItemCanteen
   category: Items
@@ -237,4 +187,3 @@
   cost: 0
   items:
     - N14Cigarette
-

--- a/Resources/Prototypes/_Nuclear14/Loadouts/masks.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/masks.yml
@@ -1,0 +1,59 @@
+- type: loadout
+  id: ClothingMaskBat
+  category: Items
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutMask
+  items:
+    - ClothingMaskBat
+
+- type: loadout
+  id: ClothingMaskBear
+  category: Items
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutMask
+  items:
+    - ClothingMaskBear
+
+- type: loadout
+  id: ClothingMaskBee
+  category: Items
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutMask
+  items:
+    - ClothingMaskFox
+
+- type: loadout
+  id: ClothingMaskJackal
+  category: Items
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutMask
+  items:
+    - ClothingMaskJackal
+
+- type: loadout
+  id: ClothingMaskRat
+  category: Items
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutMask
+  items:
+    - ClothingMaskRat
+
+- type: loadout
+  id: ClothingMaskRaven
+  category: Items
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutMask
+  items:
+    - ClothingMaskRaven

--- a/Resources/Prototypes/_Nuclear14/Loadouts/neck.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/neck.yml
@@ -1,13 +1,19 @@
 - type: loadout
   id: N14LoadoutNeckCloakLeather
   category: Accessories
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutNeck
   items:
     - N14ClothingNeckCloakLeather
 
 - type: loadout
   id: N14LoadoutNeckMantleLeather
   category: Accessories
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutNeck
   items:
     - N14ClothingNeckMantleLeather

--- a/Resources/Prototypes/_Nuclear14/Loadouts/outerClothing.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/outerClothing.yml
@@ -1,154 +1,219 @@
 - type: loadout
   id: N14LoadoutOuterGhostSheet
   category: Outer
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
     - ClothingOuterGhostSheet
-    
+
 - type: loadout
   id: N14LoadoutOuterJacketLettermanRed
   category: Outer
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
     - N14ClothingOuterJacketLettermanRed
-    
+
 - type: loadout
   id: N14LoadoutOuterJacketLettermanBrown
   category: Outer
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
     - N14ClothingOuterJacketLettermanBrown
-    
+
 - type: loadout
   id: N14LoadoutOuterRobeHubologist
   category: Outer
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
     -  N14ClothingOuterRobeHubologist
-    
+
 - type: loadout
   id: N14ClothingOuterFlannelRed
   category: Outer
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
     -  N14ClothingOuterFlannelRed
-    
+
 - type: loadout
   id: N14ClothingOuterFlannelAqua
   category: Outer
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
     -  N14ClothingOuterFlannelAqua
-    
+
 - type: loadout
   id: N14ClothingOuterFlannelBrown
   category: Outer
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
     -  N14ClothingOuterFlannelBrown
-    
+
 - type: loadout
   id: N14LoadoutOuterCoatWinterArmored
   category: Outer
-  cost: 5
+  cost: 3
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
     - N14ClothingOuterCoatWinterArmored
-    
+
 - type: loadout
   id: N14LoadoutOuterCoatBattlecoat
   category: Outer
-  cost: 5
+  cost: 3
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
     - N14ClothingOuterBattlecoatCoat
-    
+
 - type: loadout
   id: N14LoadoutOuterCoatBattlecoatTan
   category: Outer
-  cost: 5
+  cost: 3
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
     - N14ClothingOuterBattlecoatTan
-    
+
 - type: loadout
   id: N14LoadoutOuterCoatDuster
   category: Outer
-  cost: 3
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
     - N14ClothingOuterCoatDuster
-    
+
 - type: loadout
   id: N14LoadoutOuterCoatLeatherDuster
   category: Outer
-  cost: 3
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
     - N14ClothingOuterCoatLeatherDuster
 
 - type: loadout
   id: N14ClothingOuterCoatLeatherJacket
   category: Outer
-  cost: 3
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
-    - N14ClothingOuterCoatLeatherJacket 
+    - N14ClothingOuterCoatLeatherJacket
 
 - type: loadout
   id: N14ClothingOuterCoatLeatherCoat
   category: Outer
-  cost: 3
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
     - N14ClothingOuterCoatLeatherCoat
 
 - type: loadout
   id: N14ClothingOuterTownCoat
   category: Outer
-  cost: 3
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
-    - N14ClothingOuterTownCoat 
+    - N14ClothingOuterTownCoat
 
 - type: loadout
   id: N14ClothingOuterTownMediumCoat
   category: Outer
-  cost: 5
+  cost: 3
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
     - N14ClothingOuterTownMediumCoat
-
 
 - type: loadout
   id: N14LoadoutOuterLeatherArmor
   category: Outer
-  cost: 5
+  cost: 3
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
     - N14ClothingOuterLeatherArmor
-    
+
 - type: loadout
   id: N14LoadoutOuterMetalArmor
   category: Outer
-  cost: 5
+  cost: 3
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
     - N14ClothingOuterMetalArmor
-    
+
 - type: loadout
   id: N14LoadoutOuterTribalArmor
   category: Outer
-  cost: 4
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
     - N14ClothingOuterTribalArmorHeavy
-    
+
 - type: loadout
   id: N14LoadoutOuterTribalArmorHeavy
   category: Outer
-  cost: 5
+  cost: 3
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
     - N14ClothingOuterTribalArmorHeavy
-    
+
 - type: loadout
   id: N14LoadoutOuterRaiderBadlands
   category: Outer
-  cost: 5
+  cost: 3
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
     - N14ClothingOuterRaiderBadlands
-    
+
 - type: loadout
   id: N14LoadoutOuterRaiderBlastmaster
   category: Outer
-  cost: 5
+  cost: 3
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
   items:
     - N14ClothingOuterRaiderBlastmaster

--- a/Resources/Prototypes/_Nuclear14/Loadouts/shoes.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/shoes.yml
@@ -1,41 +1,59 @@
 - type: loadout
   id: N14LoadoutShoesBlack
   category: Shoes
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutShoes
   items:
     - N14ClothingShoesBlack
 
 - type: loadout
   id: N14LoadoutShoesBrown
   category: Shoes
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutShoes
   items:
     - N14ClothingShoesBrown
 
 - type: loadout
   id: N14LoadoutShoesRags
   category: Shoes
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutShoes
   items:
     - N14ClothingShoesRags
 
 - type: loadout
   id: N14LoadoutBootsCowboy
   category: Shoes
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutShoes
   items:
     - N14ClothingBootsCowboy
 
 - type: loadout
   id: N14LoadoutBootsBlack
   category: Shoes
-  cost: 2
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutShoes
   items:
     - N14ClothingBootsBlack
 
 - type: loadout
   id: N14ClothingBootsCombat
   category: Shoes
-  cost: 4
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutShoes
   items:
     - N14ClothingBootsCombat

--- a/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
@@ -1,0 +1,73 @@
+# Pistols
+- type: loadout
+  id: N14WeaponPistol22lr
+  category: Items
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutGuns
+  items:
+    - N14WeaponPistol22lr
+
+- type: loadout
+  id: N14WeaponRevolver9mm
+  category: Items
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutGuns
+  items:
+    - N14WeaponRevolver9mm
+
+- type: loadout
+  id: N14WeaponPistol10mmPipe
+  category: Items
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutGuns
+  items:
+    - N14WeaponPistol10mmPipe
+
+- type: loadout
+  id: N14WeaponPistol9mm
+  category: Items
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutGuns
+  items:
+    - N14WeaponPistol9mm
+
+# Shotguns
+- type: loadout
+  id: N14WeaponShotgunDoubleBarrel
+  category: Items
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutGuns
+  items:
+    - N14WeaponShotgunDoubleBarrel
+
+# Ammo
+- type: loadout
+  id: N14SpeedLoader9
+  category: Items
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutAmmo
+  items:
+    - SpeedLoader9
+
+# Melee
+- type: loadout
+  id: N14KitchenKnife
+  category: Items
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutMelee
+  items:
+    - N14KitchenKnife


### PR DESCRIPTION
# Description

This PR creates a set of CharacterItemGroups for most non job-specific items, while also significantly discounting said items. Most basic character customization items are made completely free, while items that offer a mechanical upgrade are discounted, generally by 2 points across the board. The tradeoff for this is that characters can only take a single item from a given Item Group, such as only one pair of shoes. Only being able to take one gun from the generic guns list, etc. This PR doesn't touch any of the job specifics, I would probably do those in a separate PR, and make them their own specific item groups. 

![image](https://github.com/user-attachments/assets/cf2fe0f0-3bfe-4864-94b9-58d340f75eb7)

