### PR TITLE
Cards decks in the pocket

### DIFF
--- a/Resources/Prototypes/EstacaoPirata/Entities/Objects/Misc/black_cards.yml
+++ b/Resources/Prototypes/EstacaoPirata/Entities/Objects/Misc/black_cards.yml
@@ -7,7 +7,7 @@
   - type: Item
     size: Small
     shape:
-    - 0,0,1,1
+    - 0,0,0,1 #Modified for N14
   - type: Sprite
     sprite: EstacaoPirata/Objects/Misc/cards.rsi
     layers:
@@ -18,7 +18,7 @@
   - type: Storage
     maxItemSize: Normal
     grid:
-    - 0,0,1,1
+    - 0,0,0,1 #Modified for N14
     whitelist:
       components:
       - CardDeck
@@ -37,6 +37,8 @@
   components:
   - type: Item
     size: Small
+    shape:
+    - 0,0,0,1
   - type: CardStack
   - type: StripMenuHidden
   - type: ContainerContainer # Frontier

--- a/Resources/Prototypes/EstacaoPirata/Entities/Objects/Misc/black_cards.yml
+++ b/Resources/Prototypes/EstacaoPirata/Entities/Objects/Misc/black_cards.yml
@@ -38,7 +38,7 @@
   - type: Item
     size: Small
     shape:
-    - 0,0,0,1
+    - 0,0,0,1 #Modified for N14
   - type: CardStack
   - type: StripMenuHidden
   - type: ContainerContainer # Frontier


### PR DESCRIPTION
Reduces the cards deck size from 2x2 to 1x2, to be more accessible to use