### PR TITLE
Breaking Window Bars

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Windows/windowcovers.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Windows/windowcovers.yml
@@ -68,6 +68,14 @@
     - type: Damageable
       damageContainer: Inorganic
       damageModifierSet: Metallic
+    - type: Destructible
+        thresholds:
+        - trigger:
+            !type:DamageTrigger
+            damage: 200
+        behaviors:
+        - !type:DoActsBehavior
+            acts: [ "Destruction" ]
     - type: PowerConsumer
     - type: Electrified
       requirePower: true


### PR DESCRIPTION
Making the window bars (N14WindowBars and N14WindowBars2) break after taking 200 damage. The lack of their ability to break has been causing issues for quite a long time, especially because they had the Damageable component this whole time, gaslighting players into thinking that they can actually break it.