### PR TITLE
Fix flare target serialization

### DIFF
--- a/Content.Server/_N14/Support/ArtilleryStrikeSystem.cs
+++ b/Content.Server/_N14/Support/ArtilleryStrikeSystem.cs
@@ -12,16 +12,24 @@ public sealed class ArtilleryStrikeSystem : SharedArtilleryStrikeSystem
 {
     [Dependency] private readonly ExplosionSystem _explosions = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     public override void Initialize()
     {
         base.Initialize();
         SubscribeLocalEvent<ArtilleryStrikeComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<ArtilleryStrikeComponent, MapInitEvent>(OnMapInit);
     }
 
     private void OnStartup(EntityUid uid, ArtilleryStrikeComponent component, ComponentStartup args)
     {
         component.StartTime = _timing.CurTime;
+    }
+
+    private void OnMapInit(EntityUid uid, ArtilleryStrikeComponent component, ref MapInitEvent args)
+    {
+        if (component.Target.MapId == MapId.Nullspace)
+            component.Target = _transform.GetMapCoordinates(uid);
     }
 
     public override void Update(float frameTime)

--- a/Content.Server/_N14/Support/VertibirdSupportSystem.cs
+++ b/Content.Server/_N14/Support/VertibirdSupportSystem.cs
@@ -23,12 +23,19 @@ public sealed class VertibirdSupportSystem : SharedVertibirdSupportSystem
     {
         base.Initialize();
         SubscribeLocalEvent<VertibirdSupportComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<VertibirdSupportComponent, MapInitEvent>(OnMapInit);
     }
 
     private void OnStartup(EntityUid uid, VertibirdSupportComponent component, ComponentStartup args)
     {
         component.StartTime = _timing.CurTime;
         component.ShotsFired = 0;
+    }
+
+    private void OnMapInit(EntityUid uid, VertibirdSupportComponent component, ref MapInitEvent args)
+    {
+        if (component.Target.MapId == MapId.Nullspace)
+            component.Target = _transform.GetMapCoordinates(uid);
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/_N14/Support/ArtilleryStrikeComponent.cs
+++ b/Content.Shared/_N14/Support/ArtilleryStrikeComponent.cs
@@ -13,7 +13,7 @@ namespace Content.Shared._N14.Support;
 public sealed partial class ArtilleryStrikeComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public MapCoordinates Target;
+    public MapCoordinates Target = MapCoordinates.Nullspace;
 
     [DataField, AutoNetworkedField]
     public TimeSpan Delay = TimeSpan.FromSeconds(5);

--- a/Content.Shared/_N14/Support/VertibirdSupportComponent.cs
+++ b/Content.Shared/_N14/Support/VertibirdSupportComponent.cs
@@ -14,7 +14,7 @@ namespace Content.Shared._N14.Support;
 public sealed partial class VertibirdSupportComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public MapCoordinates Target;
+    public MapCoordinates Target = MapCoordinates.Nullspace;
 
     [DataField, AutoNetworkedField]
     public TimeSpan Delay = TimeSpan.FromSeconds(5);


### PR DESCRIPTION
## Summary
- default artillery and vertibird flare targets to `MapCoordinates.Nullspace`
- set flare target after map initialization if still unset

## Testing
- `Scripts/sh/runTests.sh` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6872b48517c8832583599a2960d89d23