### PR TITLE
Licoxide & Lead Nerf

### DIFF
--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -592,7 +592,7 @@
       - !type:HealthChange
         damage:
           types:
-            Poison: 0.6 # Makes it 20 damage per unit.
+            Poison: 0.06 # Makes it 2 damage per unit.
 
 - type: reagent
   id: Bungotoxin

--- a/Resources/Prototypes/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Recipes/Reactions/fun.yml
@@ -86,9 +86,9 @@
   id: Licoxide
   reactants:
     Lead:
-      amount: 1
+      amount: 10
     Zinc:
-      amount: 1
+      amount: 10
   products:
     Licoxide: 1
 


### PR DESCRIPTION
Literally just made lead deal 10 times less damage and Licoxide is 10 times more difficult to make, have fun with the continued powergaming. Yes, this PR was made out of spite, how can you tell? I am tired of seeing people inject each other with overpowered chems in an instant and win any engagement.