### PR TITLE
Goodbye Snowy

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -1,6 +1,6 @@
 - type: gameMapPool
   id: DefaultMapPool
   maps:
-  #- Wave1
+  # - Wave1
   - Sunnyvale
-  - Snowyvale
+  # - Snowyvale


### PR DESCRIPTION
Quite simply removing Snowyvale from rotation because it's heavily outdated and currently we don't plan on bringing it back.
You served well, little guy, but it's time for you to go as we lack time to make sure you are maintained properly.
# o7

:cl:
- remove: Snowyvale map de-rotated.