### PR TITLE
Update nuka.yml

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Catalog/VendingMachines/Inventories/nuka.yml
+++ b/Resources/Prototypes/_Nuclear14/Catalog/VendingMachines/Inventories/nuka.yml
@@ -16,7 +16,6 @@
     N14DrinkNukaColaCherry: 3
     N14DrinkNukaColaGrape: 1
     N14DrinkNukaColaOrange: 2
-    N14DrinkNukaColaYellow: 0
     N14DrinkNukaColaQuantum: 1
     N14DrinkNukaColaQuartz: 1
     N14DrinkNukaColaVictory: 1

--- a/Resources/Prototypes/_Nuclear14/Catalog/VendingMachines/Inventories/nuka.yml
+++ b/Resources/Prototypes/_Nuclear14/Catalog/VendingMachines/Inventories/nuka.yml
@@ -16,7 +16,7 @@
     N14DrinkNukaColaCherry: 3
     N14DrinkNukaColaGrape: 1
     N14DrinkNukaColaOrange: 2
-    N14DrinkNukaColaYellow: 2
+    N14DrinkNukaColaYellow: 0
     N14DrinkNukaColaQuantum: 1
     N14DrinkNukaColaQuartz: 1
     N14DrinkNukaColaVictory: 1


### PR DESCRIPTION
# Description
A super tiny PR that removes Nuka-Yellow from vending machines. Because Roshambo can't market _THAT_ well.

:CL:

- removed Nuka Yellow from vending machines. :>