### PR TITLE
healing powder change 

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
@@ -94,7 +94,9 @@
       - !type:ModifyBleedAmount
         amount: -0.1
       - !type:ChemVomit
-        probability: 0.05
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
 
 # Strong overtime healing
 - type: reagent


### PR DESCRIPTION
Healing powder change

removed random chance to be sick from healing powder and replaced it with an overdose

2 doses is enough to make you throw up
each healing powder gives you 20u, 30u is the overdose threshold 

tried to get a reaction that let you turn healing powder into stims but it failed so i will keep it simple with this one