### PR TITLE
Jar recipe 

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Consumable/Food/preserves.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Consumable/Food/preserves.yml
@@ -27,7 +27,6 @@
         visible: false
       - state: icon-front
         map: [ "enum.SolutionContainerLayers.Overlay" ]
-  - type: Sprite
     scale: 0.5, 0.5
 
 # JamBase

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Consumable/Food/preserves.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Consumable/Food/preserves.yml
@@ -27,6 +27,8 @@
         visible: false
       - state: icon-front
         map: [ "enum.SolutionContainerLayers.Overlay" ]
+  - type: Sprite
+    scale: 0.5, 0.5
 
 # JamBase
 - type: entity

--- a/Resources/Prototypes/_Nuclear14/Recipes/Crafting/clothing.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Crafting/clothing.yml
@@ -191,7 +191,7 @@
   objectType: Item
   graph: NightstalkerhatGraph
   startNode: start
-  targetNode: helmet
+  targetNode: head
   icon:
     sprite: _Nuclear14/Clothing/Head/FalloutHats/nightstalkerhat.rsi
     state: icon

--- a/Resources/Prototypes/_Nuclear14/Recipes/Crafting/clothing.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Crafting/clothing.yml
@@ -191,7 +191,7 @@
   objectType: Item
   graph: NightstalkerhatGraph
   startNode: start
-  targetNode: head
+  targetNode: helmet
   icon:
     sprite: _Nuclear14/Clothing/Head/FalloutHats/nightstalkerhat.rsi
     state: icon

--- a/Resources/Prototypes/_Nuclear14/Recipes/Crafting/items.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Crafting/items.yml
@@ -12,3 +12,10 @@
 #    sprite: _Nuclear14/Structures/Furniture/bedsandchairs.rsi
 #    state: bedroll_rolled
 #  objectType: Item
+
+- type: latheRecipe
+  id: N14FoodJarBase
+  result: N14FoodJarBase
+  completetime: 0.8
+  materials:
+    Glass: 100

--- a/Resources/Prototypes/_Nuclear14/Recipes/Crafting/storage.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Crafting/storage.yml
@@ -55,3 +55,4 @@
     sprite: _Nuclear14/Objects/Misc/storage.rsi
     state: wallet
   objectType: Item
+


### PR DESCRIPTION

# Description


(Hopefully) adds the jar recipe to the crafting list, allows for jam and preserves to actually be seen and made. Also shrunk their sprites because it was way too big. A minor change. Hopefully we can see some roadside market stands!



<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---
<details><summary><h1>Media</h1></summary>
# Changelog


:cl:
- add: Added fun :D
