### PR TITLE
Refactor recharger laser weapons to use power cells

### DIFF
--- a/Content.Client/_N14/Weapons/Ranged/Systems/GunSystem.N14Energy.cs
+++ b/Content.Client/_N14/Weapons/Ranged/Systems/GunSystem.N14Energy.cs
@@ -1,0 +1,25 @@
+using Content.Shared._N14.Weapons.Ranged.Components;
+using Content.Client.Weapons.Ranged.Systems;
+
+namespace Content.Client.Weapons.Ranged.Systems;
+
+public sealed partial class GunSystem
+{
+    protected override void InitializeN14Energy()
+    {
+        base.InitializeN14Energy();
+        SubscribeLocalEvent<N14EnergyWeaponComponent, AmmoCounterControlEvent>(OnN14EnergyControl);
+        SubscribeLocalEvent<N14EnergyWeaponComponent, UpdateAmmoCounterEvent>(OnN14EnergyUpdate);
+    }
+
+    private void OnN14EnergyUpdate(EntityUid uid, N14EnergyWeaponComponent component, UpdateAmmoCounterEvent args)
+    {
+        if (args.Control is not BoxesStatusControl boxes) return;
+        boxes.Update(component.Shots, component.Capacity);
+    }
+
+    private void OnN14EnergyControl(EntityUid uid, N14EnergyWeaponComponent component, AmmoCounterControlEvent args)
+    {
+        args.Control = new BoxesStatusControl();
+    }
+}

--- a/Content.Server/_N14/Weapons/Ranged/Systems/GunSystem.N14Energy.cs
+++ b/Content.Server/_N14/Weapons/Ranged/Systems/GunSystem.N14Energy.cs
@@ -1,0 +1,20 @@
+using Content.Shared._N14.Weapons.Ranged.Components;
+using Content.Server.Power.Components;
+using Content.Server.Power.EntitySystems;
+
+namespace Content.Server.Weapons.Ranged.Systems;
+
+public sealed partial class GunSystem
+{
+    [Dependency] private readonly BatterySystem _battery = default!;
+
+    protected override void InitializeN14Energy()
+    {
+        base.InitializeN14Energy();
+    }
+
+    protected override void TakeCellCharge(EntityUid gunUid, EntityUid cellUid, float fireCost, BatteryComponent? battery = null)
+    {
+        _battery.UseCharge(cellUid, fireCost, battery);
+    }
+}

--- a/Content.Server/_N14/Weapons/Ranged/Systems/GunSystem.N14Energy.cs
+++ b/Content.Server/_N14/Weapons/Ranged/Systems/GunSystem.N14Energy.cs
@@ -13,8 +13,28 @@ public sealed partial class GunSystem
         base.InitializeN14Energy();
     }
 
-    protected override void TakeCellCharge(EntityUid gunUid, EntityUid cellUid, float fireCost, BatteryComponent? battery = null)
+    protected override void TakeCellCharge(EntityUid gunUid, N14EnergyWeaponComponent component, EntityUid cellUid, float fireCost)
     {
-        _battery.UseCharge(cellUid, fireCost, battery);
+        _battery.UseCharge(cellUid, fireCost);
+        UpdateN14EnergyShots(gunUid, component);
+    }
+
+    private void UpdateN14EnergyShots(EntityUid uid, N14EnergyWeaponComponent component)
+    {
+        var cell = GetMagazineEntity(uid);
+
+        if (cell == null || !TryComp<BatteryComponent>(cell.Value, out var battery))
+        {
+            component.Shots = 0;
+            component.Capacity = 0;
+        }
+        else
+        {
+            component.Shots = (int)(battery.CurrentCharge / component.FireCost);
+            component.Capacity = (int)(battery.MaxCharge / component.FireCost);
+        }
+
+        UpdateN14EnergyAppearance(uid, component);
+        Dirty(uid, component);
     }
 }

--- a/Content.Server/_N14/Weapons/Ranged/Systems/GunSystem.N14Energy.cs
+++ b/Content.Server/_N14/Weapons/Ranged/Systems/GunSystem.N14Energy.cs
@@ -6,7 +6,6 @@ namespace Content.Server.Weapons.Ranged.Systems;
 
 public sealed partial class GunSystem
 {
-    [Dependency] private readonly BatterySystem _battery = default!;
 
     protected override void InitializeN14Energy()
     {

--- a/Content.Server/_N14/Weapons/Ranged/Systems/GunSystem.N14Energy.cs
+++ b/Content.Server/_N14/Weapons/Ranged/Systems/GunSystem.N14Energy.cs
@@ -6,6 +6,7 @@ namespace Content.Server.Weapons.Ranged.Systems;
 
 public sealed partial class GunSystem
 {
+    [Dependency] private readonly BatterySystem _battery = default!;
 
     protected override void InitializeN14Energy()
     {
@@ -18,7 +19,7 @@ public sealed partial class GunSystem
         UpdateN14EnergyShots(gunUid, component);
     }
 
-    private void UpdateN14EnergyShots(EntityUid uid, N14EnergyWeaponComponent component)
+    protected override void UpdateN14EnergyShots(EntityUid uid, N14EnergyWeaponComponent component)
     {
         var cell = GetMagazineEntity(uid);
 

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -94,6 +94,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         InitializeClothing();
         InitializeContainer();
         InitializeSolution();
+        InitializeN14Energy();
 
         // Interactions
         SubscribeLocalEvent<GunComponent, GetVerbsEvent<AlternativeVerb>>(OnAltVerb);

--- a/Content.Shared/_N14/Weapons/Ranged/Components/N14EnergyWeaponComponent.cs
+++ b/Content.Shared/_N14/Weapons/Ranged/Components/N14EnergyWeaponComponent.cs
@@ -1,0 +1,32 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Content.Shared.Weapons.Ranged.Components;
+
+namespace Content.Shared._N14.Weapons.Ranged.Components;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class N14EnergyWeaponComponent : AmmoProviderComponent
+{
+    /// <summary>Energy consumed per shot.</summary>
+    [DataField("fireCost"), AutoNetworkedField]
+    public float FireCost = 50f;
+
+    /// <summary>If true the weapon uses hitscan, otherwise projectile.</summary>
+    [DataField("hitscan"), AutoNetworkedField]
+    public bool Hitscan = true;
+
+    /// <summary>Projectile prototype to spawn when firing.</summary>
+    [DataField("projectileProto", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>)), AutoNetworkedField]
+    public string? ProjectileProto;
+
+    /// <summary>Hitscan prototype to use when firing.</summary>
+    [DataField("hitscanProto", customTypeSerializer: typeof(PrototypeIdSerializer<HitscanPrototype>)), AutoNetworkedField]
+    public string? HitscanProto;
+
+    [ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public int Shots;
+
+    [ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public int Capacity;
+}

--- a/Content.Shared/_N14/Weapons/Ranged/Components/N14EnergyWeaponComponent.cs
+++ b/Content.Shared/_N14/Weapons/Ranged/Components/N14EnergyWeaponComponent.cs
@@ -1,6 +1,7 @@
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Content.Shared.Weapons.Ranged;
 using Content.Shared.Weapons.Ranged.Components;
 
 namespace Content.Shared._N14.Weapons.Ranged.Components;

--- a/Content.Shared/_N14/Weapons/Ranged/Systems/SharedGunSystem.N14Energy.cs
+++ b/Content.Shared/_N14/Weapons/Ranged/Systems/SharedGunSystem.N14Energy.cs
@@ -1,0 +1,93 @@
+using Content.Shared._N14.Weapons.Ranged.Components;
+using Content.Server.Power.Components; // only needed for parameter type
+using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Weapons.Ranged.Components;
+using Robust.Shared.Containers;
+using Robust.Shared.GameStates;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Weapons.Ranged.Systems;
+
+public abstract partial class SharedGunSystem
+{
+    protected virtual void InitializeN14Energy()
+    {
+        SubscribeLocalEvent<N14EnergyWeaponComponent, MapInitEvent>(OnN14EnergyInit);
+        SubscribeLocalEvent<N14EnergyWeaponComponent, TakeAmmoEvent>(OnN14EnergyTakeAmmo);
+        SubscribeLocalEvent<N14EnergyWeaponComponent, GetAmmoCountEvent>(OnN14EnergyAmmoCount);
+        SubscribeLocalEvent<N14EnergyWeaponComponent, EntInsertedIntoContainerMessage>(OnN14EnergySlotChange);
+        SubscribeLocalEvent<N14EnergyWeaponComponent, EntRemovedFromContainerMessage>(OnN14EnergySlotChange);
+    }
+
+    private void OnN14EnergyInit(EntityUid uid, N14EnergyWeaponComponent component, MapInitEvent args)
+    {
+        UpdateN14EnergyShots(uid, component);
+    }
+
+    private void OnN14EnergySlotChange(EntityUid uid, N14EnergyWeaponComponent component, ContainerModifiedMessage args)
+    {
+        if (args.Container.ID != MagazineSlot)
+            return;
+        UpdateN14EnergyShots(uid, component);
+    }
+
+    private void OnN14EnergyAmmoCount(EntityUid uid, N14EnergyWeaponComponent component, ref GetAmmoCountEvent args)
+    {
+        UpdateN14EnergyShots(uid, component);
+        args.Count = component.Shots;
+        args.Capacity = component.Capacity;
+    }
+
+    private void OnN14EnergyTakeAmmo(EntityUid uid, N14EnergyWeaponComponent component, TakeAmmoEvent args)
+    {
+        var cell = GetMagazineEntity(uid);
+        if (cell == null || !TryComp<BatteryComponent>(cell.Value, out var battery))
+            return;
+
+        for (var i = 0; i < args.Shots; i++)
+        {
+            if (battery.CurrentCharge < component.FireCost)
+                break;
+
+            if (component.Hitscan)
+            {
+                var hitscan = ProtoManager.Index<HitscanPrototype>(component.HitscanProto!);
+                args.Ammo.Add((null, hitscan));
+            }
+            else
+            {
+                var ent = Spawn(component.ProjectileProto!, args.Coordinates);
+                args.Ammo.Add((ent, EnsureShootable(ent)));
+            }
+
+            TakeCellCharge(uid, cell.Value, component.FireCost, battery);
+        }
+
+        UpdateN14EnergyShots(uid, component);
+    }
+
+    protected virtual void TakeCellCharge(EntityUid gunUid, EntityUid cellUid, float fireCost, BatteryComponent? battery = null) {}
+
+    private void UpdateN14EnergyShots(EntityUid uid, N14EnergyWeaponComponent component)
+    {
+        var cell = GetMagazineEntity(uid);
+        if (cell == null || !TryComp<BatteryComponent>(cell.Value, out var battery))
+        {
+            component.Shots = 0;
+            component.Capacity = 0;
+        }
+        else
+        {
+            component.Shots = (int)(battery.CurrentCharge / component.FireCost);
+            component.Capacity = (int)(battery.MaxCharge / component.FireCost);
+        }
+
+        if (TryComp<AppearanceComponent>(uid, out var appearance))
+        {
+            Appearance.SetData(uid, AmmoVisuals.HasAmmo, component.Shots != 0, appearance);
+            Appearance.SetData(uid, AmmoVisuals.AmmoCount, component.Shots, appearance);
+            Appearance.SetData(uid, AmmoVisuals.AmmoMax, component.Capacity, appearance);
+        }
+    }
+}

--- a/Content.Shared/_N14/Weapons/Ranged/Systems/SharedGunSystem.N14Energy.cs
+++ b/Content.Shared/_N14/Weapons/Ranged/Systems/SharedGunSystem.N14Energy.cs
@@ -71,9 +71,9 @@ public abstract partial class SharedGunSystem
 
     protected virtual void TakeCellCharge(EntityUid gunUid, N14EnergyWeaponComponent component, EntityUid cellUid, float fireCost) {}
 
-    partial void UpdateN14EnergyShots(EntityUid uid, N14EnergyWeaponComponent component);
+    protected virtual void UpdateN14EnergyShots(EntityUid uid, N14EnergyWeaponComponent component) {}
 
-    private void UpdateN14EnergyAppearance(EntityUid uid, N14EnergyWeaponComponent component)
+    protected void UpdateN14EnergyAppearance(EntityUid uid, N14EnergyWeaponComponent component)
     {
         if (!TryComp<AppearanceComponent>(uid, out var appearance))
             return;

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Battery/Battery.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Battery/Battery.yml
@@ -34,9 +34,6 @@
   - type: PowerCellVisuals
   - type: Riggable
   - type: Craftable
-  - type: HitscanBatteryAmmoProvider
-    proto: RedMediumLaser
-    fireCost: 50
 
 #MARK: MF
 
@@ -83,9 +80,6 @@
   - type: Battery
     maxCharge: 1200
     startingCharge: 1200
-  - type: HitscanBatteryAmmoProvider
-    proto: RedShuttleLaser
-    fireCost: 75
 
 #MARK: EC
 
@@ -113,9 +107,6 @@
   - type: Battery
     maxCharge: 600
     startingCharge: 600
-  - type: HitscanBatteryAmmoProvider
-    proto: RedLaser
-    fireCost: 50
 
 #MARK: ECP
 
@@ -143,9 +134,6 @@
   - type: Battery
     maxCharge: 2375
     startingCharge: 2375
-  - type: HitscanBatteryAmmoProvider
-    proto: RedHeavyLaser
-    fireCost: 125
 
 #MARK: Fusion Cell
 
@@ -173,9 +161,6 @@
     startingCharge: 5000
   - type: Item
     size: Normal
-  - type: HitscanBatteryAmmoProvider
-    proto: RedLaser
-    fireCost: 50
 
 #MARK: Plasma cartridge
 
@@ -210,9 +195,6 @@
   - type: Appearance
   - type: PowerCellVisuals
   - type: Riggable
-  - type: ProjectileBatteryAmmoProvider
-    proto: BulletPlasma
-    fireCost: 100
 
 - type: entity
   name: plasma cartridge
@@ -261,9 +243,6 @@
   - type: Battery
     maxCharge: 900
     startingCharge: 900
-  - type: ProjectileBatteryAmmoProvider
-    proto: BulletLightPlasma
-    fireCost: 50
 
 #MARK: Plasma shell
 
@@ -289,6 +268,3 @@
   - type: Battery
     maxCharge: 5000
     startingCharge: 5000
-  - type: ProjectileBatteryAmmoProvider
-    proto: BulletBigPlasma
-    fireCost: 50

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -116,6 +116,10 @@
     fireRate: 1.5
     soundGunshot:
       collection: N14LaserPistolGunshot
+  - type: N14EnergyWeapon
+    hitscan: true
+    hitscanProto: RedLaser
+    fireCost: 50
   - type: FollowDistance
     backStrength: 6
   - type: StaticPrice
@@ -162,6 +166,10 @@
     fireRate: 1.5
     soundGunshot:
       collection: N14LaserPistolGunshot
+  - type: N14EnergyWeapon
+    hitscan: true
+    hitscanProto: RedMediumLaser
+    fireCost: 50
   - type: FollowDistance
     backStrength: 6
   - type: StaticPrice
@@ -203,6 +211,10 @@
     soundGunshot:
       collection: N14PlasmaPistolGunshot
     fireRate: 1.5
+  - type: N14EnergyWeapon
+    hitscan: false
+    projectileProto: BulletLightPlasma
+    fireCost: 50
   - type: FollowDistance
     backStrength: 6
   - type: StaticPrice
@@ -244,6 +256,10 @@
     soundGunshot:
       collection: N14PlasmaDefenderGunshot
     fireRate: 2.5
+  - type: N14EnergyWeapon
+    hitscan: false
+    projectileProto: BulletPlasma
+    fireCost: 100
   - type: FollowDistance
     backStrength: 6
   - type: StaticPrice
@@ -255,9 +271,9 @@
 
 - type: entity
   name: recharger rifle
-  parent: BaseWeaponBattery
+  parent: N14BaseWeaponPowerCellMedium
   id: N14WeaponLaserRifleRecharger
-  description: The first model for a self-charging laser rifle, its low energy consumption and advanced internal battery lets this gun last for centuries without recharging.
+  description: The first model for a self-charging laser rifle. This variant has been refitted to accept standard power cells.
   components:
   - type: Wieldable
   - type: GunWieldBonus
@@ -273,17 +289,25 @@
       shader: unshaded
   - type: Clothing
     sprite: _Nuclear14/Objects/Weapons/Guns/Battery/recharger_rifle.rsi
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 25
+  - type: ItemSlots
+    slots:
+      gun_magazine:
+        name: Magazine
+        startingItem: N14PowerCellHigh
+        insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
+        ejectSound: /Audio/Weapons/Guns/MagOut/batrifle_magout.ogg
+        whitelist:
+          tags:
+            - N14PowerCellHigh
   - type: Gun
     soundGunshot:
       collection: N14RechargerRifleGunshot
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
-  - type: HitscanBatteryAmmoProvider
-    proto: RedLaser
+  - type: N14EnergyWeapon
+    hitscan: false
+    projectileProto: BulletRechargerLaser
     fireCost: 50
   - type: FollowDistance
     backStrength: 5
@@ -292,9 +316,9 @@
 
 - type: entity
   name: recharger pistol
-  parent: BaseWeaponBatterySmall
+  parent: N14BaseWeaponPowerCellSmall
   id: N14WeaponLaserPistolRecharger
-  description: The upgraded version of the recharger rifle, compact but maintaining the same power, its low energy consumption and advanced internal battery makes this gun last for centuries without recharging.
+  description: The upgraded version of the recharger rifle, compact but now powered by replaceable cells.
   components:
   - type: Sprite
     sprite: _Nuclear14/Objects/Weapons/Guns/Battery/recharger_pistol.rsi
@@ -306,15 +330,23 @@
       shader: unshaded
   - type: Clothing
     sprite: _Nuclear14/Objects/Weapons/Guns/Battery/recharger_pistol.rsi
+  - type: ItemSlots
+    slots:
+      gun_magazine:
+        name: Magazine
+        startingItem: N14PowerCellSmall
+        insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
+        ejectSound: /Audio/Weapons/Guns/MagOut/batrifle_magout.ogg
+        whitelist:
+          tags:
+            - N14PowerCellSmall
   - type: Gun
     soundGunshot:
       collection: N14RechargerPistolGunshot
-  - type: HitscanBatteryAmmoProvider
-    proto: RedLaser
+  - type: N14EnergyWeapon
+    hitscan: false
+    projectileProto: BulletRechargerLaser
     fireCost: 50
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 20
   - type: MagazineVisuals
     magState: mag
     steps: 5
@@ -377,6 +409,10 @@
     selectedMode: FullAuto
     availableModes:
     - FullAuto
+  - type: N14EnergyWeapon
+    hitscan: true
+    hitscanProto: RedMediumLaser
+    fireCost: 50
   - type: FollowDistance
     backStrength: 5
   - type: StaticPrice
@@ -430,6 +466,10 @@
     selectedMode: FullAuto
     availableModes:
     - FullAuto
+  - type: N14EnergyWeapon
+    hitscan: false
+    projectileProto: BulletPlasma
+    fireCost: 100
   - type: FollowDistance
     backStrength: 5
   - type: StaticPrice
@@ -480,6 +520,10 @@
     selectedMode: FullAuto
     availableModes:
     - FullAuto
+  - type: N14EnergyWeapon
+    hitscan: true
+    hitscanProto: RedHeavyLaser
+    fireCost: 125
   - type: FollowDistance
     backStrength: 5
   - type: StaticPrice
@@ -532,6 +576,10 @@
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
+  - type: N14EnergyWeapon
+    hitscan: true
+    hitscanProto: RedMediumLaser
+    fireCost: 50
   - type: FollowDistance
     backStrength: 5
   - type: StaticPrice
@@ -578,6 +626,10 @@
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
+  - type: N14EnergyWeapon
+    hitscan: true
+    hitscanProto: RedMediumLaser
+    fireCost: 50
   - type: StaticPrice
     price: 150
 
@@ -626,6 +678,10 @@
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
+  - type: N14EnergyWeapon
+    hitscan: true
+    hitscanProto: RedMediumLaser
+    fireCost: 50
   - type: FollowDistance
     backStrength: 5
   - type: StaticPrice
@@ -679,6 +735,10 @@
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
+  - type: N14EnergyWeapon
+    hitscan: false
+    projectileProto: BulletPlasma
+    fireCost: 100
   - type: FollowDistance
     backStrength: 5
   - type: StaticPrice
@@ -728,6 +788,10 @@
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
+  - type: N14EnergyWeapon
+    hitscan: false
+    projectileProto: BulletPlasma
+    fireCost: 100
   - type: StaticPrice
     price: 175
 
@@ -779,6 +843,10 @@
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
+  - type: N14EnergyWeapon
+    hitscan: false
+    projectileProto: BulletPlasma
+    fireCost: 100
   - type: FollowDistance
     backStrength: 5
   - type: StaticPrice
@@ -832,6 +900,10 @@
     availableModes:
      - SemiAuto
      - Burst
+  - type: N14EnergyWeapon
+    hitscan: false
+    projectileProto: BulletPlasma
+    fireCost: 100
   - type: FollowDistance
     backStrength: 6
   - type: StaticPrice
@@ -885,6 +957,10 @@
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
+  - type: N14EnergyWeapon
+    hitscan: true
+    hitscanProto: RedShuttleLaser
+    fireCost: 75
   - type: FollowDistance
     backStrength: 4
   - type: StaticPrice
@@ -935,6 +1011,10 @@
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
+  - type: N14EnergyWeapon
+    hitscan: true
+    hitscanProto: RedShuttleLaser
+    fireCost: 75
   - type: FollowDistance
     backStrength: 4
   - type: StaticPrice
@@ -989,6 +1069,10 @@
     selectedMode: FullAuto
     availableModes:
     - FullAuto
+  - type: N14EnergyWeapon
+    hitscan: false
+    projectileProto: BulletBigPlasma
+    fireCost: 50
   - type: Appearance
   - type: MultiHandedItem
   - type: ClothingSpeedModifier
@@ -1047,6 +1131,10 @@
     selectedMode: FullAuto
     availableModes:
     - FullAuto
+  - type: N14EnergyWeapon
+    hitscan: true
+    hitscanProto: RedLaser
+    fireCost: 50
   - type: Appearance
   - type: MultiHandedItem
   - type: ClothingSpeedModifier


### PR DESCRIPTION
## Summary
- recharger rifle and pistol now take removable power cells instead of an internal battery
- add `N14EnergyWeaponComponent` for power cell-based energy guns
- hook up new component in gun system
- convert laser and plasma weapons to use `N14EnergyWeapon`

## Testing
- `apt-get update`
- `dotnet test -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c2c162b0c832589bbd34f8673508b