### PR TITLE
Light bulb offset

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -24,7 +24,6 @@
   - type: Sprite
     sprite: Structures/Wallmounts/Lighting/light_tube.rsi
     drawdepth: Overdoors
-    offset: 0, 1
     layers:
     - map: ["enum.PoweredLightLayers.Base"]
       state: base
@@ -44,7 +43,7 @@
   - type: RCDDeconstructable
     cost: 4
     delay: 2
-    fx: EffectRCDDeconstruct2  
+    fx: EffectRCDDeconstruct2
   - type: Destructible
     thresholds:
     - trigger:
@@ -76,7 +75,7 @@
     mode: SnapgridCenter
     snap:
     - Wallmount
-    
+
 - type: entity
   name: light
   description: "A light fixture. Draws power and produces light when equipped with a light tube."

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Wallmount/base_lighting.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Wallmount/base_lighting.yml
@@ -10,7 +10,6 @@
     sprite: _Nuclear14/Structures/Wallmounts/lightbulbcaged.rsi
     state: base
     drawdepth: Overdoors
-    offset: 0, 1 # 0.75 is better but breaks for east west placement
   - type: PointLight
     energy: 1.0
     radius: 6
@@ -28,7 +27,6 @@
   - type: Sprite
     sprite: _Nuclear14/Structures/Wallmounts/lightbulbcaged.rsi
     state: empty
-    offset: 0, 1
   - type: Construction
     graph: N14Lightbulb
     node: bulbLight


### PR DESCRIPTION
# Description

* Removed offset from light bulb sprite. What kind of problem can be with light to do this offset-crutch?
* Fix for this one https://github.com/Vault-Overseers/nuclear-14/issues/481

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/038fec75-d7ee-4145-b603-fba277a04e76

</p>
</details>

---

# Changelog

:cl:
- fix: light bulb sprite offset
