### PR TITLE
Add support systems under N14

### DIFF
--- a/Content.Server/_N14/Support/ArtilleryStrikeSystem.cs
+++ b/Content.Server/_N14/Support/ArtilleryStrikeSystem.cs
@@ -1,0 +1,55 @@
+using Content.Shared._N14.Support;
+using Content.Server.Explosion.EntitySystems;
+using Robust.Shared.Map;
+using Robust.Shared.Timing;
+
+namespace Content.Server._N14.Support;
+
+/// <summary>
+/// Handles simple timed artillery strikes.
+/// </summary>
+public sealed class ArtilleryStrikeSystem : EntitySystem
+{
+    [Dependency] private readonly ExplosionSystem _explosions = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ArtilleryStrikeComponent, ComponentStartup>(OnStartup);
+    }
+
+    private void OnStartup(EntityUid uid, ArtilleryStrikeComponent component, ComponentStartup args)
+    {
+        component.StartTime = _timing.CurTime;
+    }
+
+    public override void Update(float frameTime)
+    {
+        var now = _timing.CurTime;
+        var query = EntityQueryEnumerator<ArtilleryStrikeComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (now < comp.StartTime + comp.Delay)
+                continue;
+
+            _explosions.QueueExplosion(comp.Target, comp.ExplosionType, comp.Intensity, comp.Slope, comp.MaxIntensity, canCreateVacuum: false);
+            QueueDel(uid);
+        }
+    }
+
+    public EntityUid ScheduleStrike(MapCoordinates target, TimeSpan delay, string type = "Default", float intensity = 50f, float slope = 3f, float maxIntensity = 10f)
+    {
+        var ent = Spawn(null, target);
+        var comp = EnsureComp<ArtilleryStrikeComponent>(ent);
+        comp.Target = target;
+        comp.Delay = delay;
+        comp.ExplosionType = type;
+        comp.Intensity = intensity;
+        comp.Slope = slope;
+        comp.MaxIntensity = maxIntensity;
+        comp.StartTime = _timing.CurTime;
+        Dirty(ent, comp);
+        return ent;
+    }
+}

--- a/Content.Server/_N14/Support/VertibirdSupportSystem.cs
+++ b/Content.Server/_N14/Support/VertibirdSupportSystem.cs
@@ -1,0 +1,86 @@
+using Content.Shared._N14.Support;
+using Content.Server.Explosion.EntitySystems;
+using Robust.Shared.Audio;
+using Robust.Shared.Map;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Server._N14.Support;
+
+/// <summary>
+/// Manages scheduled vertibird fire support.
+/// </summary>
+public sealed class VertibirdSupportSystem : EntitySystem
+{
+    [Dependency] private readonly ExplosionSystem _explosions = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<VertibirdSupportComponent, ComponentStartup>(OnStartup);
+    }
+
+    private void OnStartup(EntityUid uid, VertibirdSupportComponent component, ComponentStartup args)
+    {
+        component.StartTime = _timing.CurTime;
+        component.ShotsFired = 0;
+    }
+
+    public override void Update(float frameTime)
+    {
+        var now = _timing.CurTime;
+        var query = EntityQueryEnumerator<VertibirdSupportComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (comp.ShotsFired == 0 && now >= comp.StartTime + comp.Delay)
+            {
+                if (comp.ApproachSound != null)
+                    _audio.PlayPvs(comp.ApproachSound, comp.Target);
+            }
+
+            var nextTime = comp.StartTime + comp.Delay + comp.ShotsFired * comp.ShotInterval;
+            if (now < nextTime)
+                continue;
+
+            if (comp.ShotsFired >= comp.Shots)
+            {
+                QueueDel(uid);
+                continue;
+            }
+
+            var offset = _random.NextVector2(-comp.Spread, comp.Spread);
+            var pos = comp.Target.Offset(offset);
+
+            _explosions.QueueExplosion(pos, comp.ExplosionType, comp.Intensity, comp.Slope, comp.MaxIntensity, canCreateVacuum: false);
+            if (comp.FireSound != null)
+                _audio.PlayPvs(comp.FireSound, pos);
+
+            comp.ShotsFired++;
+            Dirty(uid, comp);
+        }
+    }
+
+    public EntityUid ScheduleSupport(MapCoordinates target, TimeSpan delay, int shots = 3, TimeSpan? interval = null, float spread = 2f, string type = "Default", float intensity = 30f, float slope = 2f, float maxIntensity = 5f, SoundSpecifier? approach = null, SoundSpecifier? fire = null)
+    {
+        var ent = Spawn(null, target);
+        var comp = EnsureComp<VertibirdSupportComponent>(ent);
+        comp.Target = target;
+        comp.Delay = delay;
+        comp.Shots = shots;
+        comp.ShotInterval = interval ?? TimeSpan.FromSeconds(1);
+        comp.Spread = spread;
+        comp.ExplosionType = type;
+        comp.Intensity = intensity;
+        comp.Slope = slope;
+        comp.MaxIntensity = maxIntensity;
+        comp.ApproachSound = approach;
+        comp.FireSound = fire;
+        comp.StartTime = _timing.CurTime;
+        comp.ShotsFired = 0;
+        Dirty(ent, comp);
+        return ent;
+    }
+}

--- a/Content.Shared/_N14/Support/ArtilleryStrikeComponent.cs
+++ b/Content.Shared/_N14/Support/ArtilleryStrikeComponent.cs
@@ -1,0 +1,33 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Robust.Shared.Map;
+
+namespace Content.Shared._N14.Support;
+
+/// <summary>
+/// Marks an entity that will trigger an artillery strike after a delay.
+/// </summary>
+[RegisterComponent, Access(typeof(SharedArtilleryStrikeSystem))]
+public sealed partial class ArtilleryStrikeComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public MapCoordinates Target;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan Delay = TimeSpan.FromSeconds(5);
+
+    [DataField, AutoNetworkedField]
+    public string ExplosionType = "Default";
+
+    [DataField, AutoNetworkedField]
+    public float Intensity = 50f;
+
+    [DataField, AutoNetworkedField]
+    public float Slope = 3f;
+
+    [DataField, AutoNetworkedField]
+    public float MaxIntensity = 10f;
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan StartTime;
+}

--- a/Content.Shared/_N14/Support/VertibirdSupportComponent.cs
+++ b/Content.Shared/_N14/Support/VertibirdSupportComponent.cs
@@ -1,0 +1,52 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Robust.Shared.Map;
+using Robust.Shared.Audio;
+
+namespace Content.Shared._N14.Support;
+
+/// <summary>
+/// Schedules a series of explosions representing vertibird fire support.
+/// </summary>
+[RegisterComponent, Access(typeof(SharedVertibirdSupportSystem))]
+public sealed partial class VertibirdSupportComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public MapCoordinates Target;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan Delay = TimeSpan.FromSeconds(5);
+
+    [DataField, AutoNetworkedField]
+    public int Shots = 3;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan ShotInterval = TimeSpan.FromSeconds(1);
+
+    [DataField, AutoNetworkedField]
+    public float Spread = 2f;
+
+    [DataField, AutoNetworkedField]
+    public string ExplosionType = "Default";
+
+    [DataField, AutoNetworkedField]
+    public float Intensity = 30f;
+
+    [DataField, AutoNetworkedField]
+    public float Slope = 2f;
+
+    [DataField, AutoNetworkedField]
+    public float MaxIntensity = 5f;
+
+    [DataField]
+    public SoundSpecifier? ApproachSound;
+
+    [DataField]
+    public SoundSpecifier? FireSound;
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan StartTime;
+
+    [DataField, AutoNetworkedField]
+    public int ShotsFired;
+}

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Tools/lights.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Tools/lights.yml
@@ -58,3 +58,22 @@
     radius: 1.0
     energy: 9.0
     netsync: false
+
+# Flares for fire support designation
+- type: entity
+  parent: N14Flare
+  id: N14ArtilleryFlare
+  name: artillery flare
+  description: Marks a target for artillery fire.
+  components:
+  - type: ArtilleryStrike
+    delay: 5
+
+- type: entity
+  parent: N14Flare
+  id: N14VertibirdFlare
+  name: vertibird flare
+  description: Calls in vertibird support on this location.
+  components:
+  - type: VertibirdSupport
+    delay: 5


### PR DESCRIPTION
## Summary
- move vertibird and artillery support code into `_N14` folders
- initialize support components on startup for proper timing
- add `N14ArtilleryFlare` and `N14VertibirdFlare` prototypes

## Testing
- ❌ `dotnet format --verify-no-changes --no-restore` (failed to run: `bash: dotnet: command not found`)


------
https://chatgpt.com/codex/tasks/task_e_685db622128883259298aea419beb08a