### PR TITLE
Ghoul Races Nerf

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Nuclear14/Damage/modifier_sets.yml
@@ -1,21 +1,21 @@
 - type: damageModifierSet
   id: Ghoul
   coefficients:
-    Blunt: 1.2
-    Slash: 1.1
-    Piercing: 0.9
+    Blunt: 1.05
+    Slash: 1.05
+    Piercing: 1.05
     Cold: 1
     Poison: 0.8
     Cellular: 0.2
-    Radiation: 0
+    Radiation: 0.25
     Asphyxiation: 0.1
     Bloodloss: 0.8
     
 - type: damageModifierSet
   id: GhoulGlowing
   coefficients:
-    Blunt: 1.5
-    Slash: 1.5
+    Blunt: 1.1
+    Slash: 1.1
     Piercing: 1.1
     Cold: 0.6
     Poison: 0.6


### PR DESCRIPTION
As requested by Z and the mappers, Ghouls and Glowing Ghouls are modified to make them slightly less meta for metagamers.

Description.

Increases the multipliers. 
Increases ghoul radiation damage.

Ghouls:
Blunt, slash, and piercing: increased to 1.05
Radiation: increased to 0.25

Glowing Ghouls:
Blunt, slash, and piercing: increased to 1.1

<details><summary><h1>Media</h1></summary>
<p>

![ghoul](https://cs1.gtaall.com/screenshots/4dc09/2021-04/original/c49624c10ccf6672bac63c3543805b16c564a44a/895097-gallery2.jpg)

</p>
</details>

---
<details><summary><h1>CL</h1></summary>
# Changelog
:cl:
- changes: ghouls, glowing ghouls, radiation
