### PR TITLE
Add attachment holder to service rifle

### DIFF
--- a/Content.Shared/_N14/Weapons/Attachments/GrenadeLauncherAttachmentComponent.cs
+++ b/Content.Shared/_N14/Weapons/Attachments/GrenadeLauncherAttachmentComponent.cs
@@ -1,0 +1,26 @@
+using Content.Shared.Actions;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._N14.Weapons.Attachments;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class GrenadeLauncherAttachmentComponent : Component
+{
+    [DataField(required: true)]
+    public EntProtoId GunPrototype = default!;
+
+    [DataField(required: true)]
+    public EntProtoId ActionPrototype = default!;
+
+    [DataField]
+    public EntityUid? GunEntity;
+
+    [DataField]
+    public EntityUid? ActionEntity;
+}
+
+/// <summary>
+/// Fired when the grenade launcher action is used.
+/// </summary>
+public sealed partial class GrenadeLauncherActionEvent : WorldTargetActionEvent;

--- a/Content.Shared/_N14/Weapons/Attachments/ScopeAttachmentComponent.cs
+++ b/Content.Shared/_N14/Weapons/Attachments/ScopeAttachmentComponent.cs
@@ -1,0 +1,20 @@
+using System.Numerics;
+using Content.Shared._NC.CameraFollow.Components;
+using Content.Shared._NC.FollowDistance.Components;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._N14.Weapons.Attachments;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ScopeAttachmentComponent : Component
+{
+    [DataField]
+    public EntProtoId ActionPrototype = "ActionToggleCamera";
+
+    // Runtime storage of the weapon's original follow distance
+    [DataField] public Vector2? OriginalMaxDistance;
+    [DataField] public float? OriginalBackStrength;
+
+    [DataField] public EntityUid? ActionEntity;
+}

--- a/Content.Shared/_N14/Weapons/Attachments/WeaponAttachmentComponent.cs
+++ b/Content.Shared/_N14/Weapons/Attachments/WeaponAttachmentComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._N14.Weapons.Attachments;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class WeaponAttachmentComponent : Component
+{
+    [DataField(required: true)]
+    public string Slot = string.Empty;
+}

--- a/Content.Shared/_N14/Weapons/Attachments/WeaponAttachmentHolderComponent.cs
+++ b/Content.Shared/_N14/Weapons/Attachments/WeaponAttachmentHolderComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._N14.Weapons.Attachments;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class WeaponAttachmentHolderComponent : Component
+{
+    [DataField]
+    public Dictionary<string, WeaponAttachmentSlot> Slots = new();
+}

--- a/Content.Shared/_N14/Weapons/Attachments/WeaponAttachmentSlot.cs
+++ b/Content.Shared/_N14/Weapons/Attachments/WeaponAttachmentSlot.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._N14.Weapons.Attachments;
+
+[DataDefinition]
+public sealed partial record WeaponAttachmentSlot
+{
+    [DataField(required: true)]
+    public string Name = string.Empty;
+
+    [DataField]
+    public EntProtoId? StartingAttachment;
+}

--- a/Content.Shared/_N14/Weapons/Attachments/WeaponAttachmentSystem.cs
+++ b/Content.Shared/_N14/Weapons/Attachments/WeaponAttachmentSystem.cs
@@ -1,0 +1,141 @@
+using Content.Shared.Actions;
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Systems;
+using Content.Shared._NC.FollowDistance.Components;
+using Content.Shared._NC.CameraFollow.Components;
+using Robust.Shared.Containers;
+using Robust.Shared.GameStates;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._N14.Weapons.Attachments;
+
+public sealed class WeaponAttachmentSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly SharedContainerSystem _containers = default!;
+    [Dependency] private readonly SharedActionsSystem _actions = default!;
+    [Dependency] private readonly SharedGunSystem _gun = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<WeaponAttachmentHolderComponent, MapInitEvent>(OnHolderInit);
+        SubscribeLocalEvent<WeaponAttachmentHolderComponent, ComponentShutdown>(OnHolderShutdown);
+        SubscribeLocalEvent<GrenadeLauncherActionEvent>(OnGrenadeLaunch);
+    }
+
+    private void OnHolderInit(EntityUid uid, WeaponAttachmentHolderComponent comp, MapInitEvent args)
+    {
+        foreach (var (id, slot) in comp.Slots)
+        {
+            if (slot.StartingAttachment == null)
+                continue;
+
+            var container = _containers.EnsureContainer<ContainerSlot>(uid, id);
+            var ent = Spawn(slot.StartingAttachment, Transform(uid).Coordinates);
+            _containers.Insert(ent, container);
+            SetupAttachment(uid, ent);
+        }
+    }
+
+    private void OnHolderShutdown(EntityUid uid, WeaponAttachmentHolderComponent comp, ComponentShutdown args)
+    {
+        foreach (var (id, slot) in comp.Slots)
+        {
+            if (_containers.TryGetContainer(uid, id, out var container))
+            {
+                foreach (var ent in container.ContainedEntities)
+                    CleanupAttachment(uid, ent);
+            }
+        }
+    }
+
+    private void SetupAttachment(EntityUid holder, EntityUid attachment)
+    {
+        if (TryComp<GrenadeLauncherAttachmentComponent>(attachment, out var gl))
+        {
+            gl.GunEntity = Spawn(gl.GunPrototype);
+            _actions.AddAction(holder, ref gl.ActionEntity, gl.ActionPrototype);
+        }
+
+        if (TryComp<ScopeAttachmentComponent>(attachment, out var scope) &&
+            TryComp<FollowDistanceComponent>(attachment, out var scopeFollow) &&
+            TryComp<FollowDistanceComponent>(holder, out var holderFollow))
+        {
+            scope.OriginalBackStrength = holderFollow.BackStrength;
+            scope.OriginalMaxDistance = holderFollow.MaxDistance;
+            holderFollow.BackStrength = scopeFollow.BackStrength;
+            holderFollow.MaxDistance = scopeFollow.MaxDistance;
+
+            var camera = EnsureComp<CameraFollowComponent>(holder);
+            if (scope.ActionPrototype != null)
+                _actions.AddAction(holder, ref scope.ActionEntity, scope.ActionPrototype);
+        }
+    }
+
+    private void CleanupAttachment(EntityUid holder, EntityUid attachment)
+    {
+        if (TryComp<GrenadeLauncherAttachmentComponent>(attachment, out var gl))
+        {
+            if (gl.GunEntity != null)
+                QueueDel(gl.GunEntity.Value);
+            if (gl.ActionEntity != null)
+                _actions.RemoveAction(holder, gl.ActionEntity.Value);
+        }
+
+        if (TryComp<ScopeAttachmentComponent>(attachment, out var scope) &&
+            TryComp<FollowDistanceComponent>(holder, out var holderFollow))
+        {
+            if (scope.OriginalBackStrength != null)
+                holderFollow.BackStrength = scope.OriginalBackStrength.Value;
+            if (scope.OriginalMaxDistance != null)
+                holderFollow.MaxDistance = scope.OriginalMaxDistance.Value;
+
+            if (scope.ActionEntity != null)
+                _actions.RemoveAction(holder, scope.ActionEntity.Value);
+
+            if (HasComp<CameraFollowComponent>(holder))
+                RemCompDeferred<CameraFollowComponent>(holder);
+        }
+    }
+
+    public bool TryAttach(EntityUid holder, EntityUid attachment)
+    {
+        if (!TryComp<WeaponAttachmentHolderComponent>(holder, out var holderComp) ||
+            !TryComp<WeaponAttachmentComponent>(attachment, out var attachComp))
+            return false;
+
+        if (!holderComp.Slots.TryGetValue(attachComp.Slot, out var slot))
+            return false;
+
+        var container = _containers.EnsureContainer<ContainerSlot>(holder, attachComp.Slot);
+        if (!_containers.Insert(attachment, container))
+            return false;
+
+        SetupAttachment(holder, attachment);
+        return true;
+    }
+
+    public bool TryDetach(EntityUid holder, string slotId)
+    {
+        if (!TryComp<WeaponAttachmentHolderComponent>(holder, out var holderComp))
+            return false;
+
+        if (!_containers.TryGetContainer(holder, slotId, out var container) || container.ContainedEntities.Count == 0)
+            return false;
+
+        var ent = container.ContainedEntities[0];
+        _containers.Remove(ent);
+        CleanupAttachment(holder, ent);
+        return true;
+    }
+
+    private void OnGrenadeLaunch(GrenadeLauncherActionEvent ev)
+    {
+        if (!TryComp<GrenadeLauncherAttachmentComponent>(ev.Performer, out var gl) || gl.GunEntity == null)
+            return;
+
+        if (TryComp<GunComponent>(gl.GunEntity.Value, out var gun))
+            _gun.AttemptShoot(ev.Performer, gl.GunEntity.Value, gun, ev.Target);
+    }
+}

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -182,6 +182,13 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/ltrifle.ogg
     fireOnDropChance: 0.2
+  - type: WeaponAttachmentHolder
+    slots:
+      underbarrel:
+        name: Underbarrel
+      rail:
+        name: Rail
+        startingAttachment: N14AttachmentReflexSight
   - type: ItemSlots
     slots:
       gun_magazine:

--- a/Resources/Prototypes/_Nuclear14/Actions/weapon_attachments.yml
+++ b/Resources/Prototypes/_Nuclear14/Actions/weapon_attachments.yml
@@ -1,0 +1,11 @@
+- type: entity
+  id: ActionFireLauncher
+  name: Fire launcher
+  description: Launch a grenade from the attached launcher.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: WorldTargetAction
+    useDelay: 1
+    range: 10
+    checkCanAccess: false
+    event: !type:GrenadeLauncherActionEvent

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Attachments/attachment_launcher_gun.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Attachments/attachment_launcher_gun.yml
@@ -1,0 +1,19 @@
+- type: entity
+  id: N14AttachmentLauncherGun
+  name: utility launcher module
+  abstract: true
+  components:
+  - type: Gun
+    fireRate: 1
+    selectedMode: SemiAuto
+    availableModes:
+    - SemiAuto
+    soundGunshot: /Audio/Weapons/Guns/Gunshots/grenade_launcher.ogg
+  - type: BallisticAmmoProvider
+    whitelist:
+      tags:
+      - N14Grenade
+    capacity: 1
+    proto: 40mmGrenadeFrag
+    soundInsert:
+      path: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Attachments/rail_reflex_sight.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Attachments/rail_reflex_sight.yml
@@ -1,0 +1,12 @@
+- type: entity
+  id: N14AttachmentReflexSight
+  name: reflex sight
+  description: A simple 1x reflex sight scavenged from pre-war firearms.
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Sights/reflex.rsi
+    state: icon
+  - type: Item
+    size: Small
+  - type: WeaponAttachment
+    slot: sight

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Attachments/sight_hunting_scope.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Attachments/sight_hunting_scope.yml
@@ -1,0 +1,15 @@
+- type: entity
+  id: N14AttachmentHuntingScope
+  name: hunting scope
+  description: A 3x scope for taking careful shots at range.
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Objects/Misc/crafting_junk.rsi
+    state: scope
+  - type: Item
+    size: Small
+  - type: WeaponAttachment
+    slot: sight
+  - type: ScopeAttachment
+  - type: FollowDistance
+    backStrength: 2

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Attachments/underbarrel_grenade_launcher.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Attachments/underbarrel_grenade_launcher.yml
@@ -1,0 +1,16 @@
+- type: entity
+  id: N14AttachmentUnderbarrelLauncher
+  name: M79 underbarrel launcher
+  description: A single-shot grenade launcher often bolted beneath rifles in the wasteland.
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Launchers/china_lake.rsi
+    layers:
+    - state: icon
+  - type: Item
+    size: Small
+  - type: WeaponAttachment
+    slot: underbarrel
+  - type: GrenadeLauncherAttachment
+    gunPrototype: N14AttachmentLauncherGun
+    actionPrototype: ActionFireLauncher

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -259,6 +259,13 @@
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
+  - type: WeaponAttachmentHolder
+    slots:
+      underbarrel:
+        name: Underbarrel
+      sight:
+        name: Sight
+        startingAttachment: N14AttachmentReflexSight
   - type: ItemSlots
     slots:
       gun_magazine:


### PR DESCRIPTION
## Summary
- move N14 attachment prototypes into canonical `_Nuclear14` directory
- update `N14WeaponRifle556Service` to support attachments by default
- add scope attachment system that modifies weapon follow distance and adds a camera toggle action
- provide hunting scope and update reflex sight to use the new sight slot

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685db6812c24832590b59a3bc1c746a2