### PR TITLE
Mob rad fix

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Nuclear14/Damage/modifier_sets.yml
@@ -24,6 +24,19 @@
     Asphyxiation: 0.1
     Bloodloss: 0.8
 
+    - type: damageModifierSet
+  id: GhoulNPC
+  coefficients:
+    Blunt: 1
+    Slash: 1
+    Piercing: 1
+    Cold: 1
+    Poison: 0.25
+    Cellular: 0.2
+    Radiation: 0
+    Asphyxiation: 0.1
+    Bloodloss: 0
+
 # immune to everything except physical and heat damage
 - type: damageModifierSet
   id: WastelandAnimal
@@ -38,7 +51,7 @@
     Bloodloss: 1
     Cellular: 1
   flatReductions:
-    Radiation: 5
+    Radiation: 100
     
 - type: damageModifierSet
   id: N14Insect # Exo-skeleton, should have simillarities to skeleton resistances.
@@ -46,7 +59,7 @@
     Blunt: 1.1
     Heat: 1.5
   flatReductions:
-    Radiation: 5
+    Radiation: 100
     
 - type: damageModifierSet
   id: N14Scale # Skin tougher, bones weaker, strong stomachs, cold-blooded (kindof)
@@ -57,7 +70,7 @@
     Heat: 0.9
     Poison: 0.9
   flatReductions:
-    Radiation: 5
+    Radiation: 100
     
 - type: damageModifierSet
   id: N14ScaleFireresist
@@ -68,5 +81,5 @@
     Heat: 0
     Poison: 0.9
   flatReductions:
-    Radiation: 5
+    Radiation: 100
     Heat: 10

--- a/Resources/Prototypes/_Nuclear14/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Nuclear14/Damage/modifier_sets.yml
@@ -24,7 +24,7 @@
     Asphyxiation: 0.1
     Bloodloss: 0.8
 
-    - type: damageModifierSet
+- type: damageModifierSet
   id: GhoulNPC
   coefficients:
     Blunt: 1

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/basemob.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/basemob.yml
@@ -204,7 +204,7 @@
   components:
   - type: Damageable
     damageContainer: Biological
-    damageModifierSet: Ghoul
+    damageModifierSet: GhoulNPC
   # - type: NoSlip
   - type: NpcFactionMember
     factions:


### PR DESCRIPTION
# Description
After my previous Ghoul Nerf PR, I was made aware that we lacked an NPC damageModifierSet. 
Created new spot.
After some adjusting of the ghouls to change the modifierset ID to the new one, set their stats to baseline.

Also adjusted the stats of mobs. Made most of them rad-immune as per wishes.

Please let me know of any questions or concerns.

:cl:
- add: damageModifierSet
- change: stats of ghoulNPCs