### PR TITLE
9mm Speedloader Tweaks

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Speedloaders/9mm.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Speedloaders/9mm.yml
@@ -4,6 +4,8 @@
   parent: BaseItem
   abstract: true
   components:
+  - type: Item
+    size: Tiny
   - type: Tag
     tags:
       - SpeedLoader9

--- a/Resources/Prototypes/_Nuclear14/Loadouts/items.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/items.yml
@@ -8,7 +8,7 @@
 - type: loadout
   id: N14SpeedLoader9
   category: Items
-  cost: 3
+  cost: 2
   items:
     - SpeedLoader9
 


### PR DESCRIPTION
**Description**
Made 9mm Speedloaders Tiny, and cost 2 Points instead of 3 in the loadout menu

**Why/Balance**
9mm Revolvers are Small, Currently 9mm Speedloaders are also Small.

This means its more space effective to hold another revolver instead of a speedloader and means you can skip the reload of a revolver. This nulls the entire purpose of the Speedloader.

The loadout price change is due to the fact I think having the 9mm speedloader cost as much as the gun is kinda iffy.