### PR TITLE
Fixer Mimics Ethlyredoxone

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
@@ -256,8 +256,16 @@
     Medicine:
       metabolismRate: 0.1 # Effectively once every 10 seconds.
       effects:
-      - !type:Drunk
-      # - !type:CureAddiction
+      - !type:GenericStatusEffect
+        key: Drunk
+        time: 6.0
+        type: Remove
+      - !type:HealthChange
+        damage:
+          types:
+            Poison: -0.5
+     # - !type:Drunk
+     # - !type:CureAddiction
 
 # - type: reagent
 #   id: Addictol

--- a/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
@@ -256,7 +256,7 @@
     Medicine:
       metabolismRate: 0.1 # Effectively once every 10 seconds.
       effects:
-      - !type:GenericStatusEffect
+      - !type:GenericStatusEffect # Remove this block when !type:CureAddiction is functional
         key: Drunk
         time: 6.0
         type: Remove


### PR DESCRIPTION
**Description**
Fixer now lowers time spent drunk and heals a minor amount of poison

**Why/Balance**
Fixer Currently exists only to fuck up your vision for a rather long time.

As Addiction Cures don't exist at the moment this is a temporary fix to add utility to fixer other than fucking with people.