### PR TITLE
Pip-boy geiger counter

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Devices/pda.yml
@@ -47,6 +47,16 @@
       whitelist:
         tags:
         - IdCardVault
+  - type: Geiger
+    isEnabled: true
+    showControl: true
+    showExamine: true
+    localSoundOnly: false
+    audioParameters:
+      volume: -4
+      maxDistance: 10
+      rolloffFactor: 4
+  - type: RadiationReceiver
 
 - type: entity
   parent: N14BasePipboy


### PR DESCRIPTION
# Description
* Added Geiger counter component has been added to the Pip-Boy
* In the Fallout universe, the Pip-Boy is a computer with a built-in Geiger counter, used to measure radiation levels.

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/f0d1591b-3475-44b2-ad03-80ac06db1394

</p>
</details>

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Prometheus
- add: Geiger counter for Pip-Boy
