### PR TITLE
Adjust ghoul radiation behavior

### DIFF
--- a/Content.Server/Radiation/Systems/RadiationHealingSystem.cs
+++ b/Content.Server/Radiation/Systems/RadiationHealingSystem.cs
@@ -1,0 +1,54 @@
+using Content.Server.Damage.Systems;
+using Content.Shared.Damage.Components;
+using Content.Shared.FixedPoint;
+using Content.Shared.Movement.Systems;
+using Content.Shared.Radiation.Components;
+using Content.Shared.Radiation.Events;
+
+namespace Content.Server.Radiation.Systems;
+
+public sealed partial class RadiationHealingSystem : EntitySystem
+{
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly MovementSpeedModifierSystem _movement = default!;
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<RadiationHealingComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (comp.CurrentExposure <= 0f)
+                continue;
+
+            comp.CurrentExposure = Math.Max(0f, comp.CurrentExposure - comp.DecayRate * frameTime);
+            Dirty(uid, comp);
+            _movement.RefreshMovementSpeedModifiers(uid);
+        }
+    }
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<RadiationHealingComponent, OnIrradiatedEvent>(OnIrradiated);
+    }
+
+    private void OnIrradiated(EntityUid uid, RadiationHealingComponent component, OnIrradiatedEvent args)
+    {
+        component.CurrentExposure += args.RadsPerSecond;
+        var healAmount = args.RadsPerSecond * component.HealFactor * args.FrameTime;
+
+        if (!TryComp(uid, out DamageableComponent? damage) || healAmount <= 0f)
+            return;
+
+        DamageSpecifier spec = new();
+        spec.DamageDict["Blunt"] = FixedPoint2.New(-healAmount);
+        spec.DamageDict["Slash"] = FixedPoint2.New(-healAmount);
+        spec.DamageDict["Piercing"] = FixedPoint2.New(-healAmount);
+        spec.DamageDict["Heat"] = FixedPoint2.New(-healAmount);
+        spec.DamageDict["Poison"] = FixedPoint2.New(-healAmount);
+
+        _damageable.TryChangeDamage(uid, spec, interruptsDoAfters: false);
+    }
+}

--- a/Content.Shared/Radiation/Components/RadiationHealingComponent.cs
+++ b/Content.Shared/Radiation/Components/RadiationHealingComponent.cs
@@ -1,0 +1,30 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Radiation.Components;
+
+/// <summary>
+/// Allows entities to heal when exposed to radiation and slows them based on exposure.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class RadiationHealingComponent : Component
+{
+    /// <summary>
+    /// Amount of healing per rad per second.
+    /// </summary>
+    [DataField("healFactor")] public float HealFactor = 1f;
+
+    /// <summary>
+    /// Movement speed reduction per rad of exposure.
+    /// </summary>
+    [DataField("slowFactor")] public float SlowFactor = 0.5f;
+
+    /// <summary>
+    /// Rate that radiation exposure decays each second when not irradiated.
+    /// </summary>
+    [DataField("decayRate")] public float DecayRate = 1f;
+
+    /// <summary>
+    /// Current accumulated radiation intensity in rads per second.
+    /// </summary>
+    [AutoNetworkedField] public float CurrentExposure;
+}

--- a/Content.Shared/Radiation/Systems/RadiationHealingSystem.cs
+++ b/Content.Shared/Radiation/Systems/RadiationHealingSystem.cs
@@ -1,0 +1,22 @@
+using Content.Shared.Movement.Systems;
+using Content.Shared.Radiation.Components;
+
+namespace Content.Shared.Radiation.Systems;
+
+public sealed partial class RadiationHealingSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<RadiationHealingComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMove);
+    }
+
+    private void OnRefreshMove(EntityUid uid, RadiationHealingComponent component, RefreshMovementSpeedModifiersEvent args)
+    {
+        if (component.CurrentExposure <= 0f)
+            return;
+
+        var mod = Math.Clamp(1f - component.CurrentExposure * component.SlowFactor, 0.25f, 1f);
+        args.ModifySpeed(mod);
+    }
+}

--- a/Resources/Prototypes/_Nuclear14/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Nuclear14/Damage/modifier_sets.yml
@@ -7,7 +7,7 @@
     Cold: 1
     Poison: 0.8
     Cellular: 0.2
-    Radiation: 0.25
+    Radiation: 0
     Asphyxiation: 0.1
     Bloodloss: 0.8
     

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/Species/ghouls.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/Species/ghouls.yml
@@ -81,10 +81,10 @@
     damage:
       types:
         Heat: -1
-        Radiation: 0.06 # a little less than ~50 rads per hour. Chem dependant
       groups:
         Brute: -1
         Toxin: -0.1
+  - type: RadiationHealing
   - type: MobThresholds
     thresholds:
       0: Alive
@@ -186,10 +186,10 @@
     damage:
       types:
         Heat: -1.25
-        Radiation: 0.08
       groups:
         Brute: -1.25
         Toxin: -0.125
+  - type: RadiationHealing
   - type: MobThresholds
     thresholds:
       0: Alive


### PR DESCRIPTION
## Summary
- give ghouls a new `RadiationHealingComponent`
- slow and heal ghouls via new `RadiationHealingSystem`
- remove passive radiation damage from ghoul prototypes
- make ghouls completely immune to radiation

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b143b229c8325bb283f12e4341351