### PR TITLE
Small armor buff

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
@@ -13,7 +13,7 @@
 
 #MARK: Armor
 - type: entity
-  parent: N14FalloutArmorBase
+  parent: [N14FalloutArmorBase, N14ClothingOuterBase]
   id: N14ClothingOuterZealotDuster
   name: zealot duster
   description: A heavily modified highway patrol coat clearly designed by some manner of fanatic.
@@ -25,10 +25,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.85
-        Slash: 0.85
-        Piercing: 0.9
-        Heat: 0.9
+        Blunt: 0.75
+        Slash: 0.75
+        Piercing: 0.8
+        Heat: 0.8
     priceMultiplier: 0.5
   - type: ExplosionResistance
     damageCoefficient: 0.85
@@ -63,7 +63,7 @@
     sprintModifier: 0.95
 
 - type: entity
-  parent: N14FalloutArmorBase
+  parent: [N14FalloutArmorBase, N14ClothingOuterBase]
   id: N14ClothingOuterCoatFollowersArmored
   name: Followers Armored Labcoat
   description: A vest used by the followers. It has a bulletproof vest underneath.
@@ -75,10 +75,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.85
-        Slash: 0.85
-        Piercing: 0.8
-        Heat: 0.85
+        Blunt: 0.8
+        Slash: 0.8
+        Piercing: 0.75
+        Heat: 0.8
     priceMultiplier: 0.5
   - type: ExplosionResistance
     damageCoefficient: 0.85


### PR DESCRIPTION
# Description

Improves the stats for the Zealot duster and Followers armored coat.

Why this buffs?
-Zealot Duster takes some resources for its crafting making it a little bit underwhelming getting the resources for it
-Followers coat should be on par with the vest it uses for its crafting since that what makes sense
