### PR TITLE
Healing powder changes

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
@@ -94,7 +94,9 @@
       - !type:ModifyBleedAmount
         amount: -0.1
       - !type:ChemVomit
-        probability: 0.05
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
 
 # Strong overtime healing
 - type: reagent

--- a/Resources/Prototypes/_Nuclear14/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Reactions/medicine.yml
@@ -159,3 +159,13 @@
       amount: 1
   products:
     Bitterdrink: 1
+
+- type: reaction
+  id: Stimpak
+  reactants:
+    HealingPowder:
+      amount: 2
+    Blood:
+      amount: 1
+  products:
+    HealingMixture: 1


### PR DESCRIPTION
Buff to healing powder to make it more useful
random vomit chance was removed and replaced with overdoseing causing sickness. 
taking two healing powders is enough to make you sick, healing powder giving you 20u currently and 30u is the sickness threshhold  

also made it so you could make stims using healing powder and blood at a ratio of 2 healing powder to 1 sim 

hopefully i see it getting used more and as always tell me if there is a mistake or if you want diffrent changes due to balance ect :) 