### PR TITLE
Enclave Extermination

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Catalog/Fills/storage_fills_rp.yml
+++ b/Resources/Prototypes/_Nuclear14/Catalog/Fills/storage_fills_rp.yml
@@ -68,9 +68,6 @@
         - id: N14ClothingOuterCoatFollowerLab
           prob: 0.09
           orGroup: Clothing
-        - id: N14ClothingOuterEnclaverOfficerCoat
-          prob: 0.07
-          orGroup: Clothing
         - id: N14ClothingOuterBattlecoatTan
           prob: 0.07
           orGroup: Clothing
@@ -159,9 +156,6 @@
           prob: 0.07
           orGroup: Clothing
         - id: N14ClothingUniformJumpsuitWastelandDoc
-          prob: 0.07
-          orGroup: Clothing
-        - id: N14ClothingUniformJumpsuitEnclave
           prob: 0.07
           orGroup: Clothing
         - id: N14ClothingUniformJumpsuitMerc
@@ -693,9 +687,6 @@
         - id: N14ClothingOuterCoatFollowerLab
           prob: 0.09
           orGroup: Clothing
-        - id: N14ClothingOuterEnclaverOfficerCoat
-          prob: 0.07
-          orGroup: Clothing
         - id: N14ClothingOuterBattlecoatTan
           prob: 0.07
           orGroup: Clothing
@@ -784,9 +775,6 @@
           prob: 0.05
           orGroup: Clothing
         - id: N14ClothingUniformJumpsuitWastelandDoc
-          prob: 0.07
-          orGroup: Clothing
-        - id: N14ClothingUniformJumpsuitEnclave
           prob: 0.07
           orGroup: Clothing
         - id: N14ClothingUniformJumpsuitMerc
@@ -1219,9 +1207,6 @@
         - id: N14ClothingOuterCoatFollowerLab
           prob: 0.09
           orGroup: Clothing
-        - id: N14ClothingOuterEnclaverOfficerCoat
-          prob: 0.07
-          orGroup: Clothing
         - id: N14ClothingOuterBattlecoatTan
           prob: 0.07
           orGroup: Clothing
@@ -1310,9 +1295,6 @@
           prob: 0.07
           orGroup: Clothing
         - id: N14ClothingUniformJumpsuitWastelandDoc
-          prob: 0.07
-          orGroup: Clothing
-        - id: N14ClothingUniformJumpsuitEnclave
           prob: 0.07
           orGroup: Clothing
         - id: N14ClothingUniformJumpsuitMerc

--- a/Resources/Prototypes/_Nuclear14/Catalog/Fills/storage_fills_timed.yml
+++ b/Resources/Prototypes/_Nuclear14/Catalog/Fills/storage_fills_timed.yml
@@ -56,9 +56,6 @@
         - id: N14ClothingOuterCoatFollowerLab
           prob: 0.3
           orGroup: Clothing
-        - id: N14ClothingOuterEnclaverOfficerCoat
-          prob: 0.2
-          orGroup: Clothing
         - id: N14ClothingOuterBattlecoatTan
           prob: 0.2
           orGroup: Clothing
@@ -147,9 +144,6 @@
           prob: 0.2
           orGroup: Clothing
         - id: N14ClothingUniformJumpsuitWastelandDoc
-          prob: 0.2
-          orGroup: Clothing
-        - id: N14ClothingUniformJumpsuitEnclave
           prob: 0.2
           orGroup: Clothing
         - id: N14ClothingUniformJumpsuitMerc
@@ -638,9 +632,6 @@
         - id: N14ClothingOuterCoatFollowerLab
           prob: 0.3
           orGroup: Clothing
-        - id: N14ClothingOuterEnclaverOfficerCoat
-          prob: 0.2
-          orGroup: Clothing
         - id: N14ClothingOuterBattlecoatTan
           prob: 0.2
           orGroup: Clothing
@@ -729,9 +720,6 @@
           prob: 0.1
           orGroup: Clothing
         - id: N14ClothingUniformJumpsuitWastelandDoc
-          prob: 0.2
-          orGroup: Clothing
-        - id: N14ClothingUniformJumpsuitEnclave
           prob: 0.2
           orGroup: Clothing
         - id: N14ClothingUniformJumpsuitMerc
@@ -1061,9 +1049,6 @@
         - id: N14ClothingOuterCoatFollowerLab
           prob: 0.3
           orGroup: Clothing
-        - id: N14ClothingOuterEnclaverOfficerCoat
-          prob: 0.2
-          orGroup: Clothing
         - id: N14ClothingOuterBattlecoatTan
           prob: 0.2
           orGroup: Clothing
@@ -1152,9 +1137,6 @@
           prob: 0.2
           orGroup: Clothing
         - id: N14ClothingUniformJumpsuitWastelandDoc
-          prob: 0.2
-          orGroup: Clothing
-        - id: N14ClothingUniformJumpsuitEnclave
           prob: 0.2
           orGroup: Clothing
         - id: N14ClothingUniformJumpsuitMerc

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Belt/belts.yml
@@ -189,6 +189,7 @@
   id: ClothingBeltEnclave
   name: Enclave belt
   description: A leather belt designed by the Enclave.
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/Belt/enclavebelt.rsi

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Ears/headsets_alt.yml
@@ -156,6 +156,7 @@
   parent: N14ClothingHeadsetAlt
   id: N14ClothingHeadsetEnclave
   name: enclave over-ear headset
+  categories: [ HideSpawnMenu ]
   components:
   - type: ContainerFill
     containers:

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/hats.yml
@@ -276,6 +276,7 @@
   id: N14ClothingHeadHatEnclaveIntel
   name: enclave recon beret
   description: A sharp-looking beret worn by Enclave intelligence officers.
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/Head/FalloutHats/enclaveintel.rsi
@@ -289,6 +290,7 @@
   id: N14ClothingHeadHatEnclaveOfficer
   name: enclave officer cap
   description: A decorative looking cap worn by Enclave officers.
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/Head/FalloutHats/enclaveofficer.rsi
@@ -302,6 +304,7 @@
   id: N14ClothingHeadHatEnclavePeacekeeperCap
   name: enclave peacekeeper cap
   description: A military cap worn by Enclave Peacekeepers.
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/Head/FalloutHats/enclavepeacekeeper.rsi
@@ -315,6 +318,7 @@
   id: N14ClothingHeadHatEnclaveScientist
   name: enclave scientist beret
   description: A blue beret worn by Enclave Scientists.
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/Head/FalloutHats/enclavescience.rsi

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/helmets.yml
@@ -256,6 +256,7 @@
   id: N14ClothingHeadHatEnclaveHelmet
   name: Enclave helmet
   description: A combat helmet worn by Enclave soldiers.
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/Head/FalloutHelmets/enclavehelmet.rsi
@@ -267,6 +268,7 @@
   id: N14ClothingHeadHatEnclaveHelmetHood
   name: Enclave hooded helmet
   description: A combat helmet worn by Enclave soldiers. This one has a hood covering it.
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/Head/FalloutHelmets/enclavehelmethood.rsi
@@ -278,6 +280,7 @@
   id: N14ClothingHeadHatEnclaveHelmetMarine
   name: Enclave marine helmet
   description: A marine helmet worn by elite Enclave soldiers.
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/Head/FalloutHelmets/enclavehelmetmarine.rsi

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/powerarmorhelmet.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/powerarmorhelmet.yml
@@ -231,6 +231,7 @@
   id: N14ClothingHeadHelmetPowerArmorX02
   name: X-02 power armor helmet
   description: The Enclave Mark II Powered Combat Armor helmet.
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     netsync: false
@@ -263,6 +264,7 @@
   id: N14ClothingHeadHelmetPowerArmorHellfire
   name: hellfire power armor helmet
   description: A deep black helmet of Enclave-manufactured heavy Power Armor with yellow ballistic glass, based on pre-war designs such as the T-51 and improving off of data gathered by post-war designs such as the X-01. Most commonly fielded on the East Coast, no other helmet rivals its strength.
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     netsync: false

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/coats_and_outer.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/coats_and_outer.yml
@@ -476,6 +476,7 @@
   id: N14ClothingOuterEnclaverOfficerCoat
   name: enclave officer coat
   description: A coat worn by Enclave officers. It has armor underneath.
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/Coats/falloutarmoredofficer.rsi

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
@@ -243,6 +243,7 @@
   id: N14ClothingOuterEnclaveArmor
   name: enclave armor
   description: A suit of armor used by Enclave soldiers.
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutenclavearmor.rsi
@@ -275,6 +276,7 @@
   id: N14ClothingOuterEnclavePeacekeeper
   name: enclave peacekeeper vest
   description: A bulletproof vest used by Enclave 'peacekeepers'. Pfft. Yeah, right.
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutpeacekeeper.rsi

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
@@ -157,6 +157,7 @@
   id: N14ClothingOuterPowerArmorAdvanced2
   name: X-02 power armor
   description: A mass-produced version of the original APA. It sports less plating but is easier to repair and maintain.
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/advanced2.rsi
@@ -190,6 +191,7 @@
   id: N14ClothingOuterPowerArmorAdvanced2Hellfire
   name: hellfire power armor
   description: A deep black suit of Enclave-manufactured heavy power armor based on pre-war designs such as the T-51 and improving off of data gathered by post-war designs such as the X-01. Most commonly fielded on the East Coast, no suit rivals its strength.
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/hellfire.rsi

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Uniform/falloutjumpsuits.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Uniform/falloutjumpsuits.yml
@@ -121,6 +121,7 @@
   id: N14ClothingUniformJumpsuitEnclave
   name: enclave uniform
   description: A uniform worn by members of the Enclave.
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: _Nuclear14/Clothing/Uniforms/FalloutSuits/enclaveuni.rsi

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Devices/encryption_keys.yml
@@ -33,6 +33,7 @@
   id: EncryptionKeyEnclave
   name: Enclave encryption key
   description: An encryption key used by the Enclave.
+  categories: [ HideSpawnMenu ]
   components:
   - type: EncryptionKey
     channels:

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/identification.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/identification.yml
@@ -275,6 +275,7 @@
   id: N14IDEnclaveTrooper
   name: holotag (trooper)
   description: An ID holotag worn by the Enclave.
+  categories: [ HideSpawnMenu ]
   suffix: Trooper
   components:
   - type: Sprite
@@ -288,6 +289,7 @@
   id: N14IDEnclaveOfficer
   name: holotag (officer)
   description: An ID holotag worn by higher ranking memebers of the Enclave.
+  categories: [ HideSpawnMenu ]
   suffix: Officer
   components:
   - type: Sprite
@@ -301,6 +303,7 @@
   id: N14IDEnclaveNoncombat
   name: holotag
   description: An ID holotag worn by the non-combat members of Enclave.
+  categories: [ HideSpawnMenu ]
   suffix: Scientist , Noncombat
   components:
   - type: Sprite
@@ -777,6 +780,7 @@
   parent: N14CardAccessBunkerA1
   id: N14CardAccessEnclave
   description: A special keycard stamped with an E.
+  categories: [ HideSpawnMenu ]
   suffix: Enclave
   components:
   - type: Sprite


### PR DESCRIPTION
Removal of most Enclave items from the spawn menus to avoid their accidental placement and removal of Enclave items from the loot pools for more lore accuracy. We are in a region where the Enclave shouldn't be really present in force and we shouldn't have a dozen of their coats hanging around either.
(Enclave constructs are still left in for easier buildings of Enclave locations on future maps.)