### PR TITLE
No Surgery Kit

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/UndecidedLoadout.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/UndecidedLoadout.yml
@@ -73,7 +73,7 @@
     state: medic
   - type: UndecidedLoadoutBackpack
     possibleSets:
-    - NCRA_SurgeonSet
+    # - NCRA_SurgeonSet
     - NCRA_DoctorSet
     - NCRA_ComMedSet
 


### PR DESCRIPTION
Removed the surgery kit from the NCR Army Medic's arsenal due to an odd and weird bug. @SpazTheButcher might fix it, or I'll later. But right now I got no time to figure it out and I am not leaving an infinite-item exploit like this in the game.

:cl:
- remove: Surgery kit from the NCR until bug fix.