### PR TITLE
Add N14 mob docs and feral polymorph fix

### DIFF
--- a/Content.Server/Inventory/ServerInventorySystem.cs
+++ b/Content.Server/Inventory/ServerInventorySystem.cs
@@ -23,7 +23,7 @@ namespace Content.Server.Inventory
             }
         }
 
-        public void TransferEntityInventories(Entity<InventoryComponent?> source, Entity<InventoryComponent?> target)
+        public void TransferEntityInventories(Entity<InventoryComponent?> source, Entity<InventoryComponent?> target, bool forceEquip = true)
         {
             if (!Resolve(source.Owner, ref source.Comp) || !Resolve(target.Owner, ref target.Comp))
                 return;
@@ -32,7 +32,7 @@ namespace Content.Server.Inventory
             while (enumerator.NextItem(out var item, out var slot))
             {
                 if (TryUnequip(source, slot.Name, true, true, inventory: source.Comp))
-                    TryEquip(target, item, slot.Name , true, true, inventory: target.Comp);
+                    TryEquip(target, item, slot.Name, true, forceEquip, inventory: target.Comp);
             }
         }
     }

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -240,7 +240,7 @@ public sealed partial class PolymorphSystem : EntitySystem
 
         if (configuration.Inventory == PolymorphInventoryChange.Transfer)
         {
-            _inventory.TransferEntityInventories(uid, child);
+            _inventory.TransferEntityInventories(uid, child, configuration.ForceEquip);
             foreach (var hand in _hands.EnumerateHeld(uid))
             {
                 _hands.TryDrop(uid, hand, checkActionBlocker: false);
@@ -316,7 +316,7 @@ public sealed partial class PolymorphSystem : EntitySystem
 
         if (component.Configuration.Inventory == PolymorphInventoryChange.Transfer)
         {
-            _inventory.TransferEntityInventories(uid, parent);
+            _inventory.TransferEntityInventories(uid, parent, component.Configuration.ForceEquip);
             foreach (var held in _hands.EnumerateHeld(uid))
             {
                 _hands.TryDrop(uid, held);

--- a/Content.Shared/Polymorph/PolymorphPrototype.cs
+++ b/Content.Shared/Polymorph/PolymorphPrototype.cs
@@ -85,6 +85,14 @@ public sealed partial record PolymorphConfiguration
     public PolymorphInventoryChange Inventory = PolymorphInventoryChange.None;
 
     /// <summary>
+    /// If true, items transferred by the polymorph will be force-equipped even if
+    /// they do not fit the new body's inventory whitelist. If false, incompatible
+    /// items will be dropped on the ground instead of being equipped.
+    /// </summary>
+    [DataField(serverOnly: true)]
+    public bool ForceEquip = true;
+
+    /// <summary>
     /// Whether or not the polymorph reverts when the entity goes into crit.
     /// </summary>
     [DataField(serverOnly: true)]

--- a/Resources/Prototypes/Polymorphs/ghoul.yml
+++ b/Resources/Prototypes/Polymorphs/ghoul.yml
@@ -4,6 +4,7 @@
     entity: N14MobGhoulFeral
     forced: true
     inventory: Transfer
+    forceEquip: false
     transferName: true
     transferDamage: true
     allowRepeatedMorphs: false

--- a/Resources/Prototypes/_Nuclear14/Guidebooks/mobs.yml
+++ b/Resources/Prototypes/_Nuclear14/Guidebooks/mobs.yml
@@ -1,0 +1,35 @@
+- type: guideEntry
+  id: Mobs
+  name: guide-entry-mobs
+  text: "/ServerInfo/_Nuclear14/Guidebooks/Mobs/index.xml"
+  children:
+  - MobsAnimals
+  - MobsInsects
+  - MobsMutants
+  - MobsRobots
+  - MobsSpecies
+
+- type: guideEntry
+  id: MobsAnimals
+  name: guide-entry-mobs-animals
+  text: "/ServerInfo/_Nuclear14/Guidebooks/Mobs/Animals.xml"
+
+- type: guideEntry
+  id: MobsInsects
+  name: guide-entry-mobs-insects
+  text: "/ServerInfo/_Nuclear14/Guidebooks/Mobs/Insects.xml"
+
+- type: guideEntry
+  id: MobsMutants
+  name: guide-entry-mobs-mutants
+  text: "/ServerInfo/_Nuclear14/Guidebooks/Mobs/Mutants.xml"
+
+- type: guideEntry
+  id: MobsRobots
+  name: guide-entry-mobs-robots
+  text: "/ServerInfo/_Nuclear14/Guidebooks/Mobs/Robots.xml"
+
+- type: guideEntry
+  id: MobsSpecies
+  name: guide-entry-mobs-species
+  text: "/ServerInfo/_Nuclear14/Guidebooks/Mobs/Species.xml"

--- a/Resources/Prototypes/_Nuclear14/Guidebooks/nuclear14.yml
+++ b/Resources/Prototypes/_Nuclear14/Guidebooks/nuclear14.yml
@@ -6,3 +6,4 @@
   - N14Crafting
   - Factions
   - WeaponsAmmo
+  - Mobs

--- a/Resources/ServerInfo/_Nuclear14/Guidebooks/Crafting/Materials.xml
+++ b/Resources/ServerInfo/_Nuclear14/Guidebooks/Crafting/Materials.xml
@@ -8,9 +8,10 @@ Water is a valuable resource in Nuclear14. You'll often find dirty or irradiated
   <GuideReagentEmbed Reagent="Water"/>
   <GuideReagentEmbed Reagent="WaterDirty"/>
   <GuideReagentEmbed Reagent="WaterIrradiated"/>
-
-Radscorpion Tails can be butchered from Radscorpions with a knife and are used to produce antidote.
+Filtering dirty water with charcoal creates <GuideReagentEmbed Reagent="WaterFiltered"/>. Heat this to near boiling to obtain clean <GuideReagentEmbed Reagent="Water"/>. Boiling <GuideReagentEmbed Reagent="WaterSalt"/> yields <GuideReagentEmbed Reagent="TableSalt"/>.
+Radscorpion Tails can be butchered from Radscorpions with a knife and are used to produce <GuideReagentEmbed Reagent="Antidote"/>.
 <GuideEntityEmbed Entity="N14MaterialRadscorpionTail"/>
+Fire Ants can provide <GuideEntityEmbed Entity="N14FoodFireantNectar"/> which contains <GuideReagentEmbed Reagent="N14FireAntNectar"/> for teas.
 
 Brahmin Hide, hides and chitins are butchered off their respective animals.
 <GuideEntityEmbed Entity="N14MaterialBrahminHide"/>
@@ -70,3 +71,4 @@ Plastic can be obtained by melting down pre-war scrap made of plastic using a we
 Mr Handy fuel can be found by scavenging the Wasteland and is a handy source of fuel for welders and generators.
 <GuideEntityEmbed Entity="N14FuelTankHandy"/>
 </Document>
+

--- a/Resources/ServerInfo/_Nuclear14/Guidebooks/Mobs/Animals.xml
+++ b/Resources/ServerInfo/_Nuclear14/Guidebooks/Mobs/Animals.xml
@@ -1,0 +1,12 @@
+<Document>
+# Animals
+
+The wastes contain both ordinary wildlife and smaller mutated critters.
+
+- **Molerats & Pigrats**: Burrowing pests that swarm prey. Provide small amounts of meat when butchered.
+- **Feral Dogs**: Packs of wild dogs that bite for 4 damage. Hostile to most factions.
+- **Chickens, Rabbits and Iguanas**: Harmless food sources often kept by settlers.
+- **Brahmin**: See the Mutants page for details on these two-headed cattle.
+
+While many animals can be hunted or even tamed, be alert for disease or radiation carried by the more unfortunate specimens.
+</Document>

--- a/Resources/ServerInfo/_Nuclear14/Guidebooks/Mobs/Insects.xml
+++ b/Resources/ServerInfo/_Nuclear14/Guidebooks/Mobs/Insects.xml
@@ -1,0 +1,24 @@
+<Document>
+# Insects
+
+Nuclear fallout has led to oversized and aggressive insects. Most attack on sight.
+
+## Bloatfly
+Slow and bloated flies that fire larvae from range. Butchering yields insect meat.
+
+## Giant Ants
+These mutated ants swarm targets with biting attacks for about 4 damage each.
+
+## Giant Fire Ants
+Fiery ants that deal about 5 brute damage and apply fire toxin. Butchering them drops chitin, meat and <GuideEntityEmbed Entity="N14FoodFireantNectar"/> used to make <GuideReagentEmbed Reagent="N14FireAntNectar"/>.
+
+## Radroaches
+Large cockroaches found in ruins. Weak individually but often numerous.
+
+## Radscorpions
+Venomous predators dealing about 2 slash and 8 piercing damage plus poison. Butchering them yields chitin, meat and <GuideEntityEmbed Entity="N14MaterialRadscorpionTail"/> which is processed into <GuideReagentEmbed Reagent="Antidote"/>.
+
+## Cazadors
+Fast flying insects delivering potent poison stings.
+</Document>
+

--- a/Resources/ServerInfo/_Nuclear14/Guidebooks/Mobs/Mutants.xml
+++ b/Resources/ServerInfo/_Nuclear14/Guidebooks/Mobs/Mutants.xml
@@ -1,0 +1,12 @@
+<Document>
+# Mutants
+
+Radiation has twisted many creatures into dangerous mutants. Some remain animals while others are barely recognizable.
+
+- **Yaoguai**: Massive mutated bears that slash for heavy damage. Extremely hostile and tough, dropping hides and meat.
+- **Radstags**: Two-headed deer often found grazing. Usually docile unless threatened. Provide meat and hides.
+- **Radhogs**: Hulking boars with thick skin that ram targets. Drop mutant meat when butchered.
+- **Brahmin**: Mutated cattle valued for milk and meat. Generally friendly but will defend themselves if attacked.
+
+Treat these beasts with caution—their attacks often deal 5 to 10 damage and some may carry radiation.
+</Document>

--- a/Resources/ServerInfo/_Nuclear14/Guidebooks/Mobs/Robots.xml
+++ b/Resources/ServerInfo/_Nuclear14/Guidebooks/Mobs/Robots.xml
@@ -1,0 +1,13 @@
+<Document>
+# Robots
+
+Pre-war robots still wander the wastes. Many were built for labor or defense and will attack intruders.
+
+## Protectron
+Slow but durable security robots armed with weak lasers or claws. Drops scrap electronics and sometimes energy cells when destroyed.
+
+## Mr Handy / Mr Gutsy
+Hovering utility robots equipped with saws, flamers or plasma guns depending on the model. Can fly over obstacles and attack with 6-8 burn damage.
+
+These machines generally consider all factions hostile unless specifically reprogrammed.
+</Document>

--- a/Resources/ServerInfo/_Nuclear14/Guidebooks/Mobs/Species.xml
+++ b/Resources/ServerInfo/_Nuclear14/Guidebooks/Mobs/Species.xml
@@ -1,0 +1,13 @@
+<Document>
+# Species
+
+<Box>
+  <GuideEntityEmbed Entity="MobHumanDummy" Caption="Human"/>
+  <GuideEntityEmbed Entity="N14MobGhoulDummy" Caption="Ghoul"/>
+  <GuideEntityEmbed Entity="N14MobGhoulGlowingDummy" Caption="Glowing Ghoul"/>
+</Box>
+
+Humans are the baseline species of the wastes. Severe radiation exposure gradually turns them into [g]ghouls[/g]. Ghouls regenerate from radiation instead of medicine and resist most poisons.
+
+If a ghoul continues absorbing rads they may mutate further into [i]glowing ghouls[/i] who emit radiation fields. Excessive buildup of rads or trauma can drive a ghoul [b]feral[/b], causing them to attack anyone on sight. During this transformation they keep their gear but anything no longer compatible is dropped.
+</Document>

--- a/Resources/ServerInfo/_Nuclear14/Guidebooks/Mobs/index.xml
+++ b/Resources/ServerInfo/_Nuclear14/Guidebooks/Mobs/index.xml
@@ -1,0 +1,11 @@
+<Document>
+# Mobs
+
+This section covers the creatures and hostile entities found in Nuclear 14. The following pages provide details on different categories:
+
+- [Animals](Animals.xml)
+- [Insects](Insects.xml)
+- [Mutants](Mutants.xml)
+- [Robots](Robots.xml)
+- [Species](Species.xml)
+</Document>


### PR DESCRIPTION
## Summary
- document Nuclear 14 mobs
- explain species differences and animals
- tweak polymorphs so feral ghouls drop incompatible items
- mention radscorpion tails and fire ant nectar in guides
- list water purification steps

:cl:
- tweak: Added new guidebook entries for various mobs, reagents and reactions.
- fix: Fixed feral ghouls dropping or deleting items when transforming.