### PR TITLE
Z's Badly Bored - Part 4

### DIFF
--- a/Content.Server/_N14/Support/ArtilleryStrikeSystem.cs
+++ b/Content.Server/_N14/Support/ArtilleryStrikeSystem.cs
@@ -82,6 +82,7 @@ namespace Content.Server._N14.Support
                     comp.Intensity,
                     comp.Slope,
                     comp.MaxIntensity,
+                    comp.TileBreakScale,
                     canCreateVacuum: false);
                 QueueDel(uid);
             }
@@ -94,6 +95,7 @@ namespace Content.Server._N14.Support
             float intensity = 50f,
             float slope = 3f,
             float maxIntensity = 10f
+            float tileBreakScale = 1f,
         )
         {
             var ent = Spawn(null, target);
@@ -104,6 +106,7 @@ namespace Content.Server._N14.Support
             comp.Intensity = intensity;
             comp.Slope = slope;
             comp.MaxIntensity = maxIntensity;
+            comp.TileBreakScale = tileBreakScale;
             // StartTime will be initialized when the flare activates.
             comp.StartTime = TimeSpan.Zero;
             Dirty(ent, comp);

--- a/Content.Server/_N14/Support/ArtilleryStrikeSystem.cs
+++ b/Content.Server/_N14/Support/ArtilleryStrikeSystem.cs
@@ -95,7 +95,7 @@ namespace Content.Server._N14.Support
             float intensity = 50f,
             float slope = 3f,
             float maxIntensity = 10f,
-            float tileBreakScale = 1f,
+            float tileBreakScale = 1f
         )
         {
             var ent = Spawn(null, target);

--- a/Content.Server/_N14/Support/ArtilleryStrikeSystem.cs
+++ b/Content.Server/_N14/Support/ArtilleryStrikeSystem.cs
@@ -94,7 +94,7 @@ namespace Content.Server._N14.Support
             string type = "Default",
             float intensity = 50f,
             float slope = 3f,
-            float maxIntensity = 10f
+            float maxIntensity = 10f,
             float tileBreakScale = 1f,
         )
         {

--- a/Content.Server/_N14/Support/VertibirdSupportSystem.cs
+++ b/Content.Server/_N14/Support/VertibirdSupportSystem.cs
@@ -134,6 +134,7 @@ namespace Content.Server._N14.Support
                     comp.Intensity,
                     comp.Slope,
                     comp.MaxIntensity,
+                    comp.TileBreakScale,
                     canCreateVacuum: false);
                 if (comp.FireSound != null)
                 {
@@ -159,6 +160,7 @@ namespace Content.Server._N14.Support
             float intensity = 30f,
             float slope = 2f,
             float maxIntensity = 5f,
+            float tileBreakScale = 1f,
             SoundSpecifier? approach = null,
             SoundSpecifier? fire = null
         )
@@ -177,6 +179,7 @@ namespace Content.Server._N14.Support
             comp.Intensity = intensity;
             comp.Slope = slope;
             comp.MaxIntensity = maxIntensity;
+            comp.TileBreakScale = tileBreakScale;
             comp.ApproachSound = approach;
             comp.FireSound = fire;
             // StartTime will be initialized when the flare activates.

--- a/Content.Shared/_N14/Support/ArtilleryStrikeComponent.cs
+++ b/Content.Shared/_N14/Support/ArtilleryStrikeComponent.cs
@@ -21,7 +21,7 @@ namespace Content.Shared._N14.Support
         public MapCoordinates Target = MapCoordinates.Nullspace;
 
         [DataField, AutoNetworkedField]
-        public TimeSpan Delay = TimeSpan.FromSeconds(10);
+        public TimeSpan Delay = TimeSpan.FromSeconds(5);
 
         [DataField, AutoNetworkedField]
         public string ExplosionType = "Default";
@@ -34,6 +34,9 @@ namespace Content.Shared._N14.Support
 
         [DataField, AutoNetworkedField]
         public float MaxIntensity = 10f;
+
+        [DataField, AutoNetworkedField]
+        public float TileBreakScale = 1f;
 
         [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
         public TimeSpan StartTime;

--- a/Content.Shared/_N14/Support/VertibirdSupportComponent.cs
+++ b/Content.Shared/_N14/Support/VertibirdSupportComponent.cs
@@ -26,7 +26,7 @@ public sealed partial class VertibirdSupportComponent : Component
     /// Time from activation until the approach sound plays.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public TimeSpan ApproachDelay = TimeSpan.FromSeconds(10);
+    public TimeSpan ApproachDelay = TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// Additional delay after the approach before the first shot.
@@ -60,6 +60,9 @@ public sealed partial class VertibirdSupportComponent : Component
 
     [DataField, AutoNetworkedField]
     public float MaxIntensity = 5f;
+
+    [DataField, AutoNetworkedField]
+    public float TileBreakScale = 1f;
 
     [DataField]
     public SoundSpecifier? ApproachSound;

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -218,7 +218,7 @@
       path: "/Audio/Items/Medical/brutepack_end.ogg"
   - type: Stack
     stackType: Bloodpack
-    count: 15 #Was 10, Buffed due to limb damage changes
+    count: 10 #Decreased to 10 because frick this
   - type: StackPrice
     price: 20 #Was 10, Buffed due to limb damage changes
 

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/Species/ghouls.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/Species/ghouls.yml
@@ -81,7 +81,7 @@
       0: Alive
       100: Critical
       150: Dead
-  - type: FeralGhoulify
+  # - type: FeralGhoulify
   # - type: Special
 
 - type: entity

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Throwable/support.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Throwable/support.yml
@@ -3,23 +3,26 @@
   parent: N14Flare
   id: N14ArtilleryFlare
   name: artillery flare
+  categories: [ HideSpawnMenu ] # How is this even supposed to work? I know how an aircraft spots something, but artillery?
   description: Marks a target for artillery fire.
   components:
   - type: ArtilleryStrike
     delay: 10
+    tileBreakScale: 0
 
 - type: entity
   parent: N14Flare
   id: N14VertibirdFlare
-  name: vertibird flare
-  description: Calls in vertibird support on this location.
+  name: air support flare
+  description: Calls in air support on its location. Don't stand close to it when it's lit and it has to be visible from the skies!
   components:
   - type: VertibirdSupport
-    delay: 10
-    shots: 10
+    delay: 5
+    shots: 15
     shotInterval: 0.1
-    spread: 4
-    lineLength: 10
+    spread: 3
+    lineLength: 5
     intensity: 5
+    tileBreakScale: 0
     approachSound: /Audio/_Nuclear14/Effects/airplane_fly_by.ogg
     fireSound: /Audio/_Nuclear14/Effects/a10_warthog_brrrt.ogg


### PR DESCRIPTION
A lot, read changelogs not writing separate stuff.

:cl:
- remove: Ghouls no longer turn feral, removed it due to unwanted effects.
- tweak: Air strike & artillery values tweaked, and removed the tile breaking.
- fix: Blood pack stacks now come in tens and not fifteens. It caused bugs due max stack size.