### PR TITLE
Power Armor Movespeed and Stat Bonus Nerf

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
@@ -27,7 +27,6 @@
     clothingPrototype: N14ClothingHeadHelmetPowerArmorT45
   - type: ClothingSpecialModifier
     strengthModifier: 4
-    AgilityModifer: -2
   - type: Reflect
     reflectProb: 0.15
     spread: 150

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
@@ -9,8 +9,8 @@
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/t45.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.80
-    sprintModifier: 0.80
+    walkModifier: 0.85
+    sprintModifier: 0.85
   - type: TemperatureProtection
     coefficient: 0.6
   - type: Armor
@@ -26,7 +26,8 @@
   - type: ToggleableClothing
     clothingPrototype: N14ClothingHeadHelmetPowerArmorT45
   - type: ClothingSpecialModifier
-    strengthModifier: 4
+    strengthModifier: 2
+    enduranceModifier: 2
   - type: Reflect
     reflectProb: 0.15
     spread: 150
@@ -362,8 +363,8 @@
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/canadianshield.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.92
-    sprintModifier: 0.92
+    walkModifier: 0.90
+    sprintModifier: 0.90
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
@@ -9,8 +9,8 @@
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/t45.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.85
-    sprintModifier: 0.85
+    walkModifier: 0.80
+    sprintModifier: 0.80
   - type: TemperatureProtection
     coefficient: 0.6
   - type: Armor
@@ -26,7 +26,8 @@
   - type: ToggleableClothing
     clothingPrototype: N14ClothingHeadHelmetPowerArmorT45
   - type: ClothingSpecialModifier
-    strengthModifier: 10
+    strengthModifier: 4
+    agilityModifer: -2
   - type: Reflect
     reflectProb: 0.15
     spread: 150
@@ -46,8 +47,8 @@
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/t51.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 0.85
+    sprintModifier: 0.85
   - type: Armor
     modifiers:
       coefficients:
@@ -77,8 +78,8 @@
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/t60.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.90
-    sprintModifier: 0.90
+    walkModifier: 0.85
+    sprintModifier: 0.85
   - type: Armor
     modifiers:
       coefficients:
@@ -250,8 +251,8 @@
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/midwest.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 0.85
+    sprintModifier: 0.85
   - type: Armor
     modifiers:
       coefficients:
@@ -281,8 +282,8 @@
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/midwestcommander.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.92
-    sprintModifier: 0.92
+    walkModifier: 0.90
+    sprintModifier: 0.90
   - type: Armor
     modifiers:
       coefficients:
@@ -312,8 +313,8 @@
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/t51bc.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.92
-    sprintModifier: 0.92
+    walkModifier: 0.90
+    sprintModifier: 0.90
   - type: Armor
     modifiers:
       coefficients:
@@ -345,8 +346,8 @@
   - type: ToggleableClothing
     clothingPrototype: N14ClothingHeadHelmetPowerArmorT45NCR
   - type: ClothingSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.75
+    walkModifier: 0.80
+    sprintModifier: 0.80
   - type: Reflect
     reflectProb: 0.10
     spread: 150

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
@@ -27,7 +27,7 @@
     clothingPrototype: N14ClothingHeadHelmetPowerArmorT45
   - type: ClothingSpecialModifier
     strengthModifier: 4
-    agilityModifer: -2
+    AgilityModifer: -2
   - type: Reflect
     reflectProb: 0.15
     spread: 150


### PR DESCRIPTION
**Description**

Increased Most Movement Speed Penalties and altered Power Armor Stat Bonus from +10 strength to +4 Strength
**Why/Balance**

Power Armor was absolutely nutty with its prior movespeed and the stat bonus was far too much 

(I kept seeing nerds with 1 Strength using power Armor, In all honestly it should have a minimum strength requirement to wear)