### PR TITLE
Lobbyscreen Correction

### DIFF
--- a/Resources/Prototypes/_Nuclear14/lobbyscreens.yml
+++ b/Resources/Prototypes/_Nuclear14/lobbyscreens.yml
@@ -1,3 +1,5 @@
 - type: lobbyBackground
   id: N14Vault
   background: /Textures/_Nuclear14/LobbyScreens/n14vault.png
+  name: N14 Vault
+  artist: v7v7v7v7v7v7v7v7v7v7v7v7v7v7v7v / Luck


### PR DESCRIPTION
We got a feature to display a lobby art's title and artist's name, but didn't utalise it until now. This pissed me off the other day so from now on we are crediting the benefactor of the background screen in the menu.

:cl:
- fix: Credited the lobby background artist.