### PR TITLE
Typo fixes

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/consumable/drink/alcohol.ftl
+++ b/Resources/Locale/en-US/reagents/meta/consumable/drink/alcohol.ftl
@@ -1,8 +1,8 @@
 reagent-name-absinthe = absinthe
-reagent-desc-absinthe = A anise-flavoured spirit derived from botanicals.
+reagent-desc-absinthe = An anise-flavoured spirit derived from botanicals.
 
 reagent-name-ale = ale
-reagent-desc-ale = A dark alchoholic beverage made by malted barley and yeast.
+reagent-desc-ale = A dark alcoholic beverage made from malted barley and yeast.
 
 reagent-name-beer = beer
 reagent-desc-beer = An alcoholic beverage made from malted grains, hops, yeast, and water.
@@ -53,7 +53,7 @@ reagent-name-whiskey = whiskey
 reagent-desc-whiskey = A type of distilled alcoholic beverage made from fermented grain mash.
 
 reagent-name-wine = wine
-reagent-desc-wine = An premium alchoholic beverage made from distilled grape juice.
+reagent-desc-wine = A premium alcoholic beverage made from fermented grape juice.
 
 reagent-name-champagne = champagne
 reagent-desc-champagne = A premium sparkling wine
@@ -152,7 +152,7 @@ reagent-name-hippies-delight = hippies delight
 reagent-desc-hippies-delight = You just don't get it maaaan.
 
 reagent-name-hooch = hooch
-reagent-desc-hooch = Either someone's failure at cocktail making or attempt in alchohol production. In any case, do you really want to drink that?
+reagent-desc-hooch = Either someone's failure at cocktail making or attempt in alcohol production. In any case, do you really want to drink that?
 
 reagent-name-iced-beer = iced beer
 reagent-desc-iced-beer = A beer which is so cold the air around it freezes.

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -23,13 +23,13 @@ trait-name-LightweightDrunk = Lightweight Drunk
 trait-description-LightweightDrunk =
     Your body exhibits a significantly heightened susceptibility to alcohol intoxication.
     As a result, alcohol has a more significant effect on your cognitive functions.
-    Note: This pertrains solely to the [color=blue]visual effects[/color] of intoxication, and does not affect the alchohol poisoning threshold.
+    Note: This pertrains solely to the [color=blue]visual effects[/color] of intoxication, and does not affect the alcohol poisoning threshold.
 
 trait-name-HeavyweightDrunk = Alcohol Tolerance
 trait-description-HeavyweightDrunk =
     Your body has developed an exceptionally high level of alcohol tolerance, leaving the very beverages you consume intimidated.
     As a result, the effects of alcohol on your cognitive functions are considerably less noticeable.
-    Note: This pertrains solely to the [color=blue]visual effects[/color] of intoxication, and does not affect the alchohol poisoning threshold.
+    Note: This pertrains solely to the [color=blue]visual effects[/color] of intoxication, and does not affect the alcohol poisoning threshold.
 
 trait-name-LiquorLifeline = Liquor Lifeline
 trait-description-LiquorLifeline =

--- a/Resources/Prototypes/Entities/Structures/Decoration/floordecor.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/floordecor.yml
@@ -307,7 +307,7 @@
 - type: entity
   parent: DecorStalagmite1
   id: DecorMinecart
-  name: minecrart
+  name: minecart
   description: It seems to have fallen over...
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Wallmount/signs.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmount/signs.yml
@@ -149,7 +149,7 @@
   parent: SignBazaarOn
   id: SignWorkersOnly
   name: workers only sign
-  description: No tresspassing!
+  description: No trespassing!
   components:
   - type: Sprite
     state: workers

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -494,7 +494,7 @@
   name: boom stick
   parent: N14WeaponShotgunBase
   id: N14WeaponShotgunBoomstick
-  description: A heavy and strong double barrel shotgun, it has a reinforcer barrel with teeths and a straight form to be used has a club, uses 12 gauge shells.
+  description: A heavy and strong double barrel shotgun, it has a reinforced barrel adorned with teeth and a straight form to be used as a club, uses 12 gauge shells.
   components:
   - type: Clothing
     sprite: _Nuclear14/Objects/Weapons/Guns/Shotguns/double_shotgun.rsi
@@ -527,7 +527,7 @@
   name: bloody stick
   parent: N14WeaponShotgunBase
   id: N14WeaponShotgunBloodyStick
-  description: A heavy and strong double barrel shotgun, it has a reinforcer barrel with sharp blades and a straight form to be used has a axe, uses 12 gauge shells.
+  description: A heavy and strong double barrel shotgun, it has a reinforced barrel with sharp blades and a straight form to be used as an axe, uses 12 gauge shells.
   components:
   - type: Clothing
     sprite: _Nuclear14/Objects/Weapons/Guns/Shotguns/double_shotgun.rsi


### PR DESCRIPTION
Fixes all the typos currently listed in the discord thread.

minecrart -> minecart
tresspassing -> trespassing
nowdays -> nowadays
warcrime -> war crime
firestation -> fire station
Fixed descriptions for tribal shotguns.
Fixed the spelling of alcohol in several places and a couple related typos.