### PR TITLE
Workbench Category Fix

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
@@ -349,7 +349,6 @@
       - N14FoodPlateSmall
       - N14FoodPlatePlastic
       - N14FoodPlateSmallPlastic
-      - FoodBowlBig
       - N14FoodPlateTin
       - N14FoodKebabSkewer
       - N14JunkCookpot


### PR DESCRIPTION
Removed the base SS14 food bowl from the list of craftable items in the basic workbench because it caused glitches - it lacks a recipe that's why. Thank you, Blu for reporting this issue!