### PR TITLE
Add FEVReceiver component

### DIFF
--- a/Content.Server/FEV/Components/FEVReceiverComponent.cs
+++ b/Content.Server/FEV/Components/FEVReceiverComponent.cs
@@ -1,0 +1,47 @@
+using Content.Shared.Humanoid;
+using Content.Shared.Random;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Server.FEV.Components;
+
+/// <summary>
+/// Tracks metabolized FEV on a mob and handles transformation once thresholds are met.
+/// </summary>
+[RegisterComponent]
+public sealed partial class FEVReceiverComponent : Component
+{
+    /// <summary>
+    /// Weighted species list used when selecting a random mutation result.
+    /// </summary>
+    [DataField("speciesWeights", required: true, customTypeSerializer: typeof(PrototypeIdSerializer<WeightedRandomSpeciesPrototype>))]
+    public string SpeciesWeights = "SpeciesWeights";
+
+    /// <summary>
+    /// Minimum FEV units required before a slow transformation begins.
+    /// </summary>
+    [DataField("slowThreshold")] public FixedPoint2 SlowThreshold = FixedPoint2.New(5);
+
+    /// <summary>
+    /// Minimum FEV units required for an instant transformation.
+    /// </summary>
+    [DataField("instantThreshold")] public FixedPoint2 InstantThreshold = FixedPoint2.New(15);
+
+    /// <summary>
+    /// Messages shown to the player during a slow transformation.
+    /// </summary>
+    [DataField("stageMessages")]
+    public List<string> StageMessages = new() { "fev-stage-1", "fev-stage-2", "fev-stage-3" };
+
+    /// <summary>
+    /// Time between transformation stage messages.
+    /// </summary>
+    [DataField("stageInterval")] public TimeSpan StageInterval = TimeSpan.FromSeconds(5);
+
+    public FixedPoint2 Accumulated;
+    public bool Transforming;
+    public string? TargetSpecies;
+    public int CurrentStage;
+    public TimeSpan NextStage;
+}

--- a/Content.Server/FEV/Components/PendingFEVTransformComponent.cs
+++ b/Content.Server/FEV/Components/PendingFEVTransformComponent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Server.FEV.Components;
+
+/// <summary>
+/// Handles the staged transformation process once FEV infection reaches the threshold.
+/// </summary>
+[RegisterComponent]
+public sealed partial class PendingFEVTransformComponent : Component
+{
+    [DataField("nextTime", customTypeSerializer: typeof(TimeOffsetSerializer))]
+    public TimeSpan NextTime;
+
+    [DataField("stage"), ViewVariables]
+    public int Stage;
+
+    [DataField("species"), ViewVariables]
+    public string Species = string.Empty;
+}

--- a/Content.Server/FEV/Systems/FEVReceiverSystem.cs
+++ b/Content.Server/FEV/Systems/FEVReceiverSystem.cs
@@ -1,0 +1,96 @@
+using Content.Server.FEV.Components;
+using Content.Server.Medical;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Humanoid;
+using Content.Shared.Popups;
+using Content.Shared.FixedPoint;
+using Content.Shared.Random;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Server.FEV.Systems;
+
+public sealed partial class FEVReceiverSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly ITiming _timing = default!;
+    [Dependency] private readonly HumanoidAppearanceSystem _humanoid = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<FEVReceiverComponent, TryMetabolizeReagent>(OnMetabolize);
+    }
+
+    private void OnMetabolize(EntityUid uid, FEVReceiverComponent comp, ref TryMetabolizeReagent args)
+    {
+        if (args.Reagent != "FEV")
+            return;
+
+        comp.Accumulated += args.Quantity;
+
+        if (comp.Accumulated >= comp.InstantThreshold)
+        {
+            Transform(uid, comp, instant: true);
+            return;
+        }
+
+        if (!comp.Transforming && comp.Accumulated >= comp.SlowThreshold)
+        {
+            StartSlowTransform(uid, comp);
+        }
+    }
+
+    private void StartSlowTransform(EntityUid uid, FEVReceiverComponent comp)
+    {
+        var weights = _proto.Index<WeightedRandomSpeciesPrototype>(comp.SpeciesWeights);
+        var species = weights.Pick(_random);
+
+        var pending = EnsureComp<PendingFEVTransformComponent>(uid);
+        pending.Species = species;
+        pending.Stage = 0;
+        pending.NextTime = _timing.CurTime + comp.StageInterval;
+        comp.Transforming = true;
+        comp.TargetSpecies = species;
+    }
+
+    private void Transform(EntityUid uid, FEVReceiverComponent comp, bool instant)
+    {
+        var weights = _proto.Index<WeightedRandomSpeciesPrototype>(comp.SpeciesWeights);
+        var species = weights.Pick(_random);
+        _humanoid.SetSpecies(uid, species, true);
+        comp.Transforming = false;
+        comp.Accumulated = FixedPoint2.Zero;
+        comp.TargetSpecies = null;
+        if (!instant)
+            _popup.PopupEntity(Loc.GetString("fev-complete"), uid, uid);
+    }
+
+    public override void Update(float frameTime)
+    {
+        var cur = _timing.CurTime;
+        var query = EntityQueryEnumerator<FEVReceiverComponent, PendingFEVTransformComponent, HumanoidAppearanceComponent>();
+        while (query.MoveNext(out var uid, out var comp, out var pending, out var humanoid))
+        {
+            if (pending.NextTime > cur)
+                continue;
+
+            if (pending.Stage < comp.StageMessages.Count)
+            {
+                _popup.PopupEntity(Loc.GetString(comp.StageMessages[pending.Stage]), uid, uid);
+                pending.Stage++;
+                pending.NextTime = cur + comp.StageInterval;
+            }
+            else
+            {
+                _humanoid.SetSpecies(uid, pending.Species, true, humanoid);
+                RemCompDeferred<PendingFEVTransformComponent>(uid);
+                comp.Transforming = false;
+                comp.Accumulated = FixedPoint2.Zero;
+                comp.TargetSpecies = null;
+            }
+        }
+    }
+}

--- a/Resources/Locale/en-US/fev/fev.ftl
+++ b/Resources/Locale/en-US/fev/fev.ftl
@@ -1,0 +1,4 @@
+fev-stage-1 = Your body tingles strangely.
+fev-stage-2 = You feel your muscles shifting.
+fev-stage-3 = Transformation is imminent!
+fev-complete = Your body violently mutates!

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -369,6 +369,7 @@ reagent-effect-guidebook-chem-reroll-psionic =
         *[other] allow
     } a chance to get a different psionic power
 
+
 reagent-effect-guidebook-add-moodlet =
     modifies mood by {$amount}
     { $timeout ->

--- a/Resources/Locale/en-US/reagents/meta/toxins.ftl
+++ b/Resources/Locale/en-US/reagents/meta/toxins.ftl
@@ -87,3 +87,6 @@ reagent-desc-lotophagoi-oil = A super potent drug that is much better at inducin
 
 reagent-name-ectoplasm = ectoplasm
 reagent-desc-ectoplasm = The physical component of semi-corporeal spirits.
+
+reagent-name-fev = forced evolutionary virus
+reagent-desc-fev = A highly mutagenic compound that randomly alters the subject's species when enough is metabolized.

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -674,3 +674,14 @@
             Poison: 2
       - !type:SatiateHunger
         factor: -6
+
+- type: reagent
+  id: FEV
+  name: reagent-name-fev
+  group: Toxins
+  desc: reagent-desc-fev
+  physicalDesc: reagent-physical-desc-glowing
+  flavor: bitter
+  color: "#3cb043"
+  metabolisms:
+    Poison: {}


### PR DESCRIPTION
## Summary
- replace the old `FEVChangeSpecies` reagent effect with a new `FEVReceiver` component and system
- FEV metabolization now triggers the receiver component to slowly or instantly mutate species
- added FEV localization strings and updated reagent prototype

## Testing
- `Scripts/sh/runTests.sh` *(failed: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b295ed0e483259c2a64181f4b114b