### PR TITLE
NCR loadout shenanigans

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
@@ -21,7 +21,7 @@
   name: cadet's rifleman kit
   parent: KitBase
   id: KitNCR_CadetRifleman
-  description: A crate containing all an NCR trooper needs to patrol the wasteland.
+  description: A crate containing all an rookie NCR trooper needs to patrol the wasteland.
   components:
   - type: Sprite
     state: rifleman
@@ -33,10 +33,7 @@
       - id: ClothingBeltNCRPouches
       - id: N14WeaponRifle556Service
       - id: Magazine556Rifle
-        amount: 3
-      - id: N14WeaponPistol9mm
-      - id: N14MagazinePistol9mm
-        amount: 2
+        amount: 5
       - id: N14BoxCardboardMREBoxCFilled
       - id: N14Stimpak
       - id: N14RadXPill
@@ -61,10 +58,10 @@
       - id: ClothingBeltNCRPouches
       - id: N14WeaponRifle556Butchered
       - id: Magazine556Rifle
-        amount: 3
+        amount: 2
       - id: N14WeaponPistol9mm
       - id: N14MagazinePistol9mm
-        amount: 2
+        amount: 1
       - id: N14BoxCardboardMREBoxCFilled
       - id: N14Stimpak
       - id: N14RadXPill
@@ -118,7 +115,7 @@
       - id: ClothingBeltNCR
       - id: N14WeaponRifle556Service
       - id: Magazine556Rifle
-        amount: 3
+        amount: 4
       - id: N14WeaponPistol9mm
       - id: N14MagazinePistol9mm
         amount: 2
@@ -146,7 +143,7 @@
       - id: ClothingBeltNCR
       - id: N14WeaponRifle556Butchered
       - id: Magazine556Rifle
-        amount: 3
+        amount: 4
       - id: N14WeaponPistol9mm
       - id: N14MagazinePistol9mm
         amount: 2
@@ -159,10 +156,10 @@
       path: /Audio/Effects/unwrap.ogg
 
 - type: entity
-  name: soldier's scout kit
+  name: soldier's recon kit
   parent: KitBase
   id: KitNCR_Scout
-  description: A crate containing all an NCR trooper needs to patrol the wasteland.
+  description: A crate containing the tools used by the 1st Recon Battalion.
   components:
   - type: Sprite
     state: marksman
@@ -172,8 +169,9 @@
     items:
       - id: N14ClothingOuterNCRPouchedVestSnow
       - id: ClothingBeltNCR
-      - id: N14WeaponSniper44LeverCarbine
-      - id: MagazineBox44
+      - id: N14ClothingHeadHatNCRBeretRecon
+      - id: N14WeaponSniperHunting
+      - id: MagazineBox308
       - id: N14WeaponPistol9mm
       - id: N14MagazinePistol9mm
         amount: 2
@@ -203,7 +201,7 @@
       - id: MagazineBox12gauge
       - id: N14WeaponPistol9mm
       - id: N14MagazinePistol9mm
-        amount: 2
+        amount: 3
       - id: N14BoxCardboardMREBoxCFilled
       - id: N14Stimpak
       - id: N14RadXPill
@@ -245,10 +243,10 @@
 # NCRA Engineer Kit
 
 - type: entity
-  name: engineer's mechanic kit
+  name: engineer's construction kit
   parent: KitBase
   id: KitNCR_EngiMechanic
-  description: A crate containing all an NCR engineer needs to perform their job.
+  description: A crate containing all an NCR engineer needs to build defenses and repair structures.
   components:
   - type: Sprite
     state: rifleman
@@ -258,8 +256,8 @@
     items:
       - id: N14ClothingOuterNCRPouchedVestSnow
       - id: N14ClothingBeltUtilityFilled
-      - id: N14WeaponSMG9mm
-      - id: N14MagazineSMG9mm
+      - id: N14WeaponRifle556Butchered
+      - id: Magazine556Rifle
         amount: 3
       - id: N14WeaponPistol9mm
       - id: N14MagazinePistol9mm
@@ -276,10 +274,10 @@
       path: /Audio/Effects/unwrap.ogg
 
 - type: entity
-  name: engineer's demolition kit
+  name: engineer's sapper kit
   parent: KitBase
   id: KitNCR_EngiDemo
-  description: A crate containing all an NCR engineer needs to perform their job.
+  description: A crate containing all an NCR engineer needs to kick in doors.
   components:
   - type: Sprite
     state: pointman
@@ -288,15 +286,14 @@
   - type: SpawnItemsOnUse
     items:
       - id: N14ClothingOuterNCRPouchedVestSnow
-      - id: ClothingBeltNCR
-      - id: N14WeaponShotgun
+      - id: N14WeaponSMG9mm
+      - id: N14MagazineSMG9mm
+        amount: 3
+      - id: N14WeaponShotgunShort
       - id: MagazineBox12gauge
       - id: N14ToolboxMechanical
       - id: C4
       - id: N14ripper
-      - id: N14WeaponPistol9mm
-      - id: N14MagazinePistol9mm
-        amount: 2
       - id: N14BoxCardboardMREBoxCFilled
       - id: N14Stimpak
       - id: N14RadAwayBloodbag
@@ -337,7 +334,7 @@
 # NCRA Medic Kits
 
 - type: entity
-  name: medic's sugeon kit
+  name: medic's surgeon kit
   parent: KitBase
   id: KitNCR_MedSurgeon
   description: A crate containing all an NCR medic needs to perform their job.
@@ -351,12 +348,11 @@
       - id: N14ClothingOuterCoatLab
       - id: N14ClothingBeltMedicalFilled
       - id: N14ClothingHandsGlovesNitrile
+      - id: ClothingMaskSterile
       - id: N14ClothingHeadHatNCRBeretMedic
-      - id: N14WeaponSMG9mm
-      - id: N14MagazineSMG9mm
-        amount: 3
-      - id: N14WeaponPistol9mm
-      - id: N14MagazinePistol9mm
+      - id: ClothingBackpackDuffelSurgeryFilled
+      - id: N14WeaponPistol45Colt
+      - id: N14BaseMagazine45Pistol
         amount: 2
       - id: N14SuperStimpak
       - id: Brutepack
@@ -364,7 +360,6 @@
       - id: Bloodpack
       - id: N14Antidote
       - id: N14BoxCardboardMREBoxCFilled
-      - id: N14Stimpak
       - id: N14RadAwayBloodbag
       - id: N14CleanGauze10
         amount: 2
@@ -391,9 +386,6 @@
       - id: N14WeaponSMG9mm
       - id: N14MagazineSMG9mm
         amount: 3
-      - id: N14WeaponPistol9mm
-      - id: N14MagazinePistol9mm
-        amount: 2
       - id: Brutepack
       - id: N14Ointment10
       - id: Bloodpack
@@ -420,15 +412,16 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterNCRPouchedVestWoods
-      - id: N14ClothingBeltMedicalFilled
+      - id: N14ClothingOuterNCRPouchedVestSnow
+      - id: ClothingBeltNCR
       - id: N14ClothingHeadHatNCRHelmetMetalMedic
-      - id: N14WeaponShotgun
-      - id: MagazineBox12gauge
+      - id: N14WeaponRifle556Service
+      - id: Magazine556Rifle
+        amount: 4
       - id: N14WeaponPistol9mm
       - id: N14MagazinePistol9mm
         amount: 2
-      - id: N14ChemicalSyringeAntidote
+      - id: N14MedkitCombatFilled
       - id: N14BoxCardboardMREBoxCFilled
       - id: N14Stimpak
         amount: 2
@@ -455,8 +448,6 @@
     items:
       - id: N14ClothingOuterNCRPouchedVestSnow
       - id: ClothingBeltNCR
-      - id: N14ClothingHeadHatNCRHelmetMetalWoods
-      - id: N14ClothingNeckCloakNCRWoods
       - id: N14WeaponLMG
       - id: LMGMagazine556Rifle
         amount: 3
@@ -485,8 +476,6 @@
     items:
       - id: N14ClothingOuterNCRPouchedVestWoods
       - id: ClothingBeltNCR
-      - id: N14ClothingHeadHatNCRHelmetMetalWoods
-      - id: N14ClothingNeckCloakNCRSnow
       - id: N14WeaponRifleGrenade
       - id: 40mmGrenadeFrag
         amount: 4
@@ -517,7 +506,6 @@
       - id: N14ClothingOuterNCRPouchedVestWoods
       - id: ClothingBeltNCR
       - id: N14ClothingHeadHatNCRBeretRecon
-      - id: N14ClothingNeckCloakNCRSnow
       - id: N14WeaponSniper50NCRRifle
       - id: MagazineBox50
       - id: N14WeaponPistol45Colt
@@ -576,11 +564,10 @@
   - type: SpawnItemsOnUse
     items:
       - id: N14ClothingOuterNCRPouchedVestWoods
-      - id: N14ClothingHeadHatNCRHelmetMetalSnow
       - id: ClothingBeltNCR
       - id: N14WeaponRifle556Carbine
       - id: LongMagazine556Rifle
-        amount: 3
+        amount: 4
       - id: N14WeaponPistol9mm
       - id: N14MagazinePistol9mm
         amount: 2
@@ -605,7 +592,6 @@
   - type: SpawnItemsOnUse
     items:
       - id: N14ClothingOuterNCRPouchedVestWoods
-      - id: N14ClothingHeadHatNCRHelmetMetalSnow
       - id: ClothingBeltNCR
       - id: N14WeaponLMGAutoRifle
       - id: Magazine308Rifle
@@ -663,7 +649,6 @@
   - type: SpawnItemsOnUse
     items:
       - id: N14ClothingOuterNCRPouchedVestWoods
-      - id: N14ClothingHeadHatNCRHelmetMetalWoods
       - id: ClothingBeltNCR
       - id: N14WeaponShotgunAuto
       - id: N14MagazineShotgun12

--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ncr.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ncr.yml
@@ -218,6 +218,8 @@
       jobs:
         - NCRSoldier
         - NCRSGT
+        - NCREngineer
+        - NCRWS
   items:
     - N14ClothingHeadHatNCRHelmetMetalSnow
 
@@ -231,6 +233,8 @@
       jobs:
         - NCRSoldier
         - NCRSGT
+        - NCREngineer
+        - NCRWS
   items:
     - N14ClothingHeadHatNCRHelmetMetalWoods
 
@@ -272,6 +276,8 @@
       jobs:
         - NCRSoldier
         - NCRSGT
+        - NCREngineer
+        - NCRWS
   items:
     - N14ClothingHeadHatNCRHelmetMetalGhillie
     
@@ -309,6 +315,8 @@
       jobs:
         - NCRSoldier
         - NCRSGT
+        - NCREngineer
+        - NCRWS
   items:
     - N14ClothingHeadHatWinterBoonie
 
@@ -322,6 +330,8 @@
       jobs:
         - NCRSoldier
         - NCRSGT
+        - NCREngineer
+        - NCRWS
   items:
     - N14ClothingHeadHatWoodBoonie
 
@@ -335,6 +345,8 @@
       jobs:
         - NCRSoldier
         - NCRSGT
+        - NCREngineer
+        - NCRWS
   items:
     - N14ClothingNeckCloakNCR
 
@@ -348,6 +360,8 @@
       jobs:
         - NCRSoldier
         - NCRSGT
+        - NCREngineer
+        - NCRWS
   items:
     - N14ClothingNeckCloakGhillie
 
@@ -361,6 +375,8 @@
       jobs:
         - NCRSoldier
         - NCRSGT
+        - NCREngineer
+        - NCRWS
   items:
     - N14ClothingNeckCloakNCRSnow
 
@@ -374,6 +390,8 @@
       jobs:
         - NCRSoldier
         - NCRSGT
+        - NCREngineer
+        - NCRWS
   items:
     - N14ClothingNeckCloakNCRWoods
 
@@ -387,5 +405,7 @@
       jobs:
         - NCRSoldier
         - NCRSGT
+        - NCREngineer
+        - NCRWS
   items:
     - N14ClothingMaskBrownBalaclava


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
I DID SOME FUCKING COOL SHIT:
- With the exception of the medic, all NCR Roles no longer spawn with helmets by default, and helmets have been removed from kits.
- All NCR Roles now have access to Pato's badass helmets and coats.
- NCR Cadet Kits updated to be slightly worse than normal NCR Soldier Kits
- NCR Soldier Recon Kit updated to have lore accurate hunting rifle instead of carbine
- NCR Medic kits updated for more diversity
- NCR Engineer kits updated for more diversity
- NCR WS Kits had helmets and capes removed
- NCR Sgts had helmets removed