### PR TITLE
Brute damage fix

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Tools/tools.yml
@@ -205,7 +205,7 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Brute: 10
+        Slash: 10
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
 


### PR DESCRIPTION
#Saw/Choppa Damage fix.

At this moment I noticed the choppa and saw both do.. brute damage, which doesn't do anything in game. With this PR I hope to fix that by changing the 'brute' damage to 'slash', emulating a saw more properly.


<details><summary><h1>Media</h1></summary>
<p>

[Saw time](https://pluspng.com/img-png/hand-saw-png-hand-holding-saw-2917.png)

</p>
</details>

---
<details><summary><h1>Media</h1></summary>
# Changelog


:cl:
- add: saw damage! :>
