### PR TITLE
Deletes organs on body gib to reduce visual and data clutter

### DIFF
--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -320,6 +320,7 @@ public partial class SharedBodySystem
                 _gibbingSystem.TryGibEntityWithRef(bodyId, organ.Id, GibType.Drop, GibContentsOption.Skip,
                     ref gibs, playAudio: false, launchImpulse: GibletLaunchImpulse * splatModifier,
                     launchImpulseVariance:GibletLaunchImpulseVariance, launchCone: splatCone);
+                QueueDel(organ.Id);
             }
         }
         if (TryComp<InventoryComponent>(bodyId, out var inventory))


### PR DESCRIPTION
The organs do generate a lot of visual clutter. This change deletes them on gib instead of dropping them.

Initially I thought I should try to make it only delete animal organs, but it was said to me deleting people's organs was not an issue, so I think this is a general improvement plus bonus clearing of entities to improve server performance.

If making pull requests with short descriptions is an issue, please do complain and I will justify it more, it's just such a little and easy to explain change anyway.