### PR TITLE
Caravan price fix 1

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Catalog/Cargo/cargo_consumables.yml
+++ b/Resources/Prototypes/_Nuclear14/Catalog/Cargo/cargo_consumables.yml
@@ -4,7 +4,7 @@
     sprite: _Nuclear14/Objects/Consumable/Food/pre-war.rsi
     state: porknbeans
   product: N14CrateBreakPlainFilledEmergencyRations
-  cost: 60
+  cost: 150
   category: Consumables
   group: market
 

--- a/Resources/Prototypes/_Nuclear14/Catalog/Fills/crates.yml
+++ b/Resources/Prototypes/_Nuclear14/Catalog/Fills/crates.yml
@@ -122,7 +122,7 @@
 - type: entity
   parent: N14CrateBreakPlain
   id: N14CrateBreakPlainFilledEmergencyRations
-  name: Emergency rations crate
+  name: Premium rations crate
   description: Crate containing 2 Pork n' Beans, 2 BlamCo Mac & Cheese, 2 Salisbury Steak and 2 Dandy Boy Apples.
   components:
   - type: StorageFill

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Consumable/Smokeables/packs.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Consumable/Smokeables/packs.yml
@@ -83,6 +83,8 @@
     - cig7
     - cig8
   - type: Appearance
+  - type: StaticPrice
+    price: 5
 
 # - type: entity
   # parent: N14CigPackBase

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Materials/materials.yml
@@ -435,7 +435,7 @@
   - type: Item
     size: Small
   - type: StaticPrice
-    price: 0
+    price: 3
   - type: Tag
     tags:
     - Scrap

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -116,7 +116,7 @@
     zeroVisible: true
   - type: Appearance
   - type: StaticPrice
-    price: 500
+    price: 5
   - type: FollowDistance
     backStrength: 6
 


### PR DESCRIPTION
#Description: 
This PR serves to begin the loooooong road of balancing the caravan cargo system and eliminating bugs/exploits, and effectively stop money printing. 

Moving forward with this, I want your inputs on these values/changes and see if you think things need changed. Please speak up!

Changes: 
- Increased cost of emergency rations from 60 -> 150, now called 'premium rations'
- decreased value of revolver, 500 -> 5
- set baseline cigarette value to 5
- gave scrap a value, 0 -> 3, in line with description (something to do with it, idk)

To do:
- Fix glass values
- Fix charcoal printing
- Fix beaker printing
- Fix things being valueless
- Add ability to sell caravan corpses? (Deathclaws, special variants, robots)
- Add ability to purchase wider array of goods, or goods rebalance in general 