### PR TITLE
Vault Dweller Fix

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/VaultDwellers/vaultdweller.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/VaultDwellers/vaultdweller.yml
@@ -6,9 +6,6 @@
   - !type:CharacterSpeciesRequirement
     species:
     - Human
-  - !type:CharacterDepartmentTimeRequirement
-    department: Vault
-    min: 3600 # 1 hour
   playTimeTracker: VaultDweller
   startingGear: VaultDwellerGear
   alwaysUseSpawner: true


### PR DESCRIPTION
In a recent PR I accidentally made Vault Dweller require its own playtime to be played. This has been now removed. That's about it.