### PR TITLE
Minor addition to ammo crafting (.308, 7.62)

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
@@ -128,6 +128,8 @@
       - MagazineBox556
       - N14MagazineMinigun5mm
       - Magazine762Rifle
+      - Magazine762AmmoShort
+      - Magazine762AmmoBelt
       - MagazineBox762
       - SpeedLoader9
       - N14MagazinePistol9mm
@@ -156,6 +158,7 @@
       - Magazine45SubMachineGun
       - MagazineBox45
       - Magazine308Rifle
+      - Magazine308RifleLong
       - ClipMagazine308Rifle
       - MagazineBox308
       - SpeedLoader45-70

--- a/Resources/Prototypes/_Nuclear14/Recipes/Lathes/ammo.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Lathes/ammo.yml
@@ -109,6 +109,16 @@
     Gunpowder: 2
 
 - type: latheRecipe
+  id: Magazine762AmmoShort
+  result: Magazine762AmmoShort
+  category: N14AmmoMagazine
+  completetime: 5
+  materials:
+    Lead: 40
+    Steel: 180
+    Gunpowder: 40
+
+- type: latheRecipe
   id: Magazine762Rifle
   result: Magazine762Rifle
   category: N14AmmoMagazine
@@ -117,6 +127,16 @@
     Lead: 60
     Steel: 190
     Gunpowder: 60
+
+- type: latheRecipe
+  id: Magazine762AmmoBelt
+  result: Magazine762AmmoBelt
+  category: N14AmmoMagazine
+  completetime: 5
+  materials:
+    Lead: 500
+    Steel: 1100
+    Gunpowder: 1000
 
 - type: latheRecipe
   id: MagazineBox762
@@ -487,6 +507,16 @@
     Lead: 33
     Steel: 144
     Gunpowder: 33
+
+- type: latheRecipe
+  id: Magazine308RifleLong
+  result: Magazine308RifleLong
+  category: N14AmmoMagazine
+  completetime: 5
+  materials:
+    Lead: 300
+    Steel: 500
+    Gunpowder: 300
 
 - type: latheRecipe
   id: ClipMagazine308Rifle


### PR DESCRIPTION

# Description

Adds to the crafting bench:
-Ammo Belt (7.62)
-Short Magazine (7.62)
-Long Magazine (308)

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>


![2025-4-19_08 19 18](https://github.com/user-attachments/assets/edaac0ff-66a8-46cc-82b8-460b47c31068)
![2025-4-19_08 19 13](https://github.com/user-attachments/assets/9638d993-45b9-47d9-808d-c9a3a37c63ae)


</p>
</details>


