### PR TITLE
NCR Loadout Changes

### DIFF
--- a/Resources/Locale/en-US/_Nuclear14/undecidedloadout.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/undecidedloadout.ftl
@@ -44,9 +44,9 @@ undecided-loadout-category-morale-description =
     1 NCR spear flag, 1 9mm pistol, 2 9mm magazines, 1 combat knife,
     and a C ration MRE.
 
-undecided-loadout-category-medic-name = Medic Kit
+undecided-loadout-category-medic-name = Combat Lifesaver Kit
 undecided-loadout-category-medic-description =
-    A crate containing all a NCR medic needs to patrol on the wasteland.
+    A crate containing all an NCR CLS needs to patrol the wasteland.
     Includes 1 NCR leather vest, 1 medical belt, 1 9mm SMG,
     4 9mm SMG magazines, 1 combat knife, and a C ration MRE.
 

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/UndecidedLoadout.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/UndecidedLoadout.yml
@@ -23,6 +23,26 @@
       - key: enum.UndecidedLoadoutBackpackUIKey.Key
         type: UndecidedLoadoutBackpackBoundUserInterface
 
+- type: entity
+  id: NCRdoctorloadoutkits
+  name: Undecided NCR Medic Loadout Kit
+  description: Please only take one..
+  parent: BaseItem
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: medic
+  - type: UndecidedLoadoutBackpack
+    transformAfterSelect: AlwaysPoweredWallLight
+    possibleSets:
+    - NCRDoctorSet
+  - type: ActivatableUI
+    key: enum.UndecidedLoadoutBackpackUIKey.Key
+  - type: UserInterface
+    interfaces:
+      - key: enum.UndecidedLoadoutBackpackUIKey.Key
+        type: UndecidedLoadoutBackpackBoundUserInterface
+
 # Engineer Kits
 - type: entity
   id: NCRengineerloadoutkits

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/UndecidedLoadout.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/UndecidedLoadout.yml
@@ -23,26 +23,6 @@
       - key: enum.UndecidedLoadoutBackpackUIKey.Key
         type: UndecidedLoadoutBackpackBoundUserInterface
 
-- type: entity
-  id: NCRdoctorloadoutkits
-  name: Undecided NCR Medic Loadout Kit
-  description: Please only take one..
-  parent: BaseItem
-  components:
-  - type: Sprite
-    sprite: _Nuclear14/Objects/Misc/kits.rsi
-    state: medic
-  - type: UndecidedLoadoutBackpack
-    transformAfterSelect: AlwaysPoweredWallLight
-    possibleSets:
-    - NCRDoctorSet
-  - type: ActivatableUI
-    key: enum.UndecidedLoadoutBackpackUIKey.Key
-  - type: UserInterface
-    interfaces:
-      - key: enum.UndecidedLoadoutBackpackUIKey.Key
-        type: UndecidedLoadoutBackpackBoundUserInterface
-
 # Engineer Kits
 - type: entity
   id: NCRengineerloadoutkits

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
@@ -139,10 +139,10 @@
       path: /Audio/Effects/unwrap.ogg
 
 - type: entity
-  name: medic kit
+  name: combat lifesaver kit
   parent: KitBase
   id: KitMedic
-  description: A crate containing all an NCR Medic needs to patrol the wasteland.
+  description: A crate containing all an NCR CLS needs to patrol the wasteland.
   components:
   - type: Sprite
     state: medic
@@ -180,6 +180,8 @@
       - id: N14WeaponPistol9mm
       - id: N14MagazinePistol9mm
         amount: 2
+      - id: Steel
+        amount: 20
       - id: N14CombatKnife
       - id: N14BoxCardboardMREBoxCFilled
     sound:

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
@@ -156,6 +156,7 @@
       - id: N14MagazineSMG9mm
         amount: 4
       - id: N14CombatKnife
+      - id: N14ClothingHeadHatNCRHelmetMetalMedic
       - id: N14BoxCardboardMREBoxCFilled
     sound:
       path: /Audio/Effects/unwrap.ogg

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
@@ -180,8 +180,7 @@
       - id: N14WeaponPistol9mm
       - id: N14MagazinePistol9mm
         amount: 2
-      - id: Steel
-        amount: 20
+      - id: SheetSteel10
       - id: N14CombatKnife
       - id: N14BoxCardboardMREBoxCFilled
     sound:


### PR DESCRIPTION
Renames the NCR Medic kit to NCR Combat Lifesaver to account for the fact that a rifleman can also take the kit. Eventually I'll add a separate NCR medic kit with some slightly better equipment. Also gives the kit the NCR medic helmet.

Adds metal to the NCR Engineer's loadout to bring them on par with the other engineer kits.