### PR TITLE
Z's Badly Bored - Part 2

### DIFF
--- a/Content.Server/Morgue/Components/CrematoriumComponent.cs
+++ b/Content.Server/Morgue/Components/CrematoriumComponent.cs
@@ -18,5 +18,5 @@ public sealed partial class CrematoriumComponent : Component
     public SoundSpecifier CrematingSound = new SoundPathSpecifier("/Audio/Effects/burning.ogg");
 
     [DataField("cremateFinishSound")]
-    public SoundSpecifier CremateFinishSound = new SoundPathSpecifier("/Audio/Machines/ding.ogg");
+    public SoundSpecifier CremateFinishSound = new SoundPathSpecifier("/Audio/Machines/tray_eject.ogg"); /// Screw the microwave ding
 }

--- a/Content.Shared/Standing/LayingDownComponent.cs
+++ b/Content.Shared/Standing/LayingDownComponent.cs
@@ -10,7 +10,7 @@ public sealed partial class LayingDownComponent : Component
     public TimeSpan StandingUpTime = TimeSpan.FromSeconds(1);
 
     [DataField, AutoNetworkedField]
-    public float LyingSpeedModifier = 0.0875f,
+    public float LyingSpeedModifier = 0.175f,
                  CrawlingUnderSpeedModifier = 0.125f;
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/Weapons/Ranged/Components/RechargeBasicEntityAmmoComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/RechargeBasicEntityAmmoComponent.cs
@@ -19,7 +19,7 @@ public sealed partial class RechargeBasicEntityAmmoComponent : Component
     [AutoNetworkedField]
     public SoundSpecifier RechargeSound = new SoundPathSpecifier("/Audio/Magic/forcewall.ogg")
     {
-        Params = AudioParams.Default.WithVolume(-5f)
+        Params = AudioParams.Default.WithVolume(-25f) // Lowered for N14 because no one wants to listen to dead NPCs reload.
     };
 
     [ViewVariables(VVAccess.ReadWrite),

--- a/Resources/Locale/en-US/_Nuclear14/languages.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/languages.ftl
@@ -13,3 +13,15 @@ chat-language-Tribal-name = T
 language-N14BrotherBeep-name = Brotherhood Code
 language-N14BrotherBeep-description = You can understand and 'speak' a binary language of your agumented brothers & sisters.
 chat-language-N14BrotherBeep-name = B
+
+language-N14Dog-name = Bark Tongue
+language-N14Dog-description = Your may bark and hope that there is someone who can understand it.
+chat-language-N14Dog-name = X
+
+language-N14Insect-name = Critter Chatter
+language-N14Insect-description = Weather you come from the dirt or the water, you're still able to communicate with fellow insects.
+chat-language-N14Insect-name = X
+
+language-N14Robot-name = Binary
+language-N14Robot-description = Do you lack a proper speech module? Whatever, just beep and boop in binary with the fellow machines.
+chat-language-N14Robot-name = X

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -57,8 +57,8 @@
   - type: Body
     prototype: Animal
   - type: Climbing
-  - type: NameIdentifier
-    group: GenericNumber
+   # - type: NameIdentifier # Should be commented out for N14
+    # group: GenericNumber
   - type: SlowOnDamage
     speedModifierThresholds:
       60: 0.7

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -344,6 +344,7 @@
     alternateState: Standing
   - type: OfferItem
   - type: LayingDown
+    standingUpTime: 5
   - type: Shoving
   - type: BloodstreamAffectedByMass
     power: 0.6 # A minimum size felinid will have 30% blood, a minimum size vulp will have 60%, a maximum size oni will have ~200%

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -570,7 +570,7 @@
   - type: Physics
     bodyType: Static
   - type: Grave
-  - type: ProRottingContainer
+  - type: AntiRottingContainer # Replaced for N14, no one wants organs and limbs pop out from under the dirt after rot. Eventually we should get our own grave entities with sprites.
   - type: EntityStorage
     airtight: true
     isCollidableWhenOpen: false

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Back/powersystems.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Back/powersystems.yml
@@ -15,8 +15,8 @@
     slots:
     - back
   - type: ClothingSpeedModifier
-    walkModifier: 4.75 # Don't be alarmed, it's this high to compensate for the suit's base slowdown.
-    sprintModifier: 4.75
+    walkModifier: 4.5 # Don't be alarmed, it's this high to compensate for the suit's base slowdown.
+    sprintModifier: 4.5
   - type: TemperatureProtection
     coefficient: 0.75
   - type: FireProtection

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/pets_machine.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/pets_machine.yml
@@ -78,9 +78,6 @@
   components:
   - type: InputMover
   - type: MobMover
-  - type: HTN
-    rootTask:
-      task: SimpleRangedHostileCompound
   - type: NpcFactionMember
     factions:
     - Wastelander
@@ -146,21 +143,53 @@
     enabled: true
     toggleOnInteract: true
     IsSpeaker: true
-  - type: UniversalLanguageSpeaker
-  - type: ReplacementAccent
-    accent: silicon
+  - type: LanguageKnowledge
+    speaks:
+    - N14Robot
+    understands:
+    - N14Dog
+    - N14Insect
+    - N14Robot
+    - English
+    - Tribal
+    - Chinese
+    - Sign
   - type: HandheldLight
     toggleOnInteract: false
-    wattage: 0
+    addPrefix: true
     blinkingBehaviourId: blinking
     radiatingBehaviourId: radiating
   - type: ToggleableLightVisuals
   - type: PointLight
     enabled: false
+    radius: 4.5
+    energy: 1
     mask: /Textures/Effects/LightMasks/cone.png
     autoRot: true
-    radius: 4.5
     netsync: false
+  - type: LightBehaviour
+    behaviours:
+      - !type:FadeBehaviour
+        id: radiating
+        interpolate: Linear
+        maxDuration: 2.0
+        startValue: 3.0
+        endValue: 2.0
+        isLooped: true
+        reverseWhenFinished: true
+      - !type:PulseBehaviour
+        id: blinking
+        interpolate: Nearest
+        maxDuration: 1.0
+        minValue: 0.1
+        maxValue: 2.0
+        isLooped: true
+  - type: Battery
+    maxCharge: 600 # lights drain 3/s but recharge of 2 makes this 1/s. Therefore 600 is 10 minutes of light.
+    startingCharge: 600
+  - type: BatterySelfRecharger
+    autoRecharge: true
+    autoRechargeRate: 2
   - type: NoSlip
   - type: StepTriggerImmune
     whitelist:
@@ -214,3 +243,16 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: icon
     - state: shadow_eyebot
+  - type: LanguageKnowledge
+    speaks:
+    - N14Dog
+    - N14BrotherBeep
+    understands:
+    - N14Dog
+    - N14BrotherBeep
+    - N14Insect
+    - N14Robot
+    - English
+    - Tribal
+    - Chinese
+    - Sign

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/pets_organic.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/pets_organic.yml
@@ -49,6 +49,7 @@
       Dead:
         Base: dead
   - type: MeleeWeapon
+    range: 1.25
     altDisarm: false
     hidden: true
     soundHit:
@@ -60,7 +61,7 @@
       types:
         Blunt: 4
         Slash: 8
-  - type: UniversalLanguageSpeaker
+  - type: Deathgasp
   - type: PassiveDamage 
     allowedStates:
     - Alive
@@ -89,6 +90,17 @@
       path: /Audio/Animals/small_dog_bark_happy.ogg
   - type: ReplacementAccent
     accent: dog
+  - type: LanguageKnowledge
+    speaks:
+    - N14Dog
+    understands:
+    - N14Dog
+    - N14Insect
+    - N14Robot
+    - English
+    - Tribal
+    - Chinese
+    - Sign
 
 - type: entity
   name: MBoS Mutt
@@ -122,6 +134,7 @@
       Dead:
         Base: dead
   - type: Storage
+    clickInsert: false
     grid:
     - 0,0,3,2
     maxItemSize: Normal
@@ -150,11 +163,6 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: dog
       sprite: _Nuclear14/Mobs/Pets/dog_wbos.rsi
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      90: Critical
-      200: Dead
   - type: DamageStateVisuals
     states:
       Alive:
@@ -163,6 +171,19 @@
         Base: dead
       Dead:
         Base: dead
+  - type: LanguageKnowledge
+    speaks:
+    - N14Dog
+    - N14BrotherBeep
+    understands:
+    - N14Dog
+    - N14BrotherBeep
+    - N14Robot
+    - N14Insect
+    - English
+    - Tribal
+    - Chinese
+    - Sign
         
 - type: entity
   name: NCR Mutt
@@ -355,6 +376,17 @@
       path: /Audio/Animals/small_dog_bark_happy.ogg
   - type: ReplacementAccent
     accent: xeno
+  - type: LanguageKnowledge
+    speaks:
+    - N14Insect
+    understands:
+    - N14Dog
+    - N14Insect
+    - N14Robot
+    - English
+    - Tribal
+    - Chinese
+    - Sign
 
 - type: entity
   name: Pet Ant
@@ -396,6 +428,7 @@
       100: Critical
       200: Dead
   - type: Storage
+    clickInsert: false
     grid:
     - 0,0,1,3
     - 3,0,6,3

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Consumable/Flora/wastelandflora.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Consumable/Flora/wastelandflora.yml
@@ -205,8 +205,8 @@
 - type: entity
   parent: N14WastelandFlora
   id: N14WastelandFloraWildCaveFungus
-  name: wild cave fungus
-  description: A wild fungi. It looks healthy.
+  name: cave fungus
+  description: A healthy-looking fungi.
   components:
   - type: Sprite
     state: wild_fungus
@@ -224,8 +224,8 @@
 - type: entity
   parent: N14WastelandFlora
   id: N14WastelandFloraWildCaveFungusRad
-  name: wild irradiated cave fungus
-  description: A wild fungi. It glows.
+  name: irradiated fungus
+  description: A glowing fungi.
   components:
   - type: Sprite
     state: CaveFungusRad
@@ -874,7 +874,7 @@
   parent: N14FloraProduceFood
   id: N14FloraProduceWildCaveFungus
   name: cave fungus
-  description: Wild cave fungi.
+  description: A cave fungi.
   components:
   - type: Sprite
     state: CaveFungus
@@ -897,8 +897,8 @@
 - type: entity
   parent: N14FloraProduceFood
   id: N14FloraProduceWildCaveFungusRad
-  name: irradiated cave fungus
-  description: Wild glowing cave fungi.
+  name: irradiated fungus
+  description: A glowing fungi.
   components:
   - type: Sprite
     state: CaveFungusRad

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/doors.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/doors.yml
@@ -385,10 +385,6 @@
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]
-  - type: Door
-    occludes: true
-  - type: Occluder
-    enabled: true
 
 - type: entity
   parent: N14DoorGlass

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/slanteddoors.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/slanteddoors.yml
@@ -45,9 +45,6 @@
         acts: ["Destruction"]
   - type: Occluder
   - type: BlockWeather
-  - type: Construction
-    graph: N14DoorGraph
-    node: MetalBlue
 
 - type: entity
   parent: N14DoorMetalBlueSlanted
@@ -61,9 +58,6 @@
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]
-  - type: Construction
-    graph: N14DoorGraph
-    node: MetalRed
 
 - type: entity
   parent: N14DoorMetalBlueSlanted
@@ -75,9 +69,6 @@
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]
-  - type: Construction
-    graph: N14DoorGraph
-    node: MetalBlueAlt
 
 - type: entity
   parent: N14DoorMetalBlueSlanted
@@ -95,9 +86,6 @@
     occludes: false
   - type: Occluder
     enabled: false
-  - type: Construction
-    graph: N14DoorGraph
-    node: MetalBlueWindow
 
 - type: entity
   parent: N14DoorMetalBlueWindowSlanted
@@ -129,9 +117,6 @@
       path: /Audio/_Nuclear14/Effects/Doors/DRS_Metal_Jail_Swing_Open_01.ogg
     closeSound:
       path: /Audio/_Nuclear14/Effects/Doors/DRS_Metal_Jail_Swing_Close_01.ogg
-  - type: Construction
-    graph: N14DoorGraph
-    node: MetalBar
 
 - type: entity
   parent: N14DoorMetalBlueWindowSlanted
@@ -145,9 +130,6 @@
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]
-  - type: Construction
-    graph: N14DoorGraph
-    node: MetalFence
 
 - type: entity
   parent: N14DoorMetalBlueWindowSlanted
@@ -181,9 +163,6 @@
       path: /Audio/Effects/door_open.ogg
     closeSound:
       path: /Audio/Effects/door_close.ogg
-  - type: Construction
-    graph: N14DoorGraph
-    node: WoodDoor
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Wood

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Machines/SpecificTerminals/access_terminal.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Machines/SpecificTerminals/access_terminal.yml
@@ -14,11 +14,9 @@
         shape:
           !type:PhysShapeAabb
           bounds: "-0.4,-0.2,0.4,0.2"
-        density: 190
+        density: 500
         mask:
-        - TabletopMachineMask
-        layer:
-        - TabletopMachineMask
+          - TabletopMachineMask
   - type: Clickable
   - type: InteractionOutline
   - type: Rotatable

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Storage/crates.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Storage/crates.yml
@@ -345,6 +345,8 @@
   description: A wooden crate for storage.
   abstract: true
   components:
+  - type: Transform
+    noRot: true
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Wood

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Storage/tanks.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Storage/tanks.yml
@@ -89,6 +89,8 @@
   - type: Explosive
     explosionType: Default
     totalIntensity: 120 # ~ 5 tile radius
+    maxTileBreak: 0 # Don't break floor tiles!
+    tileBreakScale: 0
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/_Nuclear14/Languages/chinese.yml
+++ b/Resources/Prototypes/_Nuclear14/Languages/chinese.yml
@@ -1,6 +1,6 @@
 - type: language
   id: Chinese #SolCommon
-  isVisibleLanguage: true
+  isVisibleLanguage: false
   speech:
     color: "#df57aaee"
     fontId: Manga

--- a/Resources/Prototypes/_Nuclear14/Languages/dog.yml
+++ b/Resources/Prototypes/_Nuclear14/Languages/dog.yml
@@ -1,12 +1,16 @@
 - type: language
-  id: N14BrotherBeep #Just a copy-paste of RobotTalk
+  id: N14Dog
   isVisibleLanguage: false
   speech:
-    color: "#980A19"
+    color: "#FFFFFFcc"
   obfuscation:
     !type:SyllableObfuscation
     minSyllables: 1
-    maxSyllables: 10
+    maxSyllables: 2
     replacement:
-    - 0
-    - 1
+    - woof
+    - bark
+    - ruff
+    - bork
+    - raff
+    - garr

--- a/Resources/Prototypes/_Nuclear14/Languages/english.yml
+++ b/Resources/Prototypes/_Nuclear14/Languages/english.yml
@@ -1,6 +1,6 @@
 - type: language
   id: English # Freespeak Modified
-  isVisibleLanguage: true
+  isVisibleLanguage: false
   speech:
     color: "#c0c0c0"
   obfuscation:

--- a/Resources/Prototypes/_Nuclear14/Languages/insect.yml
+++ b/Resources/Prototypes/_Nuclear14/Languages/insect.yml
@@ -1,12 +1,17 @@
 - type: language
-  id: N14BrotherBeep #Just a copy-paste of RobotTalk
+  id: N14Insect
   isVisibleLanguage: false
   speech:
-    color: "#980A19"
+    color: "#FFFFFFcc"
   obfuscation:
     !type:SyllableObfuscation
     minSyllables: 1
-    maxSyllables: 10
+    maxSyllables: 3
     replacement:
-    - 0
-    - 1
+    - click
+    - clack
+    - ti
+    - pi
+    - tap
+    - cli
+    - ick

--- a/Resources/Prototypes/_Nuclear14/Languages/robot.yml
+++ b/Resources/Prototypes/_Nuclear14/Languages/robot.yml
@@ -1,12 +1,12 @@
 - type: language
-  id: N14BrotherBeep #Just a copy-paste of RobotTalk
+  id: N14Robot # Used only by player-controlled mobs that can't speak like humans
   isVisibleLanguage: false
   speech:
-    color: "#980A19"
+    color: "#d69b3dcc"
   obfuscation:
     !type:SyllableObfuscation
     minSyllables: 1
     maxSyllables: 10
     replacement:
-    - 0
     - 1
+    - 0

--- a/Resources/Prototypes/_Nuclear14/Languages/tribal.yml
+++ b/Resources/Prototypes/_Nuclear14/Languages/tribal.yml
@@ -1,6 +1,6 @@
 - type: language
   id: Tribal # Canilunzt
-  isVisibleLanguage: true
+  isVisibleLanguage: false
   speech:
     color: "#d69b3dcc"
   obfuscation:

--- a/Resources/Prototypes/_Nuclear14/Recipes/Construction/Graphs/Structures/doors.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Construction/Graphs/Structures/doors.yml
@@ -24,20 +24,6 @@
             - material: N14ScrapBrass
               amount: 2
               doAfter: 15
-    - node: WoodDoor
-      entity: N14DoorWoodSlanted
-      edges:
-        - to: start
-          completed:
-            - !type:SpawnPrototype
-              prototype: MaterialWoodPlank1
-              amount: 4
-            - !type:SpawnPrototype
-              prototype: N14ScrapBrass1
-              amount: 2
-          steps:
-            - tool: Anchoring
-              doAfter: 15
     - node: woodDoorMakeshift
       entity: N14DoorMakeshift
       edges:

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/BrotherhoodWashington/commander.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/BrotherhoodWashington/commander.yml
@@ -18,7 +18,6 @@
         - !type:CharacterSpeciesRequirement
           species:
             - Human
-  weight: 10
   startingGear: BoSWashingtonCommanderGear
   alwaysUseSpawner: true
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/BrotherhoodWashington/knight.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/BrotherhoodWashington/knight.yml
@@ -13,7 +13,7 @@
       - Ghoul
     - !type:CharacterDepartmentTimeRequirement
       department: BrotherhoodWashington
-      min: 3600 # 1 hour as BoSWashingtonInitiate
+      min: 18000
   startingGear: BoSWashingtonKnightGear
   alwaysUseSpawner: true
   icon: "JobIconPassenger"

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NPC/raider_loadout.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NPC/raider_loadout.yml
@@ -7,6 +7,8 @@
     outerClothing: N14ClothingOuterLightMetalArmor
     pocket1: N14DirtyGauze1
     pocket2: N14MagazinePistol9mm
+  inhand:
+  - N14CurrencyCap
 
 - type: startingGear
   id: RaiderHunterGear
@@ -18,6 +20,8 @@
     outerClothing: N14ClothingOuterRaiderBadlands
     pocket1: N14Cartridge308Rifle
     pocket2: N14HealingPowder
+  inhand:
+  - N14CurrencyCap
 
 - type: startingGear
   id: RaiderSkrimisherGear
@@ -28,6 +32,8 @@
     outerClothing: N14ClothingOuterRaiderBlastmaster
     pocket1: N14ShellShotgun20
     pocket2: N14Jet
+  inhand:
+  - N14CurrencyCap
 
 - type: startingGear
   id: RaiderBossGear
@@ -40,6 +46,8 @@
     outerClothing: N14ClothingOuterRaiderCombat1
     pocket1: N14Stimpak
     pocket2: N14RadAwayInhaler
+  inhand:
+  - N14CurrencyCap
 
 - type: startingGear
   id: FernMercPrivateGear
@@ -51,6 +59,8 @@
     outerClothing: N14ClothingOuterRaiderBadlands
     pocket1: N14CleanGauze1
     pocket2: Magazine556Rifle
+  inhand:
+  - N14CurrencyCap
 
 - type: startingGear
   id: FernMercSergeantGear
@@ -64,6 +74,8 @@
     belt: ClothingBeltMilitary
     pocket1: N14Stimpak
     pocket2: N14MagazineShotgun12
+  inhand:
+  - N14CurrencyCap
 
 - type: startingGear
   id: FernMercLieutenantGear
@@ -76,6 +88,8 @@
     outerClothing: N14ClothingOuterCombatArmorMK2
     pocket1: N14CurrencyCap50
     pocket2: N14MagazineSMG12mm
+  inhand:
+  - N14CurrencyCap
 
 - type: startingGear
   id: EnforcerTrooperGear
@@ -86,6 +100,8 @@
     mask: N14ClothingMaskBlueMask
     pocket1: N14CleanGauze1
     pocket2: N14MagazineSMG9mm
+  inhand:
+  - N14CurrencyCap
 
 - type: startingGear
   id: EnforcerWardenGear
@@ -96,6 +112,8 @@
     outerClothing: N14ClothingOuterPoliceVest
     pocket1: N14Psycho
     pocket2: N14MagazineShotgun20
+  inhand:
+  - N14CurrencyCap
 
 - type: startingGear
   id: EnforcerChiefGear
@@ -107,6 +125,8 @@
     outerClothing: N14ClothingOuterPoliceChief
     pocket1: N14Stimpak
     pocket2: SpeedLoader44
+  inhand:
+  - N14CurrencyCap
 
 #MARK: Melee
 
@@ -147,6 +167,6 @@
     mask: N14ClothingMaskBrownBalaclava
     outerClothing: N14ClothingOuterRaiderBadlands
     pocket1: N14CurrencyCap
-    pocket2: N14DirtyGauze10
+    pocket2: N14DirtyGauze1
   inhand:
   - N14KitchenKnife

--- a/Resources/Prototypes/_Nuclear14/Traits/mental.yml
+++ b/Resources/Prototypes/_Nuclear14/Traits/mental.yml
@@ -151,6 +151,7 @@
           name: ghost-role-information-n14pet-roach-name
           description: ghost-role-information-n14pet-generic-description
           rules: ghost-role-component-default-rules
+          reregisterOnGhost: false
         - type: GhostRoleMobSpawner
           prototype: N14MobPetRoach
 
@@ -177,6 +178,7 @@
           name: ghost-role-information-n14pet-pigrat-name
           description: ghost-role-information-n14pet-generic-description
           rules: ghost-role-component-default-rules
+          reregisterOnGhost: false
         - type: GhostRoleMobSpawner
           prototype: N14MobPetPigrat
 
@@ -199,6 +201,7 @@
           name: ghost-role-information-n14pet-ant-name
           description: ghost-role-information-n14pet-hauler-description
           rules: ghost-role-component-default-rules
+          reregisterOnGhost: false
         - type: GhostRoleMobSpawner
           prototype: N14MobPetAnt
 
@@ -225,6 +228,7 @@
           name: ghost-role-information-n14pet-eyebot-name
           description: ghost-role-information-n14pet-eyebot-description
           rules: ghost-role-component-default-rules
+          reregisterOnGhost: false
         - type: GhostRoleMobSpawner
           prototype: N14MobPetEyebot
 
@@ -247,6 +251,7 @@
           name: ghost-role-information-n14pet-eyebot-mbos-name
           description: ghost-role-information-n14pet-eyebot-description
           rules: ghost-role-component-default-rules
+          reregisterOnGhost: false
         - type: GhostRoleMobSpawner
           prototype: N14MobPetEyebotMBoS
 
@@ -269,6 +274,7 @@
           name: ghost-role-information-n14pet-eyebot-wbos-name
           description: ghost-role-information-n14pet-eyebot-description
           rules: ghost-role-component-default-rules
+          reregisterOnGhost: false
         - type: GhostRoleMobSpawner
           prototype: N14MobPetEyebotWBoS
 
@@ -298,6 +304,7 @@
           name: ghost-role-information-n14pet-dog-name
           description: ghost-role-information-n14pet-generic-description
           rules: ghost-role-component-default-rules
+          reregisterOnGhost: false
         - type: GhostRoleMobSpawner
           prototype: N14MobPetDog
 
@@ -322,6 +329,7 @@
           name: ghost-role-information-n14pet-dog-mbos-name
           description: ghost-role-information-n14pet-hauler-description
           rules: ghost-role-component-default-rules
+          reregisterOnGhost: false
         - type: GhostRoleMobSpawner
           prototype: N14MobPetDogMBoS
 
@@ -346,6 +354,7 @@
           name: ghost-role-information-n14pet-dog-wbos-name
           description: ghost-role-information-n14pet-generic-description
           rules: ghost-role-component-default-rules
+          reregisterOnGhost: false
         - type: GhostRoleMobSpawner
           prototype: N14MobPetDogWBoS
 
@@ -370,6 +379,7 @@
           name: ghost-role-information-n14pet-dog-cc-name
           description: ghost-role-information-n14pet-generic-description
           rules: ghost-role-component-default-rules
+          reregisterOnGhost: false
         - type: GhostRoleMobSpawner
           prototype: N14MobPetDogCC
 
@@ -390,6 +400,7 @@
           name: ghost-role-information-n14pet-dog-ncr-name
           description: ghost-role-information-n14pet-generic-description
           rules: ghost-role-component-default-rules
+          reregisterOnGhost: false
         - type: GhostRoleMobSpawner
           prototype: N14MobPetDogNCR
 
@@ -410,5 +421,6 @@
           name: ghost-role-information-n14pet-dog-ncrmed-name
           description: ghost-role-information-n14pet-generic-description
           rules: ghost-role-component-default-rules
+          reregisterOnGhost: false
         - type: GhostRoleMobSpawner
           prototype: N14MobPetDogNCRMedicK9


### PR DESCRIPTION
The PR name starts to be very true but for a different reason... Another PR full of miscellaneous changes. These include:

- Cremators now use a different sound, no more microwave ding.
- Buffed the laying speed back up a bit, still nerfed compared to the old numbers.
  - Instead I now nerfed the speed of getting up, takes whole five seconds. Everyone around the Wastes got bad backs now.
- The reloading of NPCs should be a lot less loud now. We don't want to hear corpses reload.
- Removed number identification from most mobs and added them directly to pets.
- Pets suffer from some major buffs now, even got their own languages.
- Several issues fixed with the pets, including that some couldn't be healed (used meds on).
- Graves now preserve corpses like freezers. Simply because I said so. Jokes aside it was simply cringe that when bodies rot their organs popped up from under the dirt.
- Transparency of a single door fixed.
- Names of mushrooms shortened to avoid context menu glitches.
- Power armour speed nerfed back down because it was overbuffed.
- Fixed a bug with the pet system which allowed having two pets at the cost of your own life.
- Removed a bunch of invalid construction graphs.
- Adjusted the Washington BoS Knight timer to the proper position.
- Fixed the issues I created a few days back with some role preferences.