### PR TITLE
New Vet Ranger Loadout Options

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/helmets.yml
@@ -368,7 +368,7 @@
   parent: N14ClothingHeadHatBaseHelmetMK2
   id: N14ClothingHeadHatRangerHelmetEliteOld
   name: worn elite ranger combat helmet
-  description: An old combat helmet seen in the Divide, repurposed for higher-ranking Rangers.
+  description: Worn riot helmet from before the war. Faded by time and use, this helmet still sees use as a form of protection for the law bringers of the New California Republic.
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/Head/FalloutHelmets/rangerhelmetelite.rsi

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
@@ -783,7 +783,7 @@
   parent: N14ClothingOuterRangerCombat
   id: N14ClothingOuterRangerEliteOld
   name: worn elite ranger combat armor
-  description: A customized and well-worn suit of riot gear with parts of the suit reinforced with leather armor and slain Centurion armor pieces by the wearer. A sniper's veil is wrapped around the neck. This one has seen some wear.
+  description: Worn riot gear granted to Rangers who served as law bringers for times of great unrest. This armor is a testament to the reach and power of the Republic and its will to bring peace to the lawlessness of the wasteland.
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutrangerelite.rsi
@@ -792,10 +792,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.35
-        Heat: 0.4
+        Blunt: 0.55
+        Slash: 0.55
+        Piercing: 0.55
+        Heat: 0.55
 
 - type: entity
   parent: N14ClothingOuterRangerCombat

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
@@ -792,10 +792,12 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.55
-        Slash: 0.55
+        Blunt: 0.6
+        Slash: 0.6
         Piercing: 0.55
         Heat: 0.55
+  - type: ExplosionResistance
+    damageCoefficient: 0.65
 
 - type: entity
   parent: N14ClothingOuterRangerCombat

--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
@@ -289,3 +289,33 @@
         - NCRRangerVeteran
   items:
     - N14ClothingOuterRangerCombatDesert
+
+- type: loadout
+  id: LoadoutNCRRangerEliteOld
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRangerVeteran
+    - !type:CharacterPlaytimeRequirement
+      tracker: NCRRangerVeteran
+      min: 216000 # 60 hours veterancy unlock "First Tour"
+ items:
+    - N14ClothingOuterRangerEliteOld
+
+- type: loadout
+  id: LoadoutNCRRangerHelmetEliteOld
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRangerVeteran
+    - !type:CharacterPlaytimeRequirement
+      tracker: NCRRangerVeteran
+      min: 216000 # 60 hours veterancy unlock "First Tour"
+ items:
+    - N14ClothingHeadHatRangerHelmetEliteOld

--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
@@ -300,9 +300,9 @@
       jobs:
         - NCRRangerVeteran
     - !type:CharacterPlaytimeRequirement
-      tracker: NCRRangerVeteran
+      tracker: RangerVeteran
       min: 216000 # 60 hours veterancy unlock "First Tour"
- items:
+  items:
     - N14ClothingOuterRangerEliteOld
 
 - type: loadout
@@ -315,7 +315,7 @@
       jobs:
         - NCRRangerVeteran
     - !type:CharacterPlaytimeRequirement
-      tracker: NCRRangerVeteran
+      tracker: RangerVeteran
       min: 216000 # 60 hours veterancy unlock "First Tour"
- items:
+  items:
     - N14ClothingHeadHatRangerHelmetEliteOld


### PR DESCRIPTION
Veteran Ranger now has two new loadout items available to them after sixty hours of vetranger playtime. 

The helmet description was readjusted due to it being more widely accessible to more players than it would have been otherwise. Mentioning the divide for someone's equipment in washington didn't feel super fitting.

The duster description was readjusted for a similar reason.

The armor stats are based off of the default desert ranger duster, accessible to vet rangers. Its about the same as their default duster.

The 60h requirement for both of them is to represent a single "tour" as vet ranger (Aka, unlocking vet ranger, and then getting the playtime to unlock it again.). I am not attached to 60h, but it felt like a fair number, if you want it adjusted again, let me know.

The default uniform + the changes looks like:
![image](https://github.com/user-attachments/assets/3f57080b-a181-46d5-b1d3-9c90f91c3a62)
![image](https://github.com/user-attachments/assets/3c5bf06c-a2e9-4e9e-bb8f-8e074acbb4e7)
![image](https://github.com/user-attachments/assets/4d4861f1-25fa-4464-bcca-e7bcfef8274a)
