### PR TITLE
Removing Starvation Death Spiral

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -240,5 +240,6 @@
     bloodlossHealDamage:
       types:
         Bloodloss: -1
-    bloodRegenerationHunger: 1
-    bloodRegenerationThirst: 1.5 # 1 unit of normal blood satiates 1t, 0.3t for vampires, 0.75h, and restores 0.25 blood for non-humans...
+    # bloodRegenerationHunger: 0
+    # bloodRegenerationThirst: 0
+    # ^ DO NOT REENABLE. WILL RE-ADD THE ANNOYING STARVATION DEATH SPIRAL^ - Nerb


### PR DESCRIPTION
Removing the Bloodloss > Starvation > Bloodloss death spiral caused by any amount of bloodloss/starvation damage. 
