### PR TITLE
Rodent's Elite Ranger Fix

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
@@ -300,7 +300,7 @@
       jobs:
         - NCRRangerVeteran
     - !type:CharacterPlaytimeRequirement
-      tracker: RangerVeteran
+      tracker: NCRRangerVeteran
       min: 216000 # 60 hours veterancy unlock "First Tour"
   items:
     - N14ClothingOuterRangerEliteOld
@@ -315,7 +315,7 @@
       jobs:
         - NCRRangerVeteran
     - !type:CharacterPlaytimeRequirement
-      tracker: RangerVeteran
+      tracker: NCRRangerVeteran
       min: 216000 # 60 hours veterancy unlock "First Tour"
   items:
     - N14ClothingHeadHatRangerHelmetEliteOld


### PR DESCRIPTION
Fixes tracker for Elite Ranger Armor as it used a role that was unplayable.

I do be ratting it up.