### PR TITLE
reduces loot spawning quantity and chance

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Catalog/Fills/storage_fills_rp.yml
+++ b/Resources/Prototypes/_Nuclear14/Catalog/Fills/storage_fills_rp.yml
@@ -352,28 +352,28 @@
           orGroup: Currency
           amount: 1
           maxAmount: 25
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.7
           orGroup: Currency
           amount: 1
           maxAmount: 25
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Ammunition
           amount: 1
           maxAmount: 1
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Clothing
           amount: 1
           maxAmount: 1
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Junk
           amount: 1
           maxAmount: 1
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Consumables
           amount: 1
           maxAmount: 1
@@ -1119,28 +1119,28 @@
           orGroup: Currency
           amount: 1
           maxAmount: 25
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Currency
           amount: 1
           maxAmount: 25
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Ammunition
           amount: 1
           maxAmount: 1
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Clothing
           amount: 1
           maxAmount: 1
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Junk
           amount: 1
           maxAmount: 1
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Consumables
           amount: 1
           maxAmount: 1
@@ -1681,33 +1681,33 @@
           orGroup: Currency
           amount: 1
           maxAmount: 25
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Currency
           amount: 1
           maxAmount: 25
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Ammunition
           amount: 1
           maxAmount: 1
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Clothing
           amount: 1
           maxAmount: 1
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Junk
           amount: 1
           maxAmount: 1
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Consumables
           amount: 1
           maxAmount: 1
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Tools
           amount: 1
           maxAmount: 1
@@ -2104,28 +2104,28 @@
           orGroup: Currency
           amount: 1
           maxAmount: 25
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Currency
           amount: 1
           maxAmount: 25
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Ammunition
           amount: 1
           maxAmount: 1
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Clothing
           amount: 1
           maxAmount: 1
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Junk
           amount: 1
           maxAmount: 1
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Consumables
           amount: 1
           maxAmount: 1
@@ -2470,18 +2470,18 @@
         - id: N14ClothingBootsFire
           prob: 0.07
           orGroup: Clothing
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Ammunition
           amount: 1
           maxAmount: 1
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Clothing
           amount: 1
           maxAmount: 1
-        - id: Null
-          prob: 0.5
+        - id: N14EmptySlot
+          prob: 0.75
           orGroup: Consumables
           amount: 1
           maxAmount: 1

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/debug.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/debug.yml
@@ -1,0 +1,12 @@
+#MARK: Holotapes
+- type: entity
+  parent: BaseItem
+  id: N14EmptySlot
+  noSpawn: true
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Objects/Misc/tapes_cards.rsi
+    state: holotape_black
+    scale: 0.75, 0.75
+  - type: TimedDespawn
+    lifetime: 1


### PR DESCRIPTION
Introduces an entity that despawns after 1 second for each OrGroup. That way we get far less things spawning in random spawners.