### PR TITLE
Add Nuclear14 changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
-  CHANGELOG_DIR: ${{ vars.CHANGELOG_DIR }}
+  CHANGELOG_DIR: Resources/Changelog/Nuclear14.yml
   PR_NUMBER: ${{ github.event.number }}
 
 jobs:

--- a/.github/workflows/discord-changelog.yml
+++ b/.github/workflows/discord-changelog.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Publish changelog
       run: Tools/actions_changelogs_since_last_run.py
       env:
-        CHANGELOG_DIR: ${{ vars.CHANGELOG_DIR }}
+        CHANGELOG_DIR: Resources/Changelog/Nuclear14.yml
         CHANGELOG_WEBHOOK: ${{ secrets.CHANGELOG_WEBHOOK }}
         GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
     continue-on-error: true

--- a/Resources/Changelog/Nuclear14.yml
+++ b/Resources/Changelog/Nuclear14.yml
@@ -1,0 +1,3 @@
+Name: Nuclear14
+Order: -1
+Entries: []

--- a/Tools/actions_changelog_rss.py
+++ b/Tools/actions_changelog_rss.py
@@ -46,7 +46,9 @@ FEED_LANGUAGE    = "en-US"
 FEED_GUID_PREFIX = "ss14-changelog-wizards-"
 FEED_URL         = "https://central.spacestation14.io/changelog.xml"
 
-CHANGELOG_FILE = "Resources/Changelog/Changelog.yml"
+# Path to the changelog file. Defaults to the repository's Nuclear14 changelog
+# but can be overridden with the CHANGELOG_FILE environment variable.
+CHANGELOG_FILE = os.environ.get("CHANGELOG_FILE", "Resources/Changelog/Nuclear14.yml")
 
 TYPES_TO_EMOJI = {
     "Fix":    "🐛",

--- a/Tools/actions_changelogs_since_last_run.py
+++ b/Tools/actions_changelogs_since_last_run.py
@@ -16,7 +16,7 @@ GITHUB_API_URL    = os.environ.get("GITHUB_API_URL", "https://api.github.com")
 GITHUB_REPOSITORY = os.environ["GITHUB_REPOSITORY"]
 GITHUB_RUN        = os.environ["GITHUB_RUN_ID"]
 GITHUB_TOKEN      = os.environ["GITHUB_TOKEN"]
-CHANGELOG_DIR     = os.environ["CHANGELOG_DIR"]
+CHANGELOG_DIR     = os.environ.get("CHANGELOG_DIR", "Resources/Changelog/Nuclear14.yml")
 CHANGELOG_WEBHOOK = os.environ["CHANGELOG_WEBHOOK"]
 
 # https://discord.com/developers/docs/resources/webhook
@@ -92,8 +92,20 @@ def get_last_changelog(sess: requests.Session, sha: str) -> str:
         "Accept": "application/vnd.github.raw"
     }
 
-    resp = sess.get(f"{GITHUB_API_URL}/repos/{GITHUB_REPOSITORY}/contents/{CHANGELOG_DIR}", headers=headers, params=params)
-    resp.raise_for_status()
+    resp = sess.get(
+        f"{GITHUB_API_URL}/repos/{GITHUB_REPOSITORY}/contents/{CHANGELOG_DIR}",
+        headers=headers,
+        params=params,
+    )
+
+    try:
+        resp.raise_for_status()
+    except requests.HTTPError as e:
+        if resp.status_code == 404:
+            print("Previous changelog not found; assuming empty")
+            return "Entries: []"
+        raise
+
     return resp.text
 
 

--- a/Tools/changelogs/changelog.js
+++ b/Tools/changelogs/changelog.js
@@ -3,6 +3,10 @@ const fs = require("fs");
 const yaml = require("js-yaml");
 const axios = require("axios");
 
+// Path to the changelog file. Allows overriding via environment variable but
+// defaults to the repository's Nuclear14 changelog.
+const CHANGELOG_PATH = process.env.CHANGELOG_DIR || "Resources/Changelog/Nuclear14.yml";
+
 // Use GitHub token if available
 if (process.env.GITHUB_TOKEN) axios.defaults.headers.common["Authorization"] = `Bearer ${process.env.GITHUB_TOKEN}`;
 
@@ -120,7 +124,7 @@ function getChanges(body) {
 // Get the highest changelog number from the changelogs file
 function getHighestCLNumber() {
     // Read changelogs file
-    const file = fs.readFileSync(`../../${process.env.CHANGELOG_DIR}`, "utf8");
+    const file = fs.readFileSync(`../../${CHANGELOG_PATH}`, "utf8");
 
     // Get list of CL numbers
     const data = yaml.load(file);
@@ -135,8 +139,8 @@ function writeChangelog(entry) {
     let data = { Entries: [] };
 
     // Create a new changelogs file if it does not exist
-    if (fs.existsSync(`../../${process.env.CHANGELOG_DIR}`)) {
-        const file = fs.readFileSync(`../../${process.env.CHANGELOG_DIR}`, "utf8");
+    if (fs.existsSync(`../../${CHANGELOG_PATH}`)) {
+        const file = fs.readFileSync(`../../${CHANGELOG_PATH}`, "utf8");
         data = yaml.load(file);
     }
 
@@ -144,7 +148,7 @@ function writeChangelog(entry) {
 
     // Write updated changelogs file
     fs.writeFileSync(
-        `../../${process.env.CHANGELOG_DIR}`,
+        `../../${CHANGELOG_PATH}`,
         "Entries:\n" +
             yaml.dump(data.Entries, { indent: 2 }).replace(/^---/, "")
     );


### PR DESCRIPTION
## Summary
- add `Resources/Changelog/Nuclear14.yml`
- default changelog scripts and workflows to use this new changelog file
- include name and order metadata so the changelog appears in game
- handle missing previous changelog when posting updates to Discord

## Testing
- `python3 -m py_compile Tools/actions_changelogs_since_last_run.py`
- `python3 -m py_compile Tools/actions_changelog_rss.py`
- `node --check Tools/changelogs/changelog.js`


------
https://chatgpt.com/codex/tasks/task_e_686e8efcd8a4832590c8dc57985782c5