### PR TITLE
Re-enable Radios

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -235,7 +235,7 @@ public sealed class RadioDeviceSystem : EntitySystem
         var message = args.OriginalChatMsg.Message;
         var nameOverride = Identity.Name(args.MessageSource, EntityManager);
         IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<ChatSystem>()
-                .TrySendInGameICMessage(speaker, message, InGameICChatType.Speak, ChatTransmitRange.HideChat, true, null, null, nameOverride, false, false, args.Language);
+                .TrySendInGameICMessage(speaker, message, InGameICChatType.Speak, ChatTransmitRange.NoGhosts, true, null, null, nameOverride, false, false, args.Language);
         //Old Code: _netMan.ServerSendMessage(msg, actor.PlayerSession.Channel);
         //Original code was designed to have the parent of the radios (the map) speak to the players at the designated point. 
         //The ability for speaking maps was removed. I have changed it to send an in-game message instead, from each radio that is supposed to send the message.

--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -235,7 +235,7 @@ public sealed class RadioDeviceSystem : EntitySystem
         var message = args.OriginalChatMsg.Message;
         var nameOverride = Identity.Name(args.MessageSource, EntityManager);
         IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<ChatSystem>()
-                .TrySendInGameICMessage(speaker, message, InGameICChatType.Speak, ChatTransmitRange.NoGhosts, true, null, null, nameOverride, false, false, args.Language);
+                .TrySendInGameICMessage(speaker, message, InGameICChatType.Speak, ChatTransmitRange.GhostRangeLimit, true, null, null, nameOverride, false, false, args.Language);
         //Old Code: _netMan.ServerSendMessage(msg, actor.PlayerSession.Channel);
         //Original code was designed to have the parent of the radios (the map) speak to the players at the designated point. 
         //The ability for speaking maps was removed. I have changed it to send an in-game message instead, from each radio that is supposed to send the message.


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Original code was designed to have the parent of the radios (the map) speak to the players at the designated point. The ability for speaking maps was removed. I have changed it to send an in-game message instead, from each radio that is supposed to send the message.

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Radio](https://github.com/user-attachments/assets/7d961cae-2b99-4e2e-ad1f-dd835a8c88f7)

</p>
</details>

---
<details><summary><h1>Media</h1></summary>
# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added fun :D
