### PR TITLE
FotA loadout additions

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Loadouts/outerClothing.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/outerClothing.yml
@@ -69,6 +69,16 @@
     -  N14ClothingOuterFlannelBrown
 
 - type: loadout
+  id: N14ClothingOuterCoatFollowerLab
+  category: Outer
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
+  items:
+    -  N14ClothingOuterCoatFollowerLab
+
+- type: loadout
   id: N14LoadoutOuterCoatWinterArmored
   category: Outer
   cost: 3

--- a/Resources/Prototypes/_Nuclear14/Loadouts/outerClothing.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/outerClothing.yml
@@ -77,16 +77,6 @@
       group: N14LoadoutOuter
   items:
     -  N14ClothingOuterCoatFollowerLab
-    
-- type: loadout
-  id: N14ClothingUniformJumpsuitFollowers
-  category: Uniform
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: N14LoadoutOuter
-  items:
-    -  N14ClothingUniformJumpsuitFollowers
 
 - type: loadout
   id: N14LoadoutOuterCoatWinterArmored

--- a/Resources/Prototypes/_Nuclear14/Loadouts/outerClothing.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/outerClothing.yml
@@ -77,6 +77,16 @@
       group: N14LoadoutOuter
   items:
     -  N14ClothingOuterCoatFollowerLab
+    
+- type: loadout
+  id: N14ClothingUniformJumpsuitFollowers
+  category: Uniform
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
+  items:
+    -  N14ClothingUniformJumpsuitFollowers
 
 - type: loadout
   id: N14LoadoutOuterCoatWinterArmored


### PR DESCRIPTION
# Description
What does this do? It adds the Followers of the Apocalypse coat to the loadout screen!!

<details><summary><h1>Media</h1></summary>
<p>

![FotA](https://static.wikia.nocookie.net/fallout/images/d/dd/FollowersApocalypseLogo.png/revision/latest/scale-to-width-down/1000?cb=20230106182432)

</p>
</details>

---
<details><summary><h1>Media</h1></summary>
:cl:
- add: Added clothing option!