### PR TITLE
moved draw depth of new sprites to overmob, bumped offset for mic and…

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Furniture/beds.yml
@@ -10,9 +10,6 @@
   - type: Construction
     graph: N14Bed
     node: bed
-<<<<<<< Updated upstream
-
-=======
 
 - type: entity
   parent: N14Bed
@@ -30,7 +27,6 @@
     buckleOffset: 0,0.3
     maxBuckleDistance: 0.3
 
->>>>>>> Stashed changes
 - type: entity
   parent: N14Bed
   id: N14BedDirty
@@ -61,6 +57,7 @@
   components:
   - type: Sprite
     state: bed_wood_bunk
+    drawdepth: OverMobs
   - type: Strap
     position: Down
     rotation: -270

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Furniture/beds.yml
@@ -10,6 +10,9 @@
   - type: Construction
     graph: N14Bed
     node: bed
+<<<<<<< Updated upstream
+
+=======
 
 - type: entity
   parent: N14Bed
@@ -20,12 +23,14 @@
   - type: Sprite
     state: bed_bunk
     snapCardinals: true
+    drawdepth: OverMobs
   - type: Strap
     position: Down
     rotation: -270
     buckleOffset: 0,0.3
     maxBuckleDistance: 0.3
 
+>>>>>>> Stashed changes
 - type: entity
   parent: N14Bed
   id: N14BedDirty

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/radio.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/radio.yml
@@ -7,7 +7,7 @@
   - type: Sprite
     sprite: _Nuclear14/Structures/Misc/radio.rsi
     state: radiotower
-    drawdepth: Walls
+    drawdepth: OverMobs
   - type: Fixtures
     fixtures:
       fix1:
@@ -28,6 +28,8 @@
   components:
   - type: Sprite
     sprite: _Nuclear14/Structures/Misc/radiostation/microphones.rsi
+    drawdepth: OverMobs
+    offset: 0,0.5
     layers:
       - state: base
       - state: on
@@ -147,6 +149,7 @@
   components:
   - type: Sprite
     sprite: _Nuclear14/Structures/Misc/radiostation/radioonair.rsi
+    offset: 0,-0.25
     state: base
     layers:
     - state: off


### PR DESCRIPTION
# Description

Moved the microphone and radio tower to overmobs depth. Moved the top bunk bed to higher drawdepth than the lower bed. Adjusted the offset of the on air and microphone.