### PR TITLE
Late Night Patches

### DIFF
--- a/Content.Shared/CCVar/CCVars.NPC.cs
+++ b/Content.Shared/CCVar/CCVars.NPC.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.CCVar;
 public sealed partial class CCVars
 {
     public static readonly CVarDef<int> NPCMaxUpdates =
-        CVarDef.Create("npc.max_updates", 512);
+        CVarDef.Create("npc.max_updates", 1024);
 
     public static readonly CVarDef<bool> NPCEnabled = CVarDef.Create("npc.enabled", true);
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -259,8 +259,8 @@
   - type: NpcFactionMember
     factions:
     - Passive
-  - type: RandomBark
-    barkType: chicken
+  # - type: RandomBark
+    # barkType: chicken
 
 - type: entity
   parent: MobChicken

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -20,6 +20,9 @@
     - BypassInteractionRangeChecks
     - BypassDropChecks
     - NoConsoleSound
+  - type: MovementSpeedModifier
+    baseSprintSpeed : 24
+    baseWalkSpeed : 12
   - type: Input
     context: "aghost"
   - type: Ghost
@@ -45,53 +48,53 @@
     - NuclearOperative
     - SyndicateAgent
     - CentralCommand
-  - type: UserInterface
-    interfaces:
-      enum.SolarControlConsoleUiKey.Key:
-        type: SolarControlConsoleBoundUserInterface
-      enum.CommunicationsConsoleUiKey.Key:
-        type: CommunicationsConsoleBoundUserInterface
-      enum.RadarConsoleUiKey.Key:
-        type: RadarConsoleBoundUserInterface
-      enum.CargoConsoleUiKey.Orders:
-        type: CargoOrderConsoleBoundUserInterface
-      enum.CrewMonitoringUIKey.Key:
-        type: CrewMonitoringBoundUserInterface
-      enum.GeneralStationRecordConsoleKey.Key:
+  # - type: UserInterface
+    # interfaces:
+      # enum.SolarControlConsoleUiKey.Key:
+        # type: SolarControlConsoleBoundUserInterface
+      # enum.CommunicationsConsoleUiKey.Key:
+        # type: CommunicationsConsoleBoundUserInterface
+      # enum.RadarConsoleUiKey.Key:
+        # type: RadarConsoleBoundUserInterface
+      # enum.CargoConsoleUiKey.Orders:
+        # type: CargoOrderConsoleBoundUserInterface
+      # enum.CrewMonitoringUIKey.Key:
+        # type: CrewMonitoringBoundUserInterface
+      # enum.GeneralStationRecordConsoleKey.Key:
       # who the fuck named this bruh
-        type: GeneralStationRecordConsoleBoundUserInterface
-  - type: IntrinsicUI
-    uis:
-      enum.SolarControlConsoleUiKey.Key:
-        toggleAction: ActionAGhostShowSolar
-      enum.CommunicationsConsoleUiKey.Key:
-        toggleAction: ActionAGhostShowCommunications
-      enum.RadarConsoleUiKey.Key:
-        toggleAction: ActionAGhostShowRadar
-      enum.CargoConsoleUiKey.Orders:
-        toggleAction: ActionAGhostShowCargo
-      enum.CrewMonitoringUIKey.Key:
-        toggleAction: ActionAGhostShowCrewMonitoring
-      enum.GeneralStationRecordConsoleKey.Key:
-        toggleAction: ActionAGhostShowStationRecords
-  - type: SolarControlConsole # look ma i AM the computer!
-  - type: CommunicationsConsole
-    title: comms-console-announcement-title-centcom
-    color: "#228b22"
-  - type: RadarConsole
-    followEntity: true
-  - type: CargoOrderConsole
-  - type: BankClient
-  - type: CrewMonitoringConsole
-  - type: GeneralStationRecordConsole
-    canDeleteEntries: true
-  - type: DeviceNetwork
-    deviceNetId: Wireless
-    receiveFrequencyId: CrewMonitor
-    transmitFrequencyId: ShuttleTimer
-  - type: WirelessNetworkConnection
-    range: 500
-  - type: StationLimitedNetwork
+        # type: GeneralStationRecordConsoleBoundUserInterface
+  # - type: IntrinsicUI
+    # uis:
+      # enum.SolarControlConsoleUiKey.Key:
+        # toggleAction: ActionAGhostShowSolar
+      # enum.CommunicationsConsoleUiKey.Key:
+        # toggleAction: ActionAGhostShowCommunications
+      # enum.RadarConsoleUiKey.Key:
+        # toggleAction: ActionAGhostShowRadar
+      # enum.CargoConsoleUiKey.Orders:
+        # toggleAction: ActionAGhostShowCargo
+      # enum.CrewMonitoringUIKey.Key:
+        # toggleAction: ActionAGhostShowCrewMonitoring
+      # enum.GeneralStationRecordConsoleKey.Key:
+        # toggleAction: ActionAGhostShowStationRecords
+  # - type: SolarControlConsole # look ma i AM the computer!
+  # - type: CommunicationsConsole
+    # title: comms-console-announcement-title-centcom
+    # color: "#228b22"
+  # - type: RadarConsole
+    # followEntity: true
+  # - type: CargoOrderConsole
+  # - type: BankClient
+  # - type: CrewMonitoringConsole
+  # - type: GeneralStationRecordConsole
+    # canDeleteEntries: true
+  # - type: DeviceNetwork
+    # deviceNetId: Wireless
+    # receiveFrequencyId: CrewMonitor
+    # transmitFrequencyId: ShuttleTimer
+  # - type: WirelessNetworkConnection
+    # range: 500
+  # - type: StationLimitedNetwork
   - type: Thieving
     stripTimeMultiplier: 0
     ignoreStripHidden: true
@@ -102,85 +105,85 @@
   - type: Inventory
     templateId: aghost
   - type: InventorySlots
-  - type: Loadout
-    prototypes: [ MobAghostGear ]
+  # - type: Loadout
+    # prototypes: [ MobAghostGear ]
   - type: SupermatterImmune
   - type: BypassInteractionChecks
 
-- type: entity
-  id: ActionAGhostShowSolar
-  name: Solar Control Interface
-  description: View a solar control interface.
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: InstantAction
-    icon: { sprite: Structures/Machines/parts.rsi, state: box_0 }
-    iconOn: Structures/Machines/parts.rsi/box_2.png
-    keywords: [ "AI", "console", "interface" ]
-    priority: -10
-    event: !type:ToggleIntrinsicUIEvent { key: enum.SolarControlConsoleUiKey.Key }
+# - type: entity
+  # id: ActionAGhostShowSolar
+  # name: Solar Control Interface
+  # description: View a solar control interface.
+  # categories: [ HideSpawnMenu ]
+  # components:
+  # - type: InstantAction
+    # icon: { sprite: Structures/Machines/parts.rsi, state: box_0 }
+    # iconOn: Structures/Machines/parts.rsi/box_2.png
+    # keywords: [ "AI", "console", "interface" ]
+    # priority: -10
+    # event: !type:ToggleIntrinsicUIEvent { key: enum.SolarControlConsoleUiKey.Key }
 
-- type: entity
-  id: ActionAGhostShowCommunications
-  name: Communications Interface
-  description: View a communications interface.
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: InstantAction
-    icon: { sprite: Interface/Actions/actions_ai.rsi, state: comms_console }
-    iconOn: Interface/Actions/actions_ai.rsi/comms_console.png
-    keywords: [ "AI", "console", "interface" ]
-    priority: -4
-    event: !type:ToggleIntrinsicUIEvent { key: enum.CommunicationsConsoleUiKey.Key }
+# - type: entity
+  # id: ActionAGhostShowCommunications
+  # name: Communications Interface
+  # description: View a communications interface.
+  # categories: [ HideSpawnMenu ]
+  # components:
+  # - type: InstantAction
+    # icon: { sprite: Interface/Actions/actions_ai.rsi, state: comms_console }
+    # iconOn: Interface/Actions/actions_ai.rsi/comms_console.png
+    # keywords: [ "AI", "console", "interface" ]
+    # priority: -4
+    # event: !type:ToggleIntrinsicUIEvent { key: enum.CommunicationsConsoleUiKey.Key }
 
-- type: entity
-  id: ActionAGhostShowRadar
-  name: Mass Scanner Interface
-  description: View a mass scanner interface.
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: InstantAction
-    icon: { sprite: Interface/Actions/actions_ai.rsi, state: mass_scanner }
-    iconOn: Interface/Actions/actions_ai.rsi/mass_scanner.png
-    keywords: [ "AI", "console", "interface" ]
-    priority: -7
-    event: !type:ToggleIntrinsicUIEvent { key: enum.RadarConsoleUiKey.Key }
+# - type: entity
+  # id: ActionAGhostShowRadar
+  # name: Mass Scanner Interface
+  # description: View a mass scanner interface.
+  # categories: [ HideSpawnMenu ]
+  # components:
+  # - type: InstantAction
+    # icon: { sprite: Interface/Actions/actions_ai.rsi, state: mass_scanner }
+    # iconOn: Interface/Actions/actions_ai.rsi/mass_scanner.png
+    # keywords: [ "AI", "console", "interface" ]
+    # priority: -7
+    # event: !type:ToggleIntrinsicUIEvent { key: enum.RadarConsoleUiKey.Key }
 
-- type: entity
-  id: ActionAGhostShowCargo
-  name: Cargo Ordering Interface
-  description: View a cargo ordering interface.
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: InstantAction
-    icon: { sprite: Structures/Machines/parts.rsi, state: box_0 }
-    iconOn: Structures/Machines/parts.rsi/box_2.png
-    keywords: [ "AI", "console", "interface" ]
-    priority: -10
-    event: !type:ToggleIntrinsicUIEvent { key: enum.CargoConsoleUiKey.Orders }
+# - type: entity
+  # id: ActionAGhostShowCargo
+  # name: Cargo Ordering Interface
+  # description: View a cargo ordering interface.
+  # categories: [ HideSpawnMenu ]
+  # components:
+  # - type: InstantAction
+    # icon: { sprite: Structures/Machines/parts.rsi, state: box_0 }
+    # iconOn: Structures/Machines/parts.rsi/box_2.png
+    # keywords: [ "AI", "console", "interface" ]
+    # priority: -10
+    # event: !type:ToggleIntrinsicUIEvent { key: enum.CargoConsoleUiKey.Orders }
 
-- type: entity
-  id: ActionAGhostShowCrewMonitoring
-  name: Crew Monitoring Interface
-  description: View a crew monitoring interface.
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: InstantAction
-    icon: { sprite: Interface/Actions/actions_ai.rsi, state: crew_monitor }
-    iconOn: Interface/Actions/actions_ai.rsi/crew_monitor.png
-    keywords: [ "AI", "console", "interface" ]
-    priority: -9
-    event: !type:ToggleIntrinsicUIEvent { key: enum.CrewMonitoringUIKey.Key }
+# - type: entity
+  # id: ActionAGhostShowCrewMonitoring
+  # name: Crew Monitoring Interface
+  # description: View a crew monitoring interface.
+  # categories: [ HideSpawnMenu ]
+  # components:
+  # - type: InstantAction
+    # icon: { sprite: Interface/Actions/actions_ai.rsi, state: crew_monitor }
+    # iconOn: Interface/Actions/actions_ai.rsi/crew_monitor.png
+    # keywords: [ "AI", "console", "interface" ]
+    # priority: -9
+    # event: !type:ToggleIntrinsicUIEvent { key: enum.CrewMonitoringUIKey.Key }
 
-- type: entity
-  id: ActionAGhostShowStationRecords
-  name: Station Records Interface
-  description: View a station records Interface
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: InstantAction
-    icon: { sprite: Interface/Actions/actions_ai.rsi, state: station_records }
-    iconOn: Interface/Actions/actions_ai.rsi/station_records.png
-    keywords: [ "AI", "console", "interface" ]
-    priority: -8
-    event: !type:ToggleIntrinsicUIEvent { key: enum.GeneralStationRecordConsoleKey.Key }
+# - type: entity
+  # id: ActionAGhostShowStationRecords
+  # name: Station Records Interface
+  # description: View a station records Interface
+  # categories: [ HideSpawnMenu ]
+  # components:
+  # - type: InstantAction
+    # icon: { sprite: Interface/Actions/actions_ai.rsi, state: station_records }
+    # iconOn: Interface/Actions/actions_ai.rsi/station_records.png
+    # keywords: [ "AI", "console", "interface" ]
+    # priority: -8
+    # event: !type:ToggleIntrinsicUIEvent { key: enum.GeneralStationRecordConsoleKey.Key }

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -110,80 +110,80 @@
   - type: SupermatterImmune
   - type: BypassInteractionChecks
 
-# - type: entity
-  # id: ActionAGhostShowSolar
-  # name: Solar Control Interface
-  # description: View a solar control interface.
-  # categories: [ HideSpawnMenu ]
-  # components:
-  # - type: InstantAction
-    # icon: { sprite: Structures/Machines/parts.rsi, state: box_0 }
-    # iconOn: Structures/Machines/parts.rsi/box_2.png
-    # keywords: [ "AI", "console", "interface" ]
-    # priority: -10
-    # event: !type:ToggleIntrinsicUIEvent { key: enum.SolarControlConsoleUiKey.Key }
+- type: entity
+  id: ActionAGhostShowSolar
+  name: Solar Control Interface
+  description: View a solar control interface.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: InstantAction
+    icon: { sprite: Structures/Machines/parts.rsi, state: box_0 }
+    iconOn: Structures/Machines/parts.rsi/box_2.png
+    keywords: [ "AI", "console", "interface" ]
+    priority: -10
+    event: !type:ToggleIntrinsicUIEvent { key: enum.SolarControlConsoleUiKey.Key }
 
-# - type: entity
-  # id: ActionAGhostShowCommunications
-  # name: Communications Interface
-  # description: View a communications interface.
-  # categories: [ HideSpawnMenu ]
-  # components:
-  # - type: InstantAction
-    # icon: { sprite: Interface/Actions/actions_ai.rsi, state: comms_console }
-    # iconOn: Interface/Actions/actions_ai.rsi/comms_console.png
-    # keywords: [ "AI", "console", "interface" ]
-    # priority: -4
-    # event: !type:ToggleIntrinsicUIEvent { key: enum.CommunicationsConsoleUiKey.Key }
+- type: entity
+  id: ActionAGhostShowCommunications
+  name: Communications Interface
+  description: View a communications interface.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: InstantAction
+    icon: { sprite: Interface/Actions/actions_ai.rsi, state: comms_console }
+    iconOn: Interface/Actions/actions_ai.rsi/comms_console.png
+    keywords: [ "AI", "console", "interface" ]
+    priority: -4
+    event: !type:ToggleIntrinsicUIEvent { key: enum.CommunicationsConsoleUiKey.Key }
 
-# - type: entity
-  # id: ActionAGhostShowRadar
-  # name: Mass Scanner Interface
-  # description: View a mass scanner interface.
-  # categories: [ HideSpawnMenu ]
-  # components:
-  # - type: InstantAction
-    # icon: { sprite: Interface/Actions/actions_ai.rsi, state: mass_scanner }
-    # iconOn: Interface/Actions/actions_ai.rsi/mass_scanner.png
-    # keywords: [ "AI", "console", "interface" ]
-    # priority: -7
-    # event: !type:ToggleIntrinsicUIEvent { key: enum.RadarConsoleUiKey.Key }
+- type: entity
+  id: ActionAGhostShowRadar
+  name: Mass Scanner Interface
+  description: View a mass scanner interface.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: InstantAction
+    icon: { sprite: Interface/Actions/actions_ai.rsi, state: mass_scanner }
+    iconOn: Interface/Actions/actions_ai.rsi/mass_scanner.png
+    keywords: [ "AI", "console", "interface" ]
+    priority: -7
+    event: !type:ToggleIntrinsicUIEvent { key: enum.RadarConsoleUiKey.Key }
 
-# - type: entity
-  # id: ActionAGhostShowCargo
-  # name: Cargo Ordering Interface
-  # description: View a cargo ordering interface.
-  # categories: [ HideSpawnMenu ]
-  # components:
-  # - type: InstantAction
-    # icon: { sprite: Structures/Machines/parts.rsi, state: box_0 }
-    # iconOn: Structures/Machines/parts.rsi/box_2.png
-    # keywords: [ "AI", "console", "interface" ]
-    # priority: -10
-    # event: !type:ToggleIntrinsicUIEvent { key: enum.CargoConsoleUiKey.Orders }
+- type: entity
+  id: ActionAGhostShowCargo
+  name: Cargo Ordering Interface
+  description: View a cargo ordering interface.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: InstantAction
+    icon: { sprite: Structures/Machines/parts.rsi, state: box_0 }
+    iconOn: Structures/Machines/parts.rsi/box_2.png
+    keywords: [ "AI", "console", "interface" ]
+    priority: -10
+    event: !type:ToggleIntrinsicUIEvent { key: enum.CargoConsoleUiKey.Orders }
 
-# - type: entity
-  # id: ActionAGhostShowCrewMonitoring
-  # name: Crew Monitoring Interface
-  # description: View a crew monitoring interface.
-  # categories: [ HideSpawnMenu ]
-  # components:
-  # - type: InstantAction
-    # icon: { sprite: Interface/Actions/actions_ai.rsi, state: crew_monitor }
-    # iconOn: Interface/Actions/actions_ai.rsi/crew_monitor.png
-    # keywords: [ "AI", "console", "interface" ]
-    # priority: -9
-    # event: !type:ToggleIntrinsicUIEvent { key: enum.CrewMonitoringUIKey.Key }
+- type: entity
+  id: ActionAGhostShowCrewMonitoring
+  name: Crew Monitoring Interface
+  description: View a crew monitoring interface.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: InstantAction
+    icon: { sprite: Interface/Actions/actions_ai.rsi, state: crew_monitor }
+    iconOn: Interface/Actions/actions_ai.rsi/crew_monitor.png
+    keywords: [ "AI", "console", "interface" ]
+    priority: -9
+    event: !type:ToggleIntrinsicUIEvent { key: enum.CrewMonitoringUIKey.Key }
 
-# - type: entity
-  # id: ActionAGhostShowStationRecords
-  # name: Station Records Interface
-  # description: View a station records Interface
-  # categories: [ HideSpawnMenu ]
-  # components:
-  # - type: InstantAction
-    # icon: { sprite: Interface/Actions/actions_ai.rsi, state: station_records }
-    # iconOn: Interface/Actions/actions_ai.rsi/station_records.png
-    # keywords: [ "AI", "console", "interface" ]
-    # priority: -8
-    # event: !type:ToggleIntrinsicUIEvent { key: enum.GeneralStationRecordConsoleKey.Key }
+- type: entity
+  id: ActionAGhostShowStationRecords
+  name: Station Records Interface
+  description: View a station records Interface
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: InstantAction
+    icon: { sprite: Interface/Actions/actions_ai.rsi, state: station_records }
+    iconOn: Interface/Actions/actions_ai.rsi/station_records.png
+    keywords: [ "AI", "console", "interface" ]
+    priority: -8
+    event: !type:ToggleIntrinsicUIEvent { key: enum.GeneralStationRecordConsoleKey.Key }

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -283,11 +283,11 @@
   duffelbag: ClothingBackpackDuffelBrigmedicFilled
 
 # Aghost
-- type: startingGear
-  id: MobAghostGear
-  equipment:
-    back: ClothingBackpackSatchelHoldingAdmin
-    id: AdminPDA
+# - type: startingGear
+  # id: MobAghostGear
+  # equipment:
+    # back: ClothingBackpackSatchelHoldingAdmin
+    # id: AdminPDA
 
 #Head Rev Gear
 - type: startingGear

--- a/Resources/Prototypes/_Nuclear14/Entities/Markers/Spawners/mobs.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Markers/Spawners/mobs.yml
@@ -894,7 +894,7 @@
 
 # NPC faction guards
 - type: entity
-  name: Town Miltia Spawner
+  name: Civil Militia Spawner
   id: N14SpawnMobNPCTown
   parent: MarkerBase
   components:

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/baseRaidersMobs.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/baseRaidersMobs.yml
@@ -21,6 +21,7 @@
     - type: MindContainer
       showExamineInfo: False
     - type: InputMover
+    - type: Rotatable
     - type: MobMover
     - type: SurgeryTarget
       canOperate: false

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/faction_humanoids.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/faction_humanoids.yml
@@ -1,17 +1,17 @@
 # Town of [insert map here] should have its own NPCs for protection.
 - type: entity
-  name: Town Militia
+  name: Civil Militia
   parent: N14BaseMobRaider
   id: N14MobNPCTown
   suffix: NPC
-  description: Angry mob ready to defend their homes, might not be the best at combat but he is trying.
+  description: Angry mob ready to defend their homes, might not be the best at combat but he is trying his best.
   components:
     - type: NpcFactionMember
       factions:
       - Townsfolk
     - type: Gun
-      minAngle: 9
-      maxAngle: 45
+      minAngle: 6
+      maxAngle: 30
       angleIncrease: 0.5
       angleDecay: 4
       fireRate: 2
@@ -266,8 +266,8 @@
       factions:
       - BrotherhoodMidwestSecureArea
     - type: Gun
-      minAngle: 6
-      maxAngle: 14
+      minAngle: 4
+      maxAngle: 9
       angleIncrease: 4
       angleDecay: 16
       fireRate: 2.5
@@ -352,8 +352,8 @@
       factions:
       - BrotherhoodWashingtonSecureArea
     - type: Gun
-      minAngle: 9
-      maxAngle: 30
+      minAngle: 6
+      maxAngle: 20
       angleIncrease: 1
       angleDecay: 4
       fireRate: 2.5
@@ -437,8 +437,8 @@
       factions:
       - BrotherhoodWashingtonSecureArea
     - type: Gun
-      minAngle: 6
-      maxAngle: 14
+      minAngle: 4
+      maxAngle: 9
       angleIncrease: 4
       angleDecay: 16
       fireRate: 2.5
@@ -523,8 +523,8 @@
       factions:
       - NCRSecureArea
     - type: Gun
-      minAngle: 6
-      maxAngle: 30
+      minAngle: 4
+      maxAngle: 20
       angleIncrease: 4
       angleDecay: 16
       fireRate: 4.3
@@ -608,8 +608,8 @@
       factions:
       - NCRSecureArea
     - type: Gun
-      minAngle: 3
-      maxAngle: 21
+      minAngle: 2
+      maxAngle: 14
       angleIncrease: 4
       angleDecay: 16
       fireRate: 2.5
@@ -694,8 +694,8 @@
       factions:
       - CaravanCompanySecureArea
     - type: Gun
-      minAngle: 6
-      maxAngle: 30
+      minAngle: 4
+      maxAngle: 20
       angleIncrease: 4
       angleDecay: 16
       fireRate: 4.3
@@ -780,8 +780,8 @@
       factions:
       - TribalSecureArea
     - type: Gun
-      minAngle: 6
-      maxAngle: 30
+      minAngle: 4
+      maxAngle: 20
       angleIncrease: 1
       angleDecay: 4
       fireRate: 1
@@ -859,7 +859,7 @@
   parent: N14BaseMobRaider
   id: N14MobNPCTribeWarr
   suffix: NPC
-  description: A large and tough warrior, not many could best him in battle. He shall stand guard.
+  description: A large and tough warrior, not many could best him in a melee battle. He shall stand guard.
   components: # No gun or ammo components because this is a melee variant.
     - type: NpcFactionMember
       factions:
@@ -872,4 +872,4 @@
       prototypes:
         - TribalWarriorNPC
     - type: Sprite
-      scale: 1.05, 1.05
+      scale: 1.1, 1.1

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/landmine.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/landmine.yml
@@ -2,6 +2,8 @@
   name: anti-personnel landmine
   parent: BaseLandMine
   id: N14LandMine
+  placement:
+    mode: SnapgridCenter
   components:
   - type: ExplodeOnTrigger
   - type: Explosive # Should be identical copy of a 40mm grenade.
@@ -12,5 +14,5 @@
     maxTileBreak: 0
     canCreateVacuum: false
   - type: TileEmission
-    color: "#FE3210"
+    color: "#FE321099"
     range: -0.125

--- a/Resources/Prototypes/_Nuclear14/NPCs/Combat/gun.yml
+++ b/Resources/Prototypes/_Nuclear14/NPCs/Combat/gun.yml
@@ -1,3 +1,6 @@
+# Scrapped the entire system with the gun dropping because half of the time it didn't work anyways.
+# They will not pick up guns either, only use what is given to them
+
 - type: htnCompound
   id: N14RangedCombatCompound
   branches:
@@ -6,6 +9,38 @@
           minPercent: 0.001
       tasks:
         - !type:HTNCompoundTask
-          task: GunCombatCompound
-# Scrapped the entire system with the gun dropping because half of the time it didn't work anyways.
-# They will not pick up guns either, only use what is given to them.
+          task: N14GunCombatCompound
+
+- type: htnCompound
+  id: N14GunCombatCompound
+  branches:
+    - tasks:
+        - !type:HTNPrimitiveTask
+          operator: !type:UtilityOperator
+            proto: NearbyGunTargets
+
+        - !type:HTNPrimitiveTask
+          operator: !type:MoveToOperator
+            shutdownState: PlanFinished
+            pathfindInPlanning: true
+            removeKeyOnFinish: false
+            targetKey: TargetCoordinates
+            pathfindKey: TargetPathfind
+            stopOnLineOfSight: true
+            rangeKey: MeleeRange
+
+        - !type:HTNPrimitiveTask
+          operator: !type:JukeOperator
+            jukeType: AdjacentTile
+
+        - !type:HTNPrimitiveTask
+          preconditions:
+            - !type:KeyExistsPrecondition
+              key: Target
+          operator: !type:GunOperator
+            targetKey: Target
+          services:
+            - !type:UtilityService
+              id: RangedService
+              proto: NearbyGunTargets
+              key: Target

--- a/Resources/Prototypes/_Nuclear14/NPCs/Combat/melee.yml
+++ b/Resources/Prototypes/_Nuclear14/NPCs/Combat/melee.yml
@@ -1,3 +1,4 @@
+# It shouldn't pick up objects or anything similar, merely charge and hit you with whatever he got.
 - type: htnCompound
   id: N14MeleeCombatCompound
   branches:
@@ -6,9 +7,37 @@
           operator: !type:UtilityOperator
             proto: NearbyMeleeTargets
         - !type:HTNCompoundTask
-          task: BeforeMeleeAttackTargetCompound
-    # Melee combat (unarmed or otherwise)
-    - tasks:
-        - !type:HTNCompoundTask
-          task: MeleeAttackTargetCompound
-# Removed the ability to unbuckle and pick up melee weapons.
+          task: N14MeleeAttackTargetCompound
+
+- type: htnCompound
+  id: N14MeleeAttackTargetCompound
+  branches:
+    - preconditions:
+      - !type:KeyExistsPrecondition
+        key: Target
+      tasks:
+        - !type:HTNPrimitiveTask
+          operator: !type:MoveToOperator
+            shutdownState: PlanFinished
+            pathfindInPlanning: true
+            removeKeyOnFinish: false
+            targetKey: TargetCoordinates
+            pathfindKey: TargetPathfind
+            rangeKey: MeleeRange
+        - !type:HTNPrimitiveTask
+          operator: !type:JukeOperator
+            jukeType: Away
+        - !type:HTNPrimitiveTask
+          operator: !type:MeleeOperator
+            targetKey: Target
+          preconditions:
+            - !type:KeyExistsPrecondition
+              key: Target
+            - !type:TargetInRangePrecondition
+              targetKey: Target
+              rangeKey: MeleeRange
+          services:
+            - !type:UtilityService
+              id: MeleeService
+              proto: NearbyMeleeTargets
+              key: Target

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NPC/faction_npc_loadout.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NPC/faction_npc_loadout.yml
@@ -88,19 +88,21 @@
 - type: startingGear
   id: TribalSkirmisherNPC
   equipment:
-    jumpsuit: N14ClothingUniformJumpsuitTribal
-    shoes: N14ClothingShoesTribal
-    head: N14ClothingHeadHatTribalOutcastHood
+    jumpsuit: N14ClothingUniformJumpsuitdrylanderTribal
+    outerClothing: N14ClothingOuterTribalArmor
+    head: N14ClothingDrylanderGoggles
     gloves: N14ClothingHandsGlovesTribal
-    belt: ClothingBeltRope
+    belt: N14ClothingHandsGlovesFur
+    shoes: ClothingShoesBootsRyuzo
 
 - type: startingGear
   id: TribalWarriorNPC
   equipment:
-    jumpsuit: N14ClothingUniformJumpsuitTribal
+    jumpsuit: N14ClothingUniformJumpsuittribalpantsm
     outerClothing: N14ClothingOuterTribalArmorHeavy
+    head: N14ClothingTribalMuffaloskull
+    gloves: N14ClothingHandsGlovesTribal
     shoes: N14ClothingShoesTribal
-    head: N14ClothingHeadHatTribalOutcastHood
-    neck: N14ClothingNeckCloakYaoguai
+    neck: N14ClothingNeckMantleLeather
   inhand:
   - N14WastelandTribalSpear

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/NPC/raider_loadout.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/NPC/raider_loadout.yml
@@ -6,8 +6,6 @@
     mask: N14ClothingMaskBrownMask
     outerClothing: N14ClothingOuterLightMetalArmor
     pocket1: N14RaiderStash
-  inhand:
-  - N14CurrencyCap
 
 - type: startingGear
   id: RaiderHunterGear
@@ -18,8 +16,6 @@
     mask: N14ClothingMaskRedMask
     outerClothing: N14ClothingOuterRaiderBadlands
     pocket1: N14RaiderStash
-  inhand:
-  - N14CurrencyCap
 
 - type: startingGear
   id: RaiderSkrimisherGear
@@ -29,8 +25,6 @@
     head: ClothingHeadHelmetBone
     outerClothing: N14ClothingOuterRaiderBlastmaster
     pocket1: N14RaiderStash
-  inhand:
-  - N14CurrencyCap
 
 - type: startingGear
   id: RaiderBossGear
@@ -42,8 +36,6 @@
     eyes: N14ClothingEyesGlassesWelding
     outerClothing: N14ClothingOuterRaiderCombat1
     pocket1: N14RaiderStash
-  inhand:
-  - N14CurrencyCap
 
 - type: startingGear
   id: FernMercPrivateGear
@@ -54,8 +46,6 @@
     mask: N14ClothingMaskBrownMask
     outerClothing: N14ClothingOuterRaiderBadlands
     pocket1: N14RaiderStash
-  inhand:
-  - N14CurrencyCap
 
 - type: startingGear
   id: FernMercSergeantGear
@@ -68,8 +58,6 @@
     outerClothing: N14ClothingOuterCombatArmor
     belt: ClothingBeltMilitary
     pocket1: N14RaiderStash
-  inhand:
-  - N14CurrencyCap
 
 - type: startingGear
   id: FernMercLieutenantGear
@@ -81,8 +69,6 @@
     eyes: N14ClothingEyesSunGlasses
     outerClothing: N14ClothingOuterCombatArmorMK2
     pocket1: N14RaiderStash
-  inhand:
-  - N14CurrencyCap
 
 - type: startingGear
   id: EnforcerTrooperGear
@@ -92,8 +78,6 @@
     head: N14ClothingHeadHatBaseball
     mask: N14ClothingMaskBlueMask
     pocket1: N14RaiderStash
-  inhand:
-  - N14CurrencyCap
 
 - type: startingGear
   id: EnforcerWardenGear
@@ -103,8 +87,6 @@
     mask: N14ClothingMaskGrill
     outerClothing: N14ClothingOuterPoliceVest
     pocket1: N14RaiderStash
-  inhand:
-  - N14CurrencyCap
 
 - type: startingGear
   id: EnforcerChiefGear
@@ -115,8 +97,6 @@
     eyes: N14ClothingEyesSunGlasses
     outerClothing: N14ClothingOuterPoliceChief
     pocket1: N14RaiderStash
-  inhand:
-  - N14CurrencyCap
 
 #MARK: Melee
 


### PR DESCRIPTION
Let's see what we got, shall we?

- Increased maximum NPC updates to 1024, this should end the whole issue with mobs that refuse to move when hostile is in range. But could also lead to performance issues. We'll see how it turns out.
- This time I also silenced the chickens, one day I'll properly remake all passive mobs.
- Quality of Life changes to the admin observer entity, if you got feedback fellow staff members don't be afraid to share. (But I mostly just changed base speeds and killed a bunch of useless buttons while also nuking the bag and PDA.)
- Fixed a typo and renamed Town Militia to Civil Militia. (My fault.)
- Removed the bottlecap from the hands of raiders.
- Changed the outfits of Tribal faction NPCs.
- Polished the HTN compounds because they were a bit crudely made. (My fault.)
- Made the base raider rotatable to allow the rotating of all faction NPCs.
- Made faction NPCs more accurate with guns because it was horrible. (My fault.)