### PR TITLE
Add SpriteWorldComponent

### DIFF
--- a/Content.Client/_N14/WorldSprite/SpriteWorldComponent.cs
+++ b/Content.Client/_N14/WorldSprite/SpriteWorldComponent.cs
@@ -1,0 +1,22 @@
+using Robust.Shared.GameObjects;
+
+namespace Content.Client._N14.WorldSprite;
+
+/// <summary>
+/// Changes the entity's sprite state when placed in the game world.
+/// </summary>
+[RegisterComponent]
+public sealed partial class SpriteWorldComponent : Component
+{
+    /// <summary>
+    /// State to use when the entity is placed in the world.
+    /// </summary>
+    [DataField("worldState")]
+    public string? WorldState;
+
+    /// <summary>
+    /// The sprite's original state captured on initialization.
+    /// </summary>
+    [ViewVariables]
+    public string? DefaultState;
+}

--- a/Content.Client/_N14/WorldSprite/SpriteWorldSystem.cs
+++ b/Content.Client/_N14/WorldSprite/SpriteWorldSystem.cs
@@ -1,0 +1,53 @@
+using Content.Shared.Throwing;
+using Robust.Client.GameObjects;
+using Robust.Shared.Map.Components;
+
+namespace Content.Client._N14.WorldSprite;
+
+public sealed class SpriteWorldSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SpriteWorldComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<SpriteWorldComponent, EntParentChangedMessage>(OnParentChanged);
+        SubscribeLocalEvent<SpriteWorldComponent, ThrownEvent>(OnThrown);
+    }
+
+    private void OnInit(EntityUid uid, SpriteWorldComponent component, ComponentInit args)
+    {
+        if (!TryComp(uid, out SpriteComponent? sprite))
+            return;
+
+        component.DefaultState = sprite.LayerGetState(0);
+        UpdateSprite(uid, component, sprite, Transform(uid).ParentUid);
+    }
+
+    private void OnParentChanged(EntityUid uid, SpriteWorldComponent component, ref EntParentChangedMessage args)
+    {
+        if (!TryComp(uid, out SpriteComponent? sprite))
+            return;
+
+        UpdateSprite(uid, component, sprite, args.NewParent);
+    }
+
+    private void OnThrown(EntityUid uid, SpriteWorldComponent component, ref ThrownEvent args)
+    {
+        if (!TryComp(uid, out SpriteComponent? sprite))
+            return;
+
+        UpdateSprite(uid, component, sprite, Transform(uid).ParentUid);
+    }
+
+    private void UpdateSprite(EntityUid uid, SpriteWorldComponent component, SpriteComponent sprite, EntityUid parent)
+    {
+        var inWorld = HasComp<MapComponent>(parent) || HasComp<MapGridComponent>(parent);
+        var state = inWorld && !string.IsNullOrEmpty(component.WorldState)
+            ? component.WorldState
+            : component.DefaultState;
+
+        if (state != null)
+            sprite.LayerSetState(0, state);
+    }
+}

--- a/Content.Server/Entry/IgnoredComponents.cs
+++ b/Content.Server/Entry/IgnoredComponents.cs
@@ -19,6 +19,7 @@ namespace Content.Server.Entry
             "InventorySlots",
             "LightFade",
             "HolidayRsiSwap",
+            "SpriteWorld",
             "OptionsVisualizer"
         };
     }

--- a/Resources/Prototypes/_N14/debug.yml
+++ b/Resources/Prototypes/_N14/debug.yml
@@ -1,0 +1,11 @@
+- type: entity
+  parent: BaseItem
+  id: N14DebugWorldSprite
+  name: debug copper bar
+  suffix: N14, DEBUG
+  components:
+  - type: Sprite
+    sprite: Objects/Materials/ingots.rsi
+    state: copper
+  - type: SpriteWorld
+    worldState: copper_2


### PR DESCRIPTION
## Summary
- port world sprite system into `_N14` folder structure
- make component change sprite state when entity is on the map
- add a simple debug entity to demonstrate the component
- ignore the component server-side

:cl:
- added: Added a world sprite system so now objects can appear smaller in the game world and higher resolution in inventory. This will need implementing on a per object basis over time.