### PR TITLE
Weather War

### DIFF
--- a/Resources/Prototypes/_Nuclear14/weather.yml
+++ b/Resources/Prototypes/_Nuclear14/weather.yml
@@ -10,6 +10,7 @@
       volume: -6
   temperature: 400 # 
   duration: 60
+  chance: 0
   showMessage: true
   sender: weather-announcement
   message: weather-sandstorm-extreme
@@ -26,6 +27,7 @@
       volume: -6
   temperature: 2 # -
   duration: 60
+  chance: 0
   showMessage: true
   sender: weather-announcement
   message: weather-snowfall-extreme

--- a/Resources/Prototypes/weather.yml
+++ b/Resources/Prototypes/weather.yml
@@ -10,6 +10,7 @@
       volume: -6
   temperature: 330
   duration: 500
+  chance: 0
   message: weather-ashfall
 
 - type: weather
@@ -24,6 +25,7 @@
       volume: -6
   temperature: 320
   duration: 500
+  chance: 0
   message: weather-ashfall-light
 
 - type: weather


### PR DESCRIPTION
Disabled several weather events that either don't fit the vibe of these northern maps, or completely blind the players. Later of the two is problematic because NPCs don't get blinded like players are, causing a comically high amount of unfair deaths.