### PR TITLE
Add missing CP14 shared components and prototypes

### DIFF
--- a/Content.Server/Temperature/Systems/TemperatureSystem.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.cs
@@ -415,16 +415,3 @@ public sealed class TemperatureSystem : EntitySystem
     }
 }
 
-public sealed class OnTemperatureChangeEvent : EntityEventArgs
-{
-    public float CurrentTemperature { get; }
-    public float LastTemperature { get; }
-    public float TemperatureDelta { get; }
-
-    public OnTemperatureChangeEvent(float current, float last, float delta)
-    {
-        CurrentTemperature = current;
-        LastTemperature = last;
-        TemperatureDelta = delta;
-    }
-}

--- a/Content.Server/_CP14/Temperature/CP14FlammableEntityHeaterComponent.cs
+++ b/Content.Server/_CP14/Temperature/CP14FlammableEntityHeaterComponent.cs
@@ -1,0 +1,13 @@
+using Content.Server.Temperature.Systems;
+
+namespace Content.Server._CP14.Temperature;
+
+/// <summary>
+/// Adds thermal energy from FlammableComponent to entities with <see cref="TemperatureComponent"/> placed on it.
+/// </summary>
+[RegisterComponent, Access(typeof(EntityHeaterSystem))]
+public sealed partial class CP14FlammableEntityHeaterComponent : Component
+{
+    [DataField]
+    public float DegreesPerStack = 300f;
+}

--- a/Content.Server/_CP14/Temperature/CP14FlammableSolutionHeaterComponent.cs
+++ b/Content.Server/_CP14/Temperature/CP14FlammableSolutionHeaterComponent.cs
@@ -1,0 +1,11 @@
+namespace Content.Server._CP14.Temperature;
+
+/// <summary>
+/// allows you to heat the temperature of solutions depending on the number of stacks of fire
+/// </summary>
+[RegisterComponent, Access(typeof(CP14TemperatureSystem))]
+public sealed partial class CP14FlammableSolutionHeaterComponent : Component
+{
+    [DataField]
+    public float DegreesPerStack = 100f;
+}

--- a/Content.Server/_CP14/Workbench/CP14WorkbenchComponent.cs
+++ b/Content.Server/_CP14/Workbench/CP14WorkbenchComponent.cs
@@ -1,0 +1,46 @@
+/*
+ * This file is sublicensed under MIT License
+ * https://github.com/space-wizards/space-station-14/blob/master/LICENSE.TXT
+ */
+
+using Content.Shared._CP14.Workbench.Prototypes;
+using Content.Shared.Tag;
+using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._CP14.Workbench;
+
+/// <summary>
+/// This entity can be used to craft other objects through the interface
+/// </summary>
+[RegisterComponent]
+[Access(typeof(CP14WorkbenchSystem))]
+public sealed partial class CP14WorkbenchComponent : Component
+{
+    /// <summary>
+    /// Crafting speed modifier on this workbench.
+    /// </summary>
+    [DataField]
+    public float CraftSpeed = 1f;
+
+    [DataField]
+    public float WorkbenchRadius = 1.5f;
+
+    /// <summary>
+    /// List of recipes available for crafting on this type of workbench
+    /// </summary>
+    [DataField]
+    public List<ProtoId<CP14WorkbenchRecipePrototype>> Recipes = new();
+
+    /// <summary>
+    /// Auto recipe list fill based on tags
+    /// </summary>
+    [DataField]
+    public List<ProtoId<TagPrototype>> RecipeTags = new();
+
+    /// <summary>
+    /// Played during crafting. Can be overwritten by the crafting sound of a specific recipe.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier CraftSound = new SoundCollectionSpecifier("CP14Hammering");
+}

--- a/Content.Server/_CP14/Workbench/CP14WorkbenchSystem.UI.cs
+++ b/Content.Server/_CP14/Workbench/CP14WorkbenchSystem.UI.cs
@@ -26,10 +26,10 @@ public sealed partial class CP14WorkbenchSystem
 
     private void UpdateUIRecipes(Entity<CP14WorkbenchComponent> entity)
     {
-        if (!TryComp<ItemPlacerComponent>(entity.Owner, out var placer))
-            return;
+        var getResource = new CP14WorkbenchGetResourcesEvent();
+        RaiseLocalEvent(entity, getResource);
 
-        var placedEntities = placer.PlacedEntities;
+        var resources = getResource.Resources;
 
         var recipes = new List<CP14WorkbenchUiRecipesEntry>();
         foreach (var recipeId in entity.Comp.Recipes)
@@ -41,7 +41,7 @@ public sealed partial class CP14WorkbenchSystem
 
             foreach (var requirement in indexedRecipe.Requirements)
             {
-                if (!requirement.CheckRequirement(EntityManager, _proto, placedEntities))
+                if (!requirement.CheckRequirement(EntityManager, _proto, resources))
                 {
                     canCraft = false;
                     break;

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -394,5 +394,18 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         // networking whether a do-after has raised its events or not.
         return DoAfterStatus.Finished;
     }
+
+    public bool IsRunning(DoAfterId? id, DoAfterComponent? comp = null)
+    {
+        if (id == null)
+            return false;
+
+        return GetStatus(id.Value.Uid, id.Value.Index, comp) == DoAfterStatus.Running;
+    }
+
+    public bool IsRunning(EntityUid entity, ushort id, DoAfterComponent? comp = null)
+    {
+        return GetStatus(entity, id, comp) == DoAfterStatus.Running;
+    }
     #endregion
 }

--- a/Content.Shared/Nutrition/Components/FlavorProfileComponent.cs
+++ b/Content.Shared/Nutrition/Components/FlavorProfileComponent.cs
@@ -1,0 +1,24 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Nutrition.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class FlavorProfileComponent : Component
+{
+    /// <summary>
+    ///     Localized string containing the base flavor of this entity.
+    /// </summary>
+    [DataField]
+    public HashSet<string> Flavors { get; private set; } = new();
+
+    /// <summary>
+    ///     Reagent IDs to ignore when processing this flavor profile. Defaults to nutriment.
+    /// </summary>
+    [DataField]
+    public HashSet<string> IgnoreReagents { get; private set; } = new()
+    {
+        "Nutriment",
+        "Vitamin",
+        "Protein",
+    };
+}

--- a/Content.Shared/Nutrition/Components/FoodComponent.cs
+++ b/Content.Shared/Nutrition/Components/FoodComponent.cs
@@ -1,0 +1,77 @@
+using Content.Shared._CP14.Cooking;
+using Content.Shared.Body.Components;
+using Content.Shared.FixedPoint;
+using Content.Shared.Nutrition.EntitySystems;
+using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Nutrition.Components;
+
+[RegisterComponent, Access(typeof(CP14SharedCookingSystem))]
+public sealed partial class FoodComponent : Component
+{
+    [DataField]
+    public string Solution = "food";
+
+    [DataField]
+    public SoundSpecifier UseSound = new SoundCollectionSpecifier("eating");
+
+    [DataField]
+    public List<EntProtoId> Trash = new();
+
+    [DataField]
+    public FixedPoint2? TransferAmount = FixedPoint2.New(5);
+
+    /// <summary>
+    /// Acceptable utensil to use
+    /// </summary>
+    [DataField]
+    public UtensilType Utensil = UtensilType.Fork; //There are more "solid" than "liquid" food
+
+    /// <summary>
+    /// Is utensil required to eat this food
+    /// </summary>
+    [DataField]
+    public bool UtensilRequired;
+
+    /// <summary>
+    ///     If this is set to true, food can only be eaten if you have a stomach with a
+    ///     <see cref="StomachComponent.SpecialDigestible"/> that includes this entity in its whitelist,
+    ///     rather than just being digestible by anything that can eat food.
+    ///     Whitelist the food component to allow eating of normal food.
+    /// </summary>
+    [DataField]
+    public bool RequiresSpecialDigestion;
+
+    /// <summary>
+    ///     Stomachs required to digest this entity.
+    ///     Used to simulate 'ruminant' digestive systems (which can digest grass)
+    /// </summary>
+    [DataField]
+    public int RequiredStomachs = 1;
+
+    /// <summary>
+    /// The localization identifier for the eat message. Needs a "food" entity argument passed to it.
+    /// </summary>
+    [DataField]
+    public LocId EatMessage = "food-nom";
+
+    /// <summary>
+    /// How long it takes to eat the food personally.
+    /// </summary>
+    [DataField]
+    public float Delay = 1;
+
+    /// <summary>
+    ///     This is how many seconds it takes to force feed someone this food.
+    ///     Should probably be smaller for small items like pills.
+    /// </summary>
+    [DataField]
+    public float ForceFeedDelay = 3;
+
+    /// <summary>
+    /// For mobs that are food, requires killing them before eating.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool RequireDead = true;
+}

--- a/Content.Shared/Temperature/TemperatureEvents.cs
+++ b/Content.Shared/Temperature/TemperatureEvents.cs
@@ -13,3 +13,18 @@ public sealed class ModifyChangedTemperatureEvent : EntityEventArgs, IInventoryR
         TemperatureDelta = temperature;
     }
 }
+
+public sealed class OnTemperatureChangeEvent : EntityEventArgs
+{
+    public readonly float CurrentTemperature;
+    public readonly float LastTemperature;
+    public readonly float TemperatureDelta;
+
+    public OnTemperatureChangeEvent(float current, float last, float delta)
+    {
+        CurrentTemperature = current;
+        LastTemperature = last;
+        TemperatureDelta = delta;
+    }
+}
+

--- a/Content.Shared/_CP14/Skill/Effects/CP14SkillEffect.cs
+++ b/Content.Shared/_CP14/Skill/Effects/CP14SkillEffect.cs
@@ -1,0 +1,18 @@
+using Content.Shared._CP14.Skill.Prototypes;
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._CP14.Skill.Effects;
+
+[ImplicitDataDefinitionForInheritors]
+[MeansImplicitUse]
+public abstract partial class CP14SkillEffect
+{
+    public abstract void AddSkill(IEntityManager entManager, EntityUid target);
+
+    public abstract void RemoveSkill(IEntityManager entManager, EntityUid target);
+
+    public abstract string? GetName(IEntityManager entMagager, IPrototypeManager protoManager);
+
+    public abstract string? GetDescription(IEntityManager entMagager, IPrototypeManager protoManager, ProtoId<CP14SkillPrototype> skill);
+}

--- a/Content.Shared/_CP14/Skill/Prototypes/CP14SkillPrototype.cs
+++ b/Content.Shared/_CP14/Skill/Prototypes/CP14SkillPrototype.cs
@@ -1,0 +1,65 @@
+using System.Numerics;
+using Content.Shared._CP14.Skill.Effects;
+using Content.Shared._CP14.Skill.Restrictions;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._CP14.Skill.Prototypes;
+
+/// <summary>
+/// A skill that can be learned by the player. Skills are grouped into trees, and each skill has a cost to learn, prerequisites, and an effect.
+/// </summary>
+[Prototype("cp14Skill")]
+public sealed partial class CP14SkillPrototype : IPrototype
+{
+    [IdDataField] public string ID { get; } = default!;
+
+    /// <summary>
+    /// Skill Title. If you leave null, the name will try to generate from Effect.GetName()
+    /// </summary>
+    [DataField]
+    public LocId? Name = null;
+
+    /// <summary>
+    /// Skill Description. If you leave null, the description will try to generate from Effect.GetDescription()
+    /// </summary>
+    [DataField]
+    public LocId? Desc = null;
+
+    /// <summary>
+    /// The tree this skill belongs to. This is used to group skills together in the UI.
+    /// </summary>
+    [DataField(required: true)]
+    public ProtoId<CP14SkillTreePrototype> Tree = default!;
+
+    /// <summary>
+    ///  The cost to learn this skill. This is used to determine how many progress points are needed to learn the skill.
+    /// </summary>
+    [DataField]
+    public float LearnCost = 1f;
+
+    /// <summary>
+    ///  Skill UI position. This is used to determine where the skill will be displayed in the skill tree UI.
+    /// </summary>
+    [DataField(required: true)]
+    public Vector2 SkillUiPosition = default!;
+
+    /// <summary>
+    ///  Icon for the skill. This is used to display the skill in the skill tree UI.
+    /// </summary>
+    [DataField(required: true)]
+    public SpriteSpecifier Icon = default!;
+
+    /// <summary>
+    ///  Skill effect. This is used to determine what happens when the player learns the skill. If you leave null, the skill will not have any effect.
+    ///  But the presence of the skill itself can affect some systems that check for the presence of certain skills.
+    /// </summary>
+    [DataField]
+    public List<CP14SkillEffect> Effects = new();
+
+    /// <summary>
+    /// Skill restriction. Limiters on learning. Any reason why a player cannot learn this skill.
+    /// </summary>
+    [DataField]
+    public List<CP14SkillRestriction> Restrictions = new();
+}

--- a/Content.Shared/_CP14/Skill/Prototypes/CP14SkillTreePrototype.cs
+++ b/Content.Shared/_CP14/Skill/Prototypes/CP14SkillTreePrototype.cs
@@ -1,0 +1,44 @@
+using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._CP14.Skill.Prototypes;
+
+/// <summary>
+/// A group of skills combined into one “branch”
+/// </summary>
+[Prototype("cp14SkillTree")]
+public sealed partial class CP14SkillTreePrototype : IPrototype
+{
+    [IdDataField] public string ID { get; } = default!;
+
+    [DataField(required: true)]
+    public LocId Name;
+
+    [DataField]
+    public SpriteSpecifier? FrameIcon;
+
+    [DataField]
+    public SpriteSpecifier? HoveredIcon;
+
+    [DataField]
+    public SpriteSpecifier? SelectedIcon;
+
+    [DataField]
+    public SpriteSpecifier? LearnedIcon;
+
+    [DataField]
+    public SpriteSpecifier? AvailableIcon;
+
+    [DataField]
+    public string Parallax = "AspidParallax";
+
+    [DataField]
+    public LocId? Desc;
+
+    [DataField]
+    public Color Color;
+
+    [DataField]
+    public SoundSpecifier LearnSound = new SoundCollectionSpecifier("CP14LearnSkill");
+}

--- a/Content.Shared/_CP14/Skill/Restrictions/CP14SkillRestriction.cs
+++ b/Content.Shared/_CP14/Skill/Restrictions/CP14SkillRestriction.cs
@@ -1,0 +1,14 @@
+using Content.Shared._CP14.Skill.Prototypes;
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._CP14.Skill.Restrictions;
+
+[ImplicitDataDefinitionForInheritors]
+[MeansImplicitUse]
+public abstract partial class CP14SkillRestriction
+{
+    public abstract bool Check(IEntityManager entManager, EntityUid target, CP14SkillPrototype skill);
+
+    public abstract string GetDescription(IEntityManager entManager, IPrototypeManager protoManager);
+}

--- a/Content.Shared/_CP14/Workbench/CP14SharedWorkbenchSystem.cs
+++ b/Content.Shared/_CP14/Workbench/CP14SharedWorkbenchSystem.cs
@@ -1,0 +1,24 @@
+/*
+ * This file is sublicensed under MIT License
+ * https://github.com/space-wizards/space-station-14/blob/master/LICENSE.TXT
+ */
+
+using Content.Shared._CP14.Workbench.Prototypes;
+using Content.Shared.DoAfter;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._CP14.Workbench;
+
+public abstract class CP14SharedWorkbenchSystem : EntitySystem
+{
+}
+
+[Serializable, NetSerializable]
+public sealed partial class CP14CraftDoAfterEvent : DoAfterEvent
+{
+    [DataField(required: true)]
+    public ProtoId<CP14WorkbenchRecipePrototype> Recipe = default!;
+
+    public override DoAfterEvent Clone() => this;
+}

--- a/Content.Shared/_CP14/Workbench/Prototypes/CP14WorkbenchRecipeCategoryPrototype.cs
+++ b/Content.Shared/_CP14/Workbench/Prototypes/CP14WorkbenchRecipeCategoryPrototype.cs
@@ -1,0 +1,18 @@
+/*
+ * This file is sublicensed under MIT License
+ * https://github.com/space-wizards/space-station-14/blob/master/LICENSE.TXT
+ */
+
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._CP14.Workbench.Prototypes;
+
+[Prototype("CP14RecipeCategory")]
+public sealed class CP14WorkbenchRecipeCategoryPrototype : IPrototype
+{
+    [IdDataField]
+    public string ID { get; private set; } = string.Empty;
+
+    [DataField(required: true)]
+    public LocId Name;
+}

--- a/Content.Shared/_CP14/Workbench/WorkbenchCraftRequirement.cs
+++ b/Content.Shared/_CP14/Workbench/WorkbenchCraftRequirement.cs
@@ -17,21 +17,21 @@ public abstract partial class CP14WorkbenchCraftRequirement
     /// Here a check is made that the recipe as a whole can be fulfilled at the current moment. Do not add anything that affects gameplay here, and only perform checks here.
     /// </summary>
     /// <returns></returns>
-    public abstract bool CheckRequirement(EntityManager entManager,
+    public abstract bool CheckRequirement(IEntityManager entManager,
         IPrototypeManager protoManager,
         HashSet<EntityUid> placedEntities);
 
     /// <summary>
     /// An event that is triggered after crafting. This is the place to put important things like removing items, spending stacks or other things.
     /// </summary>
-    public virtual void PostCraft(EntityManager entManager,
+    public virtual void PostCraft(IEntityManager entManager,
         IPrototypeManager protoManager,
         HashSet<EntityUid> placedEntities)
     {
 
     }
 
-    public virtual double GetPrice(EntityManager entManager,
+    public virtual double GetPrice(IEntityManager entManager,
         IPrototypeManager protoManager)
     {
         return 0;


### PR DESCRIPTION
## Summary
- sync temperature events with upstream
- adjust workbench craft requirement API
- include skill prototypes and workbench recipe categories
- add missing workbench and temperature components
- extend DoAfterSystem with `IsRunning`
- add basic food and flavor components for cooking systems
- remove duplicate `OnTemperatureChangeEvent`

## Testing
- `dotnet build SpaceStation14.sln -c Release` *(fails: `FoodSystem` ambiguous reference, missing client resources)*

------
https://chatgpt.com/codex/tasks/task_e_68791c6f45788325bbd71e2170d40d43