### PR TITLE
Lunchbox Nerf

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/junk.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/junk.yml
@@ -272,6 +272,8 @@
   components:
   - type: Sprite
     state: lunchbox
+  - type: Item
+    size: Normal
   - type: StorageFill
     contents:
       - id: DrinkWaterBottleFull


### PR DESCRIPTION
Changes the lunchbox size from Small to Normal, making it impossible to carry it in pockets. It's still very useful seeing that it takes up 3x3 space while allows carrying 4x4. That's about it.