### PR TITLE
Wasteland Neutering

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
@@ -953,7 +953,6 @@
     - id: N14MobBrahmin
       maxAmount: 1
   - type: ReproductivePartner
-    - tags: Brahmin
 
 #MARK: Bighorner
 - type: entity

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
@@ -953,7 +953,7 @@
     - id: N14MobBrahmin
       maxAmount: 1
   - type: ReproductivePartner
-   - type: tags
+   - type: Tag
     - tags: Brahmin
 
 #MARK: Bighorner

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
@@ -953,7 +953,7 @@
     - id: N14MobBrahmin
       maxAmount: 1
   - type: ReproductivePartner
-   -type: tags
+   - type: tags
     - tags: Brahmin
 
 #MARK: Bighorner

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
@@ -953,6 +953,8 @@
     - id: N14MobBrahmin
       maxAmount: 1
   - type: ReproductivePartner
+   -type: tags
+    - tags: Brahmin
 
 #MARK: Bighorner
 - type: entity

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
@@ -953,7 +953,6 @@
     - id: N14MobBrahmin
       maxAmount: 1
   - type: ReproductivePartner
-   - type: Tag
     - tags: Brahmin
 
 #MARK: Bighorner

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/animals.yml
@@ -51,17 +51,17 @@
     damage:
       groups:
         Brute: 3
-  - type: Reproductive
-    breedChance: 0.05
-    birthPopup: reproductive-birth-popup
-    makeOffspringInfant: false
-    partnerWhitelist:
+ #- type: Reproductive
+   #breedChance: 0.05
+   #birthPopup: reproductive-birth-popup
+   #makeOffspringInfant: false
+   #partnerWhitelist:
       tags:
       - Molerat
-    offspring:
-    - id: N14MobMolerat
-      maxAmount: 1
-  - type: ReproductivePartner
+   #offspring:
+   #- id: N14MobMolerat
+     #maxAmount: 1
+ #- type: ReproductivePartner
   - type: Tag
     tags:
     - Molerat
@@ -129,18 +129,18 @@
     spawned:
     - id: N14FoodMeatPigrat
       amount: 3
-  - type: Reproductive
-    breedChance: 0.05
-    birthPopup: reproductive-birth-popup
-    makeOffspringInfant: false
-    partnerWhitelist:
+ #- type: Reproductive
+   #breedChance: 0.05
+   #birthPopup: reproductive-birth-popup
+   #makeOffspringInfant: false
+   #partnerWhitelist:
       tags:
       - Pigrat
-    offspring:
-    - id: N14MobPigrat
-      maxAmount: 1
-  - type: ReproductivePartner
-  - type: Tag
+   #offspring:
+   - id: N14MobPigrat
+     #maxAmount: 1
+ #- type: ReproductivePartner
+ #- type: Tag
     tags:
     - Pigrat
 
@@ -194,18 +194,18 @@
     damage:
       groups:
         Brute: 5
-  - type: Reproductive
-    breedChance: 0.05
-    birthPopup: reproductive-birth-popup
-    makeOffspringInfant: false
-    partnerWhitelist:
+ #- type: Reproductive
+   #breedChance: 0.05
+   #birthPopup: reproductive-birth-popup
+   #makeOffspringInfant: false
+   #partnerWhitelist:
       tags:
-      - DogFeral
-    offspring:
-    - id: N14MobDogFeral
-      maxAmount: 1
-  - type: ReproductivePartner
-  - type: Tag
+     - DogFeral
+   #offspring:
+   #- id: N14MobDogFeral
+     #maxAmount: 1
+ #- type: ReproductivePartner
+ #- type: Tag
     tags:
     - DogFeral
 
@@ -265,21 +265,21 @@
       amount: 3
     - id: N14MaterialHideGecko
       amount: 1
-  - type: Reproductive
-    breedChance: 0.05
-    birthPopup: reproductive-laid-egg-popup
-    makeOffspringInfant: false
-    partnerWhitelist:
-      tags:
-      - Gecko
-    offspring:
-    - id: N14FoodEggGeckoFertilized
-      maxAmount: 3
-  - type: ReproductivePartner
-  - type: EggLayer
-    eggSpawn:
-    - id: N14FoodEggGecko
-  - type: Tag
+  #- type: Reproductive
+    #breedChance: 0.05
+    #birthPopup: reproductive-laid-egg-popup
+    #makeOffspringInfant: false
+    #partnerWhitelist:
+      #tags:
+      #- Gecko
+    #offspring:
+    # id: N14FoodEggGeckoFertilized
+     #maxAmount: 3
+ #- type: ReproductivePartner
+ #- type: EggLayer
+   #eggSpawn:
+   #- id: N14FoodEggGecko
+ - type: Tag
     tags:
     - Gecko
     
@@ -326,9 +326,9 @@
   # - type: EggLayer
     # eggSpawn:
     # - id: N14FoodEggGecko
-  # - type: Tag
-    # tags:
-    # - Gecko
+   - type: Tag
+     tags:
+     - Gecko
   - type: Gun
     cameraRecoilScalar: 0 #no recoil
     fireRate: 10
@@ -409,9 +409,9 @@
   # - type: EggLayer
     # eggSpawn:
     # - id: N14FoodEggGecko
-  # - type: Tag
-    # tags:
-    # - Gecko
+   - type: Tag
+     tags:
+     - Gecko
       
 #MARK: Nightstalker Cub
 - type: entity
@@ -589,20 +589,20 @@
   - type: MeleeChemicalInjector
     solution: melee
     transferAmount: 1.5
-  - type: Reproductive
-    breedChance: 0.05
-    birthPopup: reproductive-laid-egg-popup
-    makeOffspringInfant: false
-    partnerWhitelist:
+ #- type: Reproductive
+   #breedChance: 0.05
+   #birthPopup: reproductive-laid-egg-popup
+   #makeOffspringInfant: false
+   #partnerWhitelist:
       tags:
-      - Nightstalker
-    offspring:
-    - id: N14FoodEggNightstalkerFertilized
-      maxAmount: 3
-  - type: ReproductivePartner
-  - type: EggLayer
-    eggSpawn:
-    - id: N14FoodEggNightstalker
+     - Nightstalker
+   #offspring:
+   #- id: N14FoodEggNightstalkerFertilized
+     #maxAmount: 3
+ #- type: ReproductivePartner
+ #- type: EggLayer
+   #eggSpawn:
+   #- id: N14FoodEggNightstalker
   - type: Tag
     tags:
     - Nightstalker
@@ -666,24 +666,24 @@
     damage:
       types:
         Slash: 15
-        Structural: 5
+        Blunt: 5
     range: 1.25
   - type: MovementSpeedModifier
     baseWalkSpeed : 3
     baseSprintSpeed : 4.75
   - type: NoSlip
-  - type: Reproductive
-    breedChance: 0.05
-    birthPopup: reproductive-birth-popup
-    makeOffspringInfant: false
-    partnerWhitelist:
+ #- type: Reproductive
+   #breedChance: 0.05
+   #birthPopup: reproductive-birth-popup
+   #makeOffspringInfant: false
+   #partnerWhitelist:
       tags:
       - Yaoguai
-    offspring:
-    - id: N14MobYaoguai
-      maxAmount: 1
-  - type: ReproductivePartner
-  - type: Tag
+   #offspring:
+   #- id: N14MobYaoguai
+     #maxAmount: 1
+ #- type: ReproductivePartner
+ #- type: Tag
     tags:
     - Yaoguai
 
@@ -751,7 +751,7 @@
     range: 1.75
   - type: MovementSpeedModifier
     baseWalkSpeed : 4
-    baseSprintSpeed : 5
+    baseSprintSpeed : 5.5
   - type: Hands
   - type: Puller
   - type: Tool
@@ -1132,17 +1132,17 @@
       types:
         Blunt: 7
         Piercing: 1
-  - type: Reproductive
-    breedChance: 0.05
-    birthPopup: reproductive-birth-popup
-    makeOffspringInfant: false
-    partnerWhitelist:
+ #- type: Reproductive
+   #breedChance: 0.05
+   #birthPopup: reproductive-birth-popup
+   #makeOffspringInfant: false
+   #partnerWhitelist:
       tags:
       - Radhog
-    offspring:
-    - id: N14MobRadhog
-      maxAmount: 1
-  - type: ReproductivePartner
+   #offspring:
+   #- id: N14MobRadhog
+     #maxAmount: 1
+ #- type: ReproductivePartner
 
 #MARK: Chicken
 - type: entity

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/robots.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/robots.yml
@@ -97,7 +97,7 @@
   components:
   - type: MovementSpeedModifier
     baseWalkSpeed : 2
-    baseSprintSpeed : 4
+    baseSprintSpeed : 6
   # - type: GhostRole
     # prob: 1
     # makeSentient: true


### PR DESCRIPTION
#Neutering of the Wasteland Animals & Minor Buff


This pull request works to remove the issue of overpopulation of the wasteland creatures aside from those stronger than the scalpel. Or the most essential.



---
<details><summary><h1>Media</h1></summary>
# Changelog

:cl:
Safe from neutering:
Deathclaws, chickens, radstags, and brahmin.

It also makes certain threats (deathclaw, assaultron) more.. threat? Movement buff.
 - Deathclaw: from 5 to 5.5
 - Assaultron: from 4 to 6
